### PR TITLE
Correct riot mem size for the platform Accton-AS5835-54X

### DIFF
--- a/device/accton/x86_64-accton_as5835_54x-r0/Accton-AS5835-54X/mv2-as5835-48x10G+6x100G.config.bcm
+++ b/device/accton/x86_64-accton_as5835_54x-r0/Accton-AS5835-54X/mv2-as5835-48x10G+6x100G.config.bcm
@@ -43,9 +43,10 @@ l3_alpm_ipv6_128b_bkt_rsvd=1
 
 flow_init_mode=1
 riot_enable=1
-riot_overlay_l3_intf_mem_size=512
-riot_overlay_l3_egress_mem_size=4096
+riot_overlay_l3_intf_mem_size=4096
+riot_overlay_l3_egress_mem_size=8192
 l3_ecmp_levels=2
+riot_overlay_ecmp_resilient_hash_size=16384
 use_all_splithorizon_groups=1
 host_as_route_disable=1
 sai_tunnel_support=1


### PR DESCRIPTION
#### Why I did it
Adjust the riot mem size to fit allocate rule - multiple of 2048

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

