### PR TITLE
[Edgecore][as4630-54te] Fixed pytest of sfp tx_disable test item failed.

### DIFF
--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/sfp.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/sfp.py
@@ -167,7 +167,7 @@ class Sfp(SfpOptoeBase):
             A Boolean, True if tx_disable is enabled, False if disabled
         """
         if self.port_num < 49: #Copper port, no sysfs
-            return False
+            return [False]
 
         if self.port_num < 53:
             tx_disable = False
@@ -175,9 +175,12 @@ class Sfp(SfpOptoeBase):
             tx_path = "{}{}{}".format(CPLD_I2C_PATH, '/module_tx_disable_', self.port_num)
             tx_disable=self._api_helper.read_txt_file(tx_path)
             if tx_disable is not None:
-                return tx_disable
+                if tx_disable == '1':
+                    return [True]
+                else:
+                    return [False]
             else:
-                return False
+                return [False]
 
         else:
             api = self.get_xcvr_api()


### PR DESCRIPTION
#### Why I did it
Fixed pytest test_tx_disable[as4630-54te-1] item failed.

#### How I did it
The root cause is the API need return the value type need to be: "list", ex: "[True]" instead of "True"

#### How to verify it
Re pytest same test item. After modified, the test result is PASSED.

#### Which release branch to backport (provide reason below if selected)



- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog


#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

