### PR TITLE
[PDDF] Add debian prerm to remove unrelated service

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as4630-54pe.prerm
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as4630-54pe.prerm
@@ -1,0 +1,7 @@
+# Disable pddf-platform-init, monitor, monitor-fan, monitor-psu
+
+systemctl stop pddf-platform-init.service
+systemctl disable pddf-platform-init.service
+systemctl stop as4630-54pe-pddf-platform-monitor.service
+systemctl disable as4630-54pe-pddf-platform-monitor.service
+

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as5835-54t.prerm
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as5835-54t.prerm
@@ -1,0 +1,7 @@
+# Disable pddf-platform-init, monitor, monitor-fan, monitor-psu
+
+systemctl stop pddf-platform-init.service
+systemctl disable pddf-platform-init.service
+systemctl stop as5835-54t-pddf-platform-monitor.service
+systemctl disable as5835-54t-pddf-platform-monitor.service
+

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as5835-54x.prerm
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as5835-54x.prerm
@@ -1,0 +1,7 @@
+# Disable pddf-platform-init, monitor, monitor-fan, monitor-psu
+
+systemctl stop pddf-platform-init.service
+systemctl disable pddf-platform-init.service
+systemctl stop as5835-54x-pddf-platform-monitor.service
+systemctl disable as5835-54x-pddf-platform-monitor.service
+

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7326-56x.prerm
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7326-56x.prerm
@@ -1,0 +1,9 @@
+# Disable pddf-platform-init, monitor, monitor-fan, monitor-psu
+
+systemctl stop pddf-platform-init.service
+systemctl disable pddf-platform-init.service
+systemctl stop as7326-56x-pddf-platform-monitor.service
+systemctl disable as7326-56x-pddf-platform-monitor.service
+systemctl stop as7326-platform-handle_mac.service
+systemctl disable as7326-platform-handle_mac.service
+

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7712-32x.prerm
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7712-32x.prerm
@@ -1,0 +1,7 @@
+# Disable pddf-platform-init, monitor, monitor-fan, monitor-psu
+
+systemctl stop pddf-platform-init.service
+systemctl disable pddf-platform-init.service
+systemctl stop as7712-pddf-platform-monitor.service
+systemctl disable as7712-pddf-platform-monitor.service
+

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7726-32x.prerm
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7726-32x.prerm
@@ -1,0 +1,10 @@
+# Disable pddf-platform-init, monitor, monitor-fan, monitor-psu
+
+systemctl stop pddf-platform-init.service
+systemctl disable pddf-platform-init.service
+systemctl stop as7726-32x-pddf-platform-monitor.service
+systemctl disable as7726-32x-pddf-platform-monitor.service
+systemctl stop as7726-32x-platform-handle_mac.service
+systemctl disable as7726-32x-platform-handle_mac.service
+
+

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7816-64x.prerm
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as7816-64x.prerm
@@ -1,0 +1,7 @@
+# Disable pddf-platform-init, monitor, monitor-fan, monitor-psu
+
+systemctl stop pddf-platform-init.service
+systemctl disable pddf-platform-init.service
+systemctl stop as7816-pddf-platform-monitor.service
+systemctl disable as7816-pddf-platform-monitor.service
+

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as9716-32d.prerm
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as9716-32d.prerm
@@ -1,7 +1,5 @@
 # Disable pddf-platform-init, monitor, monitor-fan, monitor-psu
 
-systemctl stop as9716-platform-custom-init.service
-systemctl disable as9716-platform-custom-init.service
 systemctl stop pddf-platform-init.service
 systemctl disable pddf-platform-init.service
 systemctl stop as9716-32d-pddf-platform-monitor.service

--- a/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as9716-32d.prerm
+++ b/platform/broadcom/sonic-platform-modules-accton/debian/sonic-platform-accton-as9716-32d.prerm
@@ -1,0 +1,9 @@
+# Disable pddf-platform-init, monitor, monitor-fan, monitor-psu
+
+systemctl stop as9716-platform-custom-init.service
+systemctl disable as9716-platform-custom-init.service
+systemctl stop pddf-platform-init.service
+systemctl disable pddf-platform-init.service
+systemctl stop as9716-32d-pddf-platform-monitor.service
+systemctl disable as9716-32d-pddf-platform-monitor.service
+


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For support PDDF platform that will see unrelated service in the DUT.
For example, we can see unrelated service in as4630-54pe machine.
root@sonic:~# systemctl status as
as4630-54pe-pddf-platform-monitor.service
as4630-54pe-platform-monitor-fan.service
as4630-54pe-platform-monitor-psu.service
as4630-54pe-platform-monitor.service
as7326-platform-handle_mac.service
as7712-pddf-platform-monitor.service
as7726-32x-platform-handle_mac.service
as7816-pddf-platform-monitor.service
as9716-platform-custom-init.service
#### How I did it
Add *.prerm for support pddf platform. Then when boot or install deb, it will remove all service.
After that, *.post will enable one platform service.
#### How to verify it
Put all *.prerm to debian folder. Rebuild image and boot.
We only see "as4630-54pe service" in as4630 machine.
root@sonic:~# systemctl status as
as4630-54pe-pddf-platform-monitor.service
as4630-54pe-platform-monitor-fan.service
as4630-54pe-platform-monitor-psu.service
as4630-54pe-platform-monitor.service
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

