### PR TITLE
[AS9726-32D] Change the decision of FAN direction

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as9726-32d/classes/fanutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9726-32d/classes/fanutil.py
@@ -36,9 +36,10 @@ class FanUtil(object):
     FAN_NUM_5_IDX = 5
     FAN_NUM_6_IDX = 6
 
-    FAN_NODE_NUM_OF_MAP = 2
+    FAN_NODE_NUM_OF_MAP = 3
     FAN_NODE_FAULT_IDX_OF_MAP = 1    
     FAN_NODE_DIR_IDX_OF_MAP = 2
+    FAN_NODE_PRESENT_IDX_OF_MAP = 3
     
     BASE_VAL_PATH = '/sys/bus/i2c/devices/14-0066/{0}'
     FAN_DUTY_PATH = '/sys/bus/i2c/devices/14-0066/fan_duty_cycle_percentage'
@@ -60,21 +61,27 @@ class FanUtil(object):
     _fan_device_node_mapping = {
            (FAN_NUM_1_IDX, FAN_NODE_FAULT_IDX_OF_MAP): 'fan1_fault',           
            (FAN_NUM_1_IDX, FAN_NODE_DIR_IDX_OF_MAP): 'fan1_direction',           
+           (FAN_NUM_1_IDX, FAN_NODE_PRESENT_IDX_OF_MAP): 'fan1_present',
 
            (FAN_NUM_2_IDX, FAN_NODE_FAULT_IDX_OF_MAP): 'fan2_fault',
            (FAN_NUM_2_IDX, FAN_NODE_DIR_IDX_OF_MAP): 'fan2_direction',
+           (FAN_NUM_2_IDX, FAN_NODE_PRESENT_IDX_OF_MAP): 'fan2_present',
 
            (FAN_NUM_3_IDX, FAN_NODE_FAULT_IDX_OF_MAP): 'fan3_fault',
            (FAN_NUM_3_IDX, FAN_NODE_DIR_IDX_OF_MAP): 'fan3_direction',
+           (FAN_NUM_3_IDX, FAN_NODE_PRESENT_IDX_OF_MAP): 'fan3_present',
 
            (FAN_NUM_4_IDX, FAN_NODE_FAULT_IDX_OF_MAP): 'fan4_fault',
            (FAN_NUM_4_IDX, FAN_NODE_DIR_IDX_OF_MAP): 'fan4_direction',
+           (FAN_NUM_4_IDX, FAN_NODE_PRESENT_IDX_OF_MAP): 'fan4_present',
 
            (FAN_NUM_5_IDX, FAN_NODE_FAULT_IDX_OF_MAP): 'fan5_fault',
            (FAN_NUM_5_IDX, FAN_NODE_DIR_IDX_OF_MAP): 'fan5_direction',
+           (FAN_NUM_5_IDX, FAN_NODE_PRESENT_IDX_OF_MAP): 'fan5_present',
             
            (FAN_NUM_6_IDX, FAN_NODE_FAULT_IDX_OF_MAP): 'fan6_fault',
            (FAN_NUM_6_IDX, FAN_NODE_DIR_IDX_OF_MAP): 'fan6_direction',
+           (FAN_NUM_6_IDX, FAN_NODE_PRESENT_IDX_OF_MAP): 'fan6_present',
            }
 
     def _get_fan_device_node(self, fan_num, node_num):
@@ -177,6 +184,9 @@ class FanUtil(object):
     def get_fan_dir(self, fan_num):
         return self._get_fan_node_val(fan_num, self.FAN_NODE_DIR_IDX_OF_MAP)
 
+    def get_fan_present(self, fan_num):
+        return self._get_fan_node_val(fan_num, self.FAN_NODE_PRESENT_IDX_OF_MAP)
+
     def get_fan_duty_cycle(self):
         #duty_path = self.FAN_DUTY_PATH
         try:
@@ -209,7 +219,10 @@ class FanUtil(object):
             logging.debug('GET. Parameter error. fan_num, %d', fan_num)
             return None
 
-        if self.get_fan_fault(fan_num) is not None and self.get_fan_fault(fan_num) > 0:
+        if self.get_fan_fault(fan_num) is None:
+            return None
+
+        if self.get_fan_fault(fan_num) > 0:
             logging.debug('GET. FAN fault. fan_num, %d', fan_num)
             return False
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. DUT automatically reboots after Fan Tray 1 is removed (takes over 10 minutes).
2. No  log in syslog after DUT automatically reboots .

#### How I did it
1. Change the decision of FAN direction.
2. Sync the log buffer to the disk before powering off the DUT.

#### How to verify it
```
root@sonic:/home/admin# accton_as9726_32d_monitor.py -t 60 60 60 60 60 60 60 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10
[60000, 60000, 60000, 60000, 60000, 60000, 60000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000]
01:49:05 root        : DEBUG    fan_policy_state=LEVEL_FAN_MAX
01:49:35 root        : DEBUG    b2f_dir=0 f2b_dir=5
01:49:35 root        : DEBUG    fan_policy = fan_policy_f2b
01:49:35 root        : DEBUG    [(1, None, 62000), (1, None, 62000), (1, None, 62000), (1, None, 62000), (1, None, 62000), (1, None, 62000), (1, None, 62000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85dceb50>, 12000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5400>, 12000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5b80>, 12000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c65340>, 12000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c65ac0>, 12000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5e50>, 12000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5190>, 12000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c65040>, 12000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c67280>, 12000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c67a00>, 12000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c801c0>, 12000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c80940>, 12000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c94100>, 12000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c94880>, 12000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c24040>, 12000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c94910>, 12000)]
01:49:35 root        : WARNING  Alarm-Yellow for temperature high is detected
01:49:35 root        : DEBUG    GET. FAN fault. fan_num, 1
01:49:35 root        : DEBUG    fan_1 fail, set duty_cycle to 100
01:50:05 root        : DEBUG    b2f_dir=0 f2b_dir=5
01:50:05 root        : DEBUG    fan_policy = fan_policy_f2b
01:50:05 root        : DEBUG    [(1, None, 64000), (1, None, 64000), (1, None, 64000), (1, None, 64000), (1, None, 64000), (1, None, 64000), (1, None, 64000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85dceb50>, 14000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5400>, 14000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5b80>, 14000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c65340>, 14000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c65ac0>, 14000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5e50>, 14000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5190>, 14000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c65040>, 14000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c67280>, 14000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c67a00>, 14000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c801c0>, 14000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c80940>, 14000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c94100>, 14000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c94880>, 14000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c24040>, 14000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c94910>, 14000)]
01:50:05 root        : DEBUG    GET. FAN fault. fan_num, 1
01:50:05 root        : DEBUG    fan_1 fail, set duty_cycle to 100
01:50:35 root        : DEBUG    b2f_dir=0 f2b_dir=5
01:50:35 root        : DEBUG    fan_policy = fan_policy_f2b
01:50:35 root        : DEBUG    [(1, None, 66000), (1, None, 66000), (1, None, 66000), (1, None, 66000), (1, None, 66000), (1, None, 66000), (1, None, 66000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85dceb50>, 16000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5400>, 16000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5b80>, 16000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c65340>, 16000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c65ac0>, 16000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5e50>, 16000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5190>, 16000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c65040>, 16000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c67280>, 16000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c67a00>, 16000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c801c0>, 16000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c80940>, 16000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c94100>, 16000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c94880>, 16000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c24040>, 16000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c94910>, 16000)]
01:50:35 root        : DEBUG    GET. FAN fault. fan_num, 1
01:50:35 root        : DEBUG    fan_1 fail, set duty_cycle to 100
01:51:05 root        : DEBUG    b2f_dir=0 f2b_dir=5
01:51:05 root        : DEBUG    fan_policy = fan_policy_f2b
01:51:05 root        : DEBUG    [(1, None, 68000), (1, None, 68000), (1, None, 68000), (1, None, 68000), (1, None, 68000), (1, None, 68000), (1, None, 68000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85dceb50>, 18000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5400>, 18000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5b80>, 18000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c65340>, 18000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c65ac0>, 18000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5e50>, 18000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5190>, 18000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c65040>, 18000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c67280>, 18000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c67a00>, 18000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c801c0>, 18000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c80940>, 18000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c94100>, 18000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c94880>, 18000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c24040>, 18000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c94910>, 18000)]
01:51:05 root        : WARNING  Alarm-Red for temperature high is detected
01:51:05 root        : DEBUG    GET. FAN fault. fan_num, 1
01:51:05 root        : DEBUG    fan_1 fail, set duty_cycle to 100
01:51:35 root        : DEBUG    b2f_dir=0 f2b_dir=5
01:51:35 root        : DEBUG    fan_policy = fan_policy_f2b
01:51:35 root        : DEBUG    [(1, None, 70000), (1, None, 70000), (1, None, 70000), (1, None, 70000), (1, None, 70000), (1, None, 70000), (1, None, 70000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85dceb50>, 20000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5400>, 20000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5b80>, 20000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c65340>, 20000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c65ac0>, 20000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5e50>, 20000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5190>, 20000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c65040>, 20000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c67280>, 20000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c67a00>, 20000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c801c0>, 20000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c80940>, 20000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c94100>, 20000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c94880>, 20000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c24040>, 20000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c94910>, 20000)]
01:51:35 root        : DEBUG    GET. FAN fault. fan_num, 1
01:51:35 root        : DEBUG    fan_1 fail, set duty_cycle to 100
01:52:06 root        : DEBUG    b2f_dir=0 f2b_dir=5
01:52:06 root        : DEBUG    fan_policy = fan_policy_f2b
01:52:06 root        : DEBUG    [(1, None, 72000), (1, None, 72000), (1, None, 72000), (1, None, 72000), (1, None, 72000), (1, None, 72000), (1, None, 72000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85dceb50>, 22000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5400>, 22000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5b80>, 22000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c65340>, 22000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c65ac0>, 22000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5e50>, 22000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85cd5190>, 22000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c65040>, 22000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c67280>, 22000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c67a00>, 22000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c801c0>, 22000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c80940>, 22000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c94100>, 22000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c94880>, 22000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c24040>, 22000), (2, <sonic_platform.sfp.Sfp object at 0x7f8f85c94910>, 22000)]
01:52:06 root        : CRITICAL Alarm-Critical for temperature high is detected, shutdown DUT

# cat /var/log/syslog after booting
admin@sonic:~$ sudo su
root@sonic:/home/admin# cat /var/log/syslog | grep Alarm-Yellow
Nov 16 01:49:35.214537 sonic WARNING Alarm-Yellow for temperature high is detected
root@sonic:/home/admin# 
root@sonic:/home/admin# cat /var/log/syslog | grep Alarm-Red
Nov 16 01:51:05.673546 sonic WARNING Alarm-Red for temperature high is detected
root@sonic:/home/admin# 
root@sonic:/home/admin# cat /var/log/syslog | grep Alarm-Critical
Nov 16 01:52:06.175252 sonic CRIT Alarm-Critical for temperature high is detected, shutdown DUT
``` 
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

