### PR TITLE
Revert set sai tunnel support for HR4 devices

### DIFF
--- a/device/accton/x86_64-accton_as4625_54p-r0/Accton-AS4625-54P/hr4-as4625-48x1G+6x10G.config.bcm
+++ b/device/accton/x86_64-accton_as4625_54p-r0/Accton-AS4625-54P/hr4-as4625-48x1G+6x10G.config.bcm
@@ -33,15 +33,6 @@ ifp_inports_support_enable=1
 
 num_ipv6_lpm_128b_entries=512
 
-flow_init_mode=1
-riot_enable=1
-riot_overlay_l3_intf_mem_size=512
-riot_overlay_l3_egress_mem_size=4096
-l3_ecmp_levels=2
-use_all_splithorizon_groups=1
-host_as_route_disable=1
-sai_tunnel_support=1
-
 dport_map_port_25=1
 dport_map_port_26=2
 dport_map_port_27=3

--- a/device/accton/x86_64-accton_as4625_54t-r0/Accton-AS4625-54T/hr4-as4625-48x1G+6x10G.config.bcm
+++ b/device/accton/x86_64-accton_as4625_54t-r0/Accton-AS4625-54T/hr4-as4625-48x1G+6x10G.config.bcm
@@ -33,15 +33,6 @@ ifp_inports_support_enable=1
 
 num_ipv6_lpm_128b_entries=512
 
-flow_init_mode=1
-riot_enable=1
-riot_overlay_l3_intf_mem_size=512
-riot_overlay_l3_egress_mem_size=4096
-l3_ecmp_levels=2
-use_all_splithorizon_groups=1
-host_as_route_disable=1
-sai_tunnel_support=1
-
 dport_map_port_25=1
 dport_map_port_26=2
 dport_map_port_27=3


### PR DESCRIPTION
Accton-AS4625-54P/hr4-as4625-48x1G+6x10G.config.bcm Accton-AS4625-54T/hr4-as4625-48x1G+6x10G.config.bcm

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

