### PR TITLE
[AS7326-56X] Fix incorrect CPLD value for red blinking

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/modules/accton_as7326_56x_leds.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/modules/accton_as7326_56x_leds.c
@@ -59,7 +59,7 @@ static struct accton_as7326_56x_led_data  *ledctl = NULL;
 #define LED_MODE_DIAG_RED_VALUE	  (0x06)
 #define LED_MODE_DIAG_BLUE_VALUE  (0x03)
 #define LED_MODE_DIAG_GREEN_BLINK_VALUE  (0x17)
-#define LED_MODE_DIAG_RED_BLINK_VALUE	 (0x0d)
+#define LED_MODE_DIAG_RED_BLINK_VALUE	 (0x0f)
 #define LED_MODE_DIAG_BLUE_BLINK_VALUE   (0x27)
 
 #define LED_MODE_DIAG_OFF_VALUE	  (0x07)
@@ -69,7 +69,7 @@ static struct accton_as7326_56x_led_data  *ledctl = NULL;
 #define LED_MODE_LOC_RED_VALUE	 (0x06)
 #define LED_MODE_LOC_BLUE_VALUE  (0x03)
 #define LED_MODE_LOC_GREEN_BLINK_VALUE  (0x17)
-#define LED_MODE_LOC_RED_BLINK_VALUE	(0x0d)
+#define LED_MODE_LOC_RED_BLINK_VALUE	(0x0f)
 #define LED_MODE_LOC_BLUE_BLINK_VALUE   (0x27)
 #define LED_MODE_LOC_OFF_VALUE	(0x07)
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The CPLD value is incorrect for red blinking.

#### How I did it
Change CPLD value

#### How to verify it
1.  echo 7 > /sys/class/leds/accton_as7326_56x_led::loc/brightness 
2.  monitor the LOC led.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

