### PR TITLE
[AS4625-54T] Turn off LOC LED

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as4625-54t/utils/accton_as4625_54t_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4625-54t/utils/accton_as4625_54t_util.py
@@ -41,6 +41,9 @@ PROJECT_NAME = 'as4625_54t'
 DEBUG = False
 ARGS = []
 FORCE = 0
+LED_MODE_OFF = 0
+LED_MODE_GREEN = 1  # Default value for LOC LED
+LED_LOC_PATH = "/sys/class/leds/as4625_led::loc/brightness"
 
 def main():
     global DEBUG
@@ -325,6 +328,24 @@ def do_sonic_platform_clean():
 
     return
 
+def set_loc_led(color):
+    global FORCE
+
+    if os.path.exists(LED_LOC_PATH):
+        cmd = 'echo {} > {}'.format(color, LED_LOC_PATH)
+        try:
+            status, output = log_os_system(cmd, 1)
+            if status:
+                print(output)
+                if FORCE == 0:
+                    return status
+        except Exception as e:
+            print({}.format(e))
+    else:
+        print('{} does not exist.'.format(LED_LOC_PATH))
+
+    return
+
 def do_install():
     print('Checking system....')
     if driver_check() is False:
@@ -343,6 +364,8 @@ def do_install():
                 return status
     else:
         print(PROJECT_NAME.upper() + ' devices detected....')
+
+    set_loc_led(LED_MODE_OFF)
 
     do_sonic_platform_install()
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
After booting, the LOC LED must be turned off. 

#### How I did it
During booting, turn off the LOC LED in accton_as4625_54t_util.py.

#### How to verify it
The LOC LED is off after booting.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

