### PR TITLE
Set sai tunnel support for multiple device

### DIFF
--- a/device/accton/x86_64-accton_as4625_54p-r0/Accton-AS4625-54P/hr4-as4625-48x1G+6x10G.config.bcm
+++ b/device/accton/x86_64-accton_as4625_54p-r0/Accton-AS4625-54P/hr4-as4625-48x1G+6x10G.config.bcm
@@ -33,6 +33,14 @@ ifp_inports_support_enable=1
 
 num_ipv6_lpm_128b_entries=512
 
+flow_init_mode=1
+riot_enable=1
+riot_overlay_l3_intf_mem_size=512
+riot_overlay_l3_egress_mem_size=4096
+l3_ecmp_levels=2
+use_all_splithorizon_groups=1
+host_as_route_disable=1
+sai_tunnel_support=1
 
 dport_map_port_25=1
 dport_map_port_26=2
@@ -350,7 +358,7 @@ phy_chain_rx_polarity_flip_physical{57.0}=0x0
 phy_chain_rx_polarity_flip_physical{58.0}=0x0
 phy_chain_rx_polarity_flip_physical{59.0}=0x0
 phy_chain_rx_polarity_flip_physical{60.0}=0x0
- 
+
 
 #PHYx TSC-M16-0, TSC3
 dport_map_port_61=53

--- a/device/accton/x86_64-accton_as4625_54t-r0/Accton-AS4625-54T/hr4-as4625-48x1G+6x10G.config.bcm
+++ b/device/accton/x86_64-accton_as4625_54t-r0/Accton-AS4625-54T/hr4-as4625-48x1G+6x10G.config.bcm
@@ -33,6 +33,14 @@ ifp_inports_support_enable=1
 
 num_ipv6_lpm_128b_entries=512
 
+flow_init_mode=1
+riot_enable=1
+riot_overlay_l3_intf_mem_size=512
+riot_overlay_l3_egress_mem_size=4096
+l3_ecmp_levels=2
+use_all_splithorizon_groups=1
+host_as_route_disable=1
+sai_tunnel_support=1
 
 dport_map_port_25=1
 dport_map_port_26=2
@@ -350,7 +358,7 @@ phy_chain_rx_polarity_flip_physical{57.0}=0x0
 phy_chain_rx_polarity_flip_physical{58.0}=0x0
 phy_chain_rx_polarity_flip_physical{59.0}=0x0
 phy_chain_rx_polarity_flip_physical{60.0}=0x0
- 
+
 
 #PHYx TSC-M16-0, TSC3
 dport_map_port_61=53

--- a/device/accton/x86_64-accton_as5835_54x-r0/Accton-AS5835-54X/mv2-as5835-48x10G+6x100G.config.bcm
+++ b/device/accton/x86_64-accton_as5835_54x-r0/Accton-AS5835-54X/mv2-as5835-48x10G+6x100G.config.bcm
@@ -41,6 +41,15 @@ skip_L2_USER_ENTRY=0
 bcm_tunnel_term_compatible_mode=1
 l3_alpm_ipv6_128b_bkt_rsvd=1
 
+flow_init_mode=1
+riot_enable=1
+riot_overlay_l3_intf_mem_size=512
+riot_overlay_l3_egress_mem_size=4096
+l3_ecmp_levels=2
+use_all_splithorizon_groups=1
+host_as_route_disable=1
+sai_tunnel_support=1
+
 #FC0
 dport_map_port_1=1
 dport_map_port_2=2

--- a/device/accton/x86_64-accton_as7326_56x-r0/Accton-AS7326-56X/td3-as7326-48x25G+8x100G.config.bcm
+++ b/device/accton/x86_64-accton_as7326_56x-r0/Accton-AS7326-56X/td3-as7326-48x25G+8x100G.config.bcm
@@ -42,6 +42,7 @@ riot_overlay_l3_intf_mem_size=4096
 riot_overlay_l3_egress_mem_size=32768
 riot_overlay_ecmp_resilient_hash_size=16384
 flow_init_mode=1
+host_as_route_disable=1
 
 dport_map_port_1=6
 dport_map_port_2=2

--- a/device/accton/x86_64-accton_as7726_32x-r0/Accton-AS7726-32X/td3-as7726-32x100G.config.bcm
+++ b/device/accton/x86_64-accton_as7726_32x-r0/Accton-AS7726-32X/td3-as7726-32x100G.config.bcm
@@ -36,6 +36,15 @@ bcm_tunnel_term_compatible_mode=1
 l3_alpm_ipv6_128b_bkt_rsvd=1
 phy_an_c73=1
 
+use_all_splithorizon_groups=1
+riot_enable=1
+sai_tunnel_support=1
+riot_overlay_l3_intf_mem_size=4096
+riot_overlay_l3_egress_mem_size=32768
+riot_overlay_ecmp_resilient_hash_size=16384
+flow_init_mode=1
+host_as_route_disable=1
+
 dport_map_port_1=1
 dport_map_port_5=2
 dport_map_port_9=3


### PR DESCRIPTION
Set sai tunnel support for multiple device

Accton-AS4625-54P/hr4-as4625-48x1G+6x10G.config.bcm
Accton-AS4625-54T/hr4-as4625-48x1G+6x10G.config.bcm
Accton-AS5835-54X/mv2-as5835-48x10G+6x100G.config.bcm
Accton-AS7326-56X/td3-as7326-48x25G+8x100G.config.bcm
Accton-AS7726-32X/td3-as7726-32x100G.config.bcm

