### PR TITLE
[Edge-core][common driver][pmbus][ym2651y.c] When …

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/common/modules/ym2651y.c
+++ b/platform/broadcom/sonic-platform-modules-accton/common/modules/ym2651y.c
@@ -983,6 +983,11 @@ static int ym2651y_update_thread(void *arg)
 
             /* PMBus STATUS_WORD(0x79): psu_power_good, high byte bit 3, 0=>OK, 1=>FAIL */
             data->reg_val.status_word |= 0x800;
+
+            /* psu_power_good = failed, modified to return 1023 degree for python used. */
+            data->reg_val.temp_input[0] = 0x3ff;
+            data->reg_val.temp_input[1] = 0x3ff;
+            data->reg_val.temp_input[2] = 0x3ff;
         }
         mutex_unlock(&data->update_lock);
 


### PR DESCRIPTION
…psu_power_good is failed, temperature return 1023 degree.

#### Why I did it
The driver will poll for 3 seconds at a time to update the pmbus value. Before modification, psu_power_good = failed ==>The temperature will be returned as 0 (degrees). This will cause the sonic to send syslog when the psu is powered up, but detect 0 degrees before updating the correct temperature. (misjudgment) 

#### How I did it
Therefore, it is necessary to modify the value that when psu_power_good = failed ==> the temperature returns 1023 (degrees), so that the python program can know that the status of 1023 is for power_good is failed value(befor update the correct temperature value).

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

