### PR TITLE
[AS9736-64d] Fixed the pytest failed itmes.

### DIFF
--- a/device/accton/x86_64-accton_as9736_64d-r0/Accton-AS9736-64D/th4-as9736-64x400G.config.yml
+++ b/device/accton/x86_64-accton_as9736_64d-r0/Accton-AS9736-64D/th4-as9736-64x400G.config.yml
@@ -16,6 +16,10 @@ bcm_device:
       vlan_default_port: 3
       l3_alpm_template: 1
       port_allow_tpid_disable: 1
+      riot_overlay_l3_intf_mem_size: 4096
+      riot_overlay_l3_egress_mem_size: 8192
+      l3_ecmp_member_first_lkup_mem_size: 8192
+      l3_intf_vlan_split_egress: 1
 ...
 ---
 bcm_device:

--- a/device/accton/x86_64-accton_as9736_64d-r0/platform.json
+++ b/device/accton/x86_64-accton_as9736_64d-r0/platform.json
@@ -34,34 +34,61 @@
         ],
         "fans": [
             {
-                "name": "FAN-1F"
+                "name": "FAN-1F",
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-1R"
+                "name": "FAN-1R",
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-2F"
+                "name": "FAN-2F",
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-2R"
+                "name": "FAN-2R",
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-3F"
+                "name": "FAN-3F",
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-3R"
+                "name": "FAN-3R",
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-4F"
+                "name": "FAN-4F",
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-4R"
+                "name": "FAN-4R",
+                "status_led": {
+                    "controllable": false
+                }
             }
         ],
         "fan_drawers":[
             {
                 "name": "FanTray1",
                 "num_fans" : 2,
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
                         "name": "FAN-1F"
@@ -74,6 +101,9 @@
             {
                 "name": "FanTray2",
                 "num_fans" : 2,
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
                         "name": "FAN-2F"
@@ -86,6 +116,9 @@
             {
                 "name": "FanTray3",
                 "num_fans" : 2,
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
                         "name": "FAN-3F"
@@ -98,6 +131,9 @@
             {
                 "name": "FanTray4",
                 "num_fans" : 2,
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
                         "name": "FAN-4F"

--- a/device/accton/x86_64-accton_as9736_64d-r0/platform.json
+++ b/device/accton/x86_64-accton_as9736_64d-r0/platform.json
@@ -359,1050 +359,1049 @@
                 "name": "Ethernet0"
             },
             {
-                "name": "Ethernet4"
-            },
-            {
                 "name": "Ethernet8"
-            },
-            {
-                "name": "Ethernet12"
             },
             {
                 "name": "Ethernet16"
             },
             {
-                "name": "Ethernet20"
-            },
-            {
                 "name": "Ethernet24"
-            },
-            {
-                "name": "Ethernet28"
             },
             {
                 "name": "Ethernet32"
             },
             {
-                "name": "Ethernet36"
-            },
-            {
                 "name": "Ethernet40"
-            },
-            {
-                "name": "Ethernet44"
             },
             {
                 "name": "Ethernet48"
             },
             {
-                "name": "Ethernet52"
-            },
-            {
                 "name": "Ethernet56"
-            },
-            {
-                "name": "Ethernet60"
             },
             {
                 "name": "Ethernet64"
             },
             {
-                "name": "Ethernet68"
-            },
-            {
                 "name": "Ethernet72"
-            },
-            {
-                "name": "Ethernet76"
             },
             {
                 "name": "Ethernet80"
             },
             {
-                "name": "Ethernet84"
-            },
-            {
                 "name": "Ethernet88"
-            },
-            {
-                "name": "Ethernet92"
             },
             {
                 "name": "Ethernet96"
             },
             {
-                "name": "Ethernet100"
-            },
-            {
                 "name": "Ethernet104"
-            },
-            {
-                "name": "Ethernet108"
             },
             {
                 "name": "Ethernet112"
             },
             {
-                "name": "Ethernet116"
-            },
-            {
                 "name": "Ethernet120"
-            },
-            {
-                "name": "Ethernet124"
             },
             {
                 "name": "Ethernet128"
             },
             {
-                "name": "Ethernet132"
-            },
-            {
                 "name": "Ethernet136"
-            },
-            {
-                "name": "Ethernet140"
             },
             {
                 "name": "Ethernet144"
             },
             {
-                "name": "Ethernet148"
-            },
-            {
                 "name": "Ethernet152"
-            },
-            {
-                "name": "Ethernet156"
             },
             {
                 "name": "Ethernet160"
             },
             {
-                "name": "Ethernet164"
-            },
-            {
                 "name": "Ethernet168"
-            },
-            {
-                "name": "Ethernet172"
             },
             {
                 "name": "Ethernet176"
             },
             {
-                "name": "Ethernet180"
-            },
-            {
                 "name": "Ethernet184"
-            },
-            {
-                "name": "Ethernet188"
             },
             {
                 "name": "Ethernet192"
             },
             {
-                "name": "Ethernet196"
-            },
-            {
                 "name": "Ethernet200"
-            },
-            {
-                "name": "Ethernet204"
             },
             {
                 "name": "Ethernet208"
             },
             {
-                "name": "Ethernet212"
-            },
-            {
                 "name": "Ethernet216"
-            },
-            {
-                "name": "Ethernet220"
             },
             {
                 "name": "Ethernet224"
             },
             {
-                "name": "Ethernet228"
-            },
-            {
                 "name": "Ethernet232"
-            },
-            {
-                "name": "Ethernet236"
             },
             {
                 "name": "Ethernet240"
             },
             {
-                "name": "Ethernet244"
-            },
-            {
                 "name": "Ethernet248"
-            },
-            {
-                "name": "Ethernet252"
             },
             {
                 "name": "Ethernet256"
             },
             {
-                "name": "Ethernet257"
+                "name": "Ethernet264"
+            },
+            {
+                "name": "Ethernet272"
+            },
+            {
+                "name": "Ethernet280"
+            },
+            {
+                "name": "Ethernet288"
+            },
+            {
+                "name": "Ethernet296"
+            },
+            {
+                "name": "Ethernet304"
+            },
+            {
+                "name": "Ethernet312"
+            },
+            {
+                "name": "Ethernet320"
+            },
+            {
+                "name": "Ethernet328"
+            },
+            {
+                "name": "Ethernet336"
+            },
+            {
+                "name": "Ethernet344"
+            },
+            {
+                "name": "Ethernet352"
+            },
+            {
+                "name": "Ethernet360"
+            },
+            {
+                "name": "Ethernet368"
+            },
+            {
+                "name": "Ethernet376"
+            },
+            {
+                "name": "Ethernet384"
+            },
+            {
+                "name": "Ethernet392"
+            },
+            {
+                "name": "Ethernet400"
+            },
+            {
+                "name": "Ethernet408"
+            },
+            {
+                "name": "Ethernet416"
+            },
+            {
+                "name": "Ethernet424"
+            },
+            {
+                "name": "Ethernet432"
+            },
+            {
+                "name": "Ethernet440"
+            },
+            {
+                "name": "Ethernet448"
+            },
+            {
+                "name": "Ethernet456"
+            },
+            {
+                "name": "Ethernet464"
+            },
+            {
+                "name": "Ethernet472"
+            },
+            {
+                "name": "Ethernet480"
+            },
+            {
+                "name": "Ethernet488"
+            },
+            {
+                "name": "Ethernet496"
+            },
+            {
+                "name": "Ethernet504"
+            },
+            {
+                "name": "Ethernet512"
+            },
+            {
+                "name": "Ethernet513"
             }
         ]
     },
     "interfaces": {
         "Ethernet0": {
-            "index": "1,1,1,1",
-            "lanes": "65,66,67,68",
+            "index": "1,1,1,1,1,1,1,1",
+            "lanes": "130,131,132,133,134,135,136,137",
             "breakout_modes": {
                 "1x400G": ["Eth1(Port1)"],
                 "2x200G": ["Eth1/1(Port1)", "Eth1/2(Port1)"],
                 "4x100G": ["Eth1/1(Port1)", "Eth1/2(Port1)", "Eth1/3(Port1)", "Eth1/4(Port1)"],
-                "1x100G[40G](2)": ["Eth1(Port1)"],
-                "2x50G(2)": ["Eth1/1(Port1)", "Eth1/2(Port1)"],
-                "4x25G[10G]": ["Eth1/1(Port1)", "Eth1/2(Port1)", "Eth1/3(Port1)", "Eth1/4(Port1)"]
-            }
-        },
-
-        "Ethernet4": {
-            "index": "2,2,2,2",
-            "lanes": "69,70,71,72",
-            "breakout_modes": {
-                "1x400G": ["Eth2(Port2)"],
-                "2x200G": ["Eth2/1(Port2)", "Eth2/2(Port2)"],
-                "4x100G": ["Eth2/1(Port2)", "Eth2/2(Port2)", "Eth2/3(Port2)", "Eth2/4(Port2)"],
-                "1x100G[40G](2)": ["Eth2(Port2)"],
-                "2x50G(2)": ["Eth2/1(Port2)", "Eth2/2(Port2)"],
-                "4x25G[10G]": ["Eth2/1(Port2)", "Eth2/2(Port2)", "Eth2/3(Port2)", "Eth2/4(Port2)"]
+                "1x100G[40G](4)": ["Eth1(Port1)"],
+                "2x50G(4)": ["Eth1/1(Port1)", "Eth1/2(Port1)"],
+                "4x25G[10G](4)": ["Eth1/1(Port1)", "Eth1/2(Port1)", "Eth1/3(Port1)", "Eth1/4(Port1)"]
             }
         },
 
         "Ethernet8": {
-            "index": "3,3,3,3",
-            "lanes": "73,74,75,76",
+            "index": "2,2,2,2,2,2,2,2",
+            "lanes": "138,139,140,141,142,143,144,145",
             "breakout_modes": {
-                "1x400G": ["Eth3(Port3)"],
-                "2x200G": ["Eth3/1(Port3)", "Eth3/2(Port3)"],
-                "4x100G": ["Eth3/1(Port3)", "Eth3/2(Port3)", "Eth3/3(Port3)", "Eth3/4(Port3)"],
-                "1x100G[40G](2)": ["Eth3(Port3)"],
-                "2x50G(2)": ["Eth3/1(Port3)", "Eth3/2(Port3)"],
-                "4x25G[10G]": ["Eth3/1(Port3)", "Eth3/2(Port3)", "Eth3/3(Port3)", "Eth3/4(Port3)"]
-            }
-        },
-
-        "Ethernet12": {
-            "index": "4,4,4,4",
-            "lanes": "77,78,79,80",
-            "breakout_modes": {
-                "1x400G": ["Eth4(Port4)"],
-                "2x200G": ["Eth4/1(Port4)", "Eth4/2(Port4)"],
-                "4x100G": ["Eth4/1(Port4)", "Eth4/2(Port4)", "Eth4/3(Port4)", "Eth4/4(Port4)"],
-                "1x100G[40G](2)": ["Eth4(Port4)"],
-                "2x50G(2)": ["Eth4/1(Port4)", "Eth4/2(Port4)"],
-                "4x25G[10G]": ["Eth4/1(Port4)", "Eth4/2(Port4)", "Eth4/3(Port4)", "Eth4/4(Port4)"]
+                "1x400G": ["Eth2(Port2)"],
+                "2x200G": ["Eth2/1(Port2)", "Eth2/2(Port2)"],
+                "4x100G": ["Eth2/1(Port2)", "Eth2/2(Port2)", "Eth2/3(Port2)", "Eth2/4(Port2)"],
+                "1x100G[40G](4)": ["Eth2(Port2)"],
+                "2x50G(4)": ["Eth2/1(Port2)", "Eth2/2(Port2)"],
+                "4x25G[10G](4)": ["Eth2/1(Port2)", "Eth2/2(Port2)", "Eth2/3(Port2)", "Eth2/4(Port2)"]
             }
         },
 
         "Ethernet16": {
-            "index": "5,5,5,5",
-            "lanes": "81,82,83,84",
+            "index": "3,3,3,3,3,3,3,3",
+            "lanes": "146,147,148,149,150,151,152,153",
             "breakout_modes": {
-                "1x400G": ["Eth5(Port5)"],
-                "2x200G": ["Eth5/1(Port5)", "Eth5/2(Port5)"],
-                "4x100G": ["Eth5/1(Port5)", "Eth5/2(Port5)", "Eth5/3(Port5)", "Eth5/4(Port5)"],
-                "1x100G[40G](2)": ["Eth5(Port5)"],
-                "2x50G(2)": ["Eth5/1(Port5)", "Eth5/2(Port5)"],
-                "4x25G[10G]": ["Eth5/1(Port5)", "Eth5/2(Port5)", "Eth5/3(Port5)", "Eth5/4(Port5)"]
-            }
-        },
-
-        "Ethernet20": {
-            "index": "6,6,6,6",
-            "lanes": "85,86,87,88",
-            "breakout_modes":  {
-                "1x400G": ["Eth6(Port6)"],
-                "2x200G": ["Eth6/1(Port6)", "Eth6/2(Port6)"],
-                "4x100G": ["Eth6/1(Port6)", "Eth6/2(Port6)", "Eth6/3(Port6)", "Eth6/4(Port6)"],
-                "1x100G[40G](2)": ["Eth6(Port6)"],
-                "2x50G(2)": ["Eth6/1(Port6)", "Eth6/2(Port6)"],
-                "4x25G[10G]": ["Eth6/1(Port6)", "Eth6/2(Port6)", "Eth6/3(Port6)", "Eth6/4(Port6)"]
+                "1x400G": ["Eth3(Port3)"],
+                "2x200G": ["Eth3/1(Port3)", "Eth3/2(Port3)"],
+                "4x100G": ["Eth3/1(Port3)", "Eth3/2(Port3)", "Eth3/3(Port3)", "Eth3/4(Port3)"],
+                "1x100G[40G](4)": ["Eth3(Port3)"],
+                "2x50G(4)": ["Eth3/1(Port3)", "Eth3/2(Port3)"],
+                "4x25G[10G](4)": ["Eth3/1(Port3)", "Eth3/2(Port3)", "Eth3/3(Port3)", "Eth3/4(Port3)"]
             }
         },
 
         "Ethernet24": {
-            "index": "7,7,7,7",
-            "lanes": "89,90,91,92",
-            "breakout_modes":  {
-                "1x400G": ["Eth7(Port7)"],
-                "2x200G": ["Eth7/1(Port7)", "Eth7/2(Port7)"],
-                "4x100G": ["Eth7/1(Port7)", "Eth7/2(Port7)", "Eth7/3(Port7)", "Eth7/4(Port7)"],
-                "1x100G[40G](2)": ["Eth7(Port7)"],
-                "2x50G(2)": ["Eth7/1(Port7)", "Eth7/2(Port7)"],
-                "4x25G[10G]": ["Eth7/1(Port7)", "Eth7/2(Port7)", "Eth7/3(Port7)", "Eth7/4(Port7)"]
-            }
-        },
-
-        "Ethernet28": {
-            "index": "8,8,8,8",
-            "lanes": "93,94,95,96",
+            "index": "4,4,4,4,4,4,4,4",
+            "lanes": "154,155,156,157,158,159,160,161",
             "breakout_modes": {
-                "1x400G": ["Eth8(Port8)"],
-                "2x200G": ["Eth8/1(Port8)", "Eth8/2(Port8)"],
-                "4x100G": ["Eth8/1(Port8)", "Eth8/2(Port8)", "Eth8/3(Port8)", "Eth8/4(Port8)"],
-                "1x100G[40G](2)": ["Eth8(Port8)"],
-                "2x50G(2)": ["Eth8/1(Port8)", "Eth8/2(Port8)"],
-                "4x25G[10G]": ["Eth8/1(Port8)", "Eth8/2(Port8)", "Eth8/3(Port8)", "Eth8/4(Port8)"]
+                "1x400G": ["Eth4(Port4)"],
+                "2x200G": ["Eth4/1(Port4)", "Eth4/2(Port4)"],
+                "4x100G": ["Eth4/1(Port4)", "Eth4/2(Port4)", "Eth4/3(Port4)", "Eth4/4(Port4)"],
+                "1x100G[40G](4)": ["Eth4(Port4)"],
+                "2x50G(4)": ["Eth4/1(Port4)", "Eth4/2(Port4)"],
+                "4x25G[10G](4)": ["Eth4/1(Port4)", "Eth4/2(Port4)", "Eth4/3(Port4)", "Eth4/4(Port4)"]
             }
         },
 
         "Ethernet32": {
-            "index": "9,9,9,9",
-            "lanes": "97,98,99,100",
+            "index": "5,5,5,5,5,5,5,5",
+            "lanes": "162,163,164,165,166,167,168,169",
             "breakout_modes": {
-                "1x400G": ["Eth9(Port9)"],
-                "2x200G": ["Eth9/1(Port9)", "Eth9/2(Port9)"],
-                "4x100G": ["Eth9/1(Port9)", "Eth9/2(Port9)", "Eth9/3(Port9)", "Eth9/4(Port9)"],
-                "1x100G[40G](2)": ["Eth9(Port9)"],
-                "2x50G(2)": ["Eth9/1(Port9)", "Eth9/2(Port9)"],
-                "4x25G[10G]": ["Eth9/1(Port9)", "Eth9/2(Port9)", "Eth9/3(Port9)", "Eth9/4(Port9)"]
-            }
-        },
-
-        "Ethernet36": {
-            "index": "10,10,10,10",
-            "lanes": "101,102,103,104",
-            "breakout_modes": {
-                "1x400G": ["Eth10(Port10)"],
-                "2x200G": ["Eth10/1(Port10)", "Eth10/2(Port10)"],
-                "4x100G": ["Eth10/1(Port10)", "Eth10/2(Port10)", "Eth10/3(Port10)", "Eth10/4(Port10)"],
-                "1x100G[40G](2)": ["Eth10(Port10)"],
-                "2x50G(2)": ["Eth10/1(Port10)", "Eth10/2(Port10)"],
-                "4x25G[10G]": ["Eth10/1(Port10)", "Eth10/2(Port10)", "Eth10/3(Port10)", "Eth10/4(Port10)"]
+                "1x400G": ["Eth5(Port5)"],
+                "2x200G": ["Eth5/1(Port5)", "Eth5/2(Port5)"],
+                "4x100G": ["Eth5/1(Port5)", "Eth5/2(Port5)", "Eth5/3(Port5)", "Eth5/4(Port5)"],
+                "1x100G[40G](4)": ["Eth5(Port5)"],
+                "2x50G(4)": ["Eth5/1(Port5)", "Eth5/2(Port5)"],
+                "4x25G[10G](4)": ["Eth5/1(Port5)", "Eth5/2(Port5)", "Eth5/3(Port5)", "Eth5/4(Port5)"]
             }
         },
 
         "Ethernet40": {
-            "index": "11,11,11,11",
-            "lanes": "125,126,127,128",
+            "index": "6,6,6,6,6,6,6,6",
+            "lanes": "170,171,172,173,174,175,176,177",
             "breakout_modes": {
-                "1x400G": ["Eth11(Port11)"],
-                "2x200G": ["Eth11/1(Port11)", "Eth11/2(Port11)"],
-                "4x100G": ["Eth11/1(Port11)", "Eth11/2(Port11)", "Eth11/3(Port11)", "Eth11/4(Port11)"],
-                "1x100G[40G](2)": ["Eth11(Port11)"],
-                "2x50G(2)": ["Eth11/1(Port11)", "Eth11/2(Port11)"],
-                "4x25G[10G]": ["Eth11/1(Port11)", "Eth11/2(Port11)", "Eth11/3(Port11)", "Eth11/4(Port11)"]
-            }
-        },
-
-        "Ethernet44": {
-            "index": "12,12,12,12",
-            "lanes": "121,122,123,124",
-            "breakout_modes": {
-                "1x400G": ["Eth12(Port12)"],
-                "2x200G": ["Eth12/1(Port12)", "Eth12/2(Port12)"],
-                "4x100G": ["Eth12/1(Port12)", "Eth12/2(Port12)", "Eth12/3(Port12)", "Eth12/4(Port12)"],
-                "1x100G[40G](2)": ["Eth12(Port12)"],
-                "2x50G(2)": ["Eth12/1(Port12)", "Eth12/2(Port12)"],
-                "4x25G[10G]": ["Eth12/1(Port12)", "Eth12/2(Port12)", "Eth12/3(Port12)", "Eth12/4(Port12)"]
+                "1x400G": ["Eth6(Port6)"],
+                "2x200G": ["Eth6/1(Port6)", "Eth6/2(Port6)"],
+                "4x100G": ["Eth6/1(Port6)", "Eth6/2(Port6)", "Eth6/3(Port6)", "Eth6/4(Port6)"],
+                "1x100G[40G](4)": ["Eth6(Port6)"],
+                "2x50G(4)": ["Eth6/1(Port6)", "Eth6/2(Port6)"],
+                "4x25G[10G](4)": ["Eth6/1(Port6)", "Eth6/2(Port6)", "Eth6/3(Port6)", "Eth6/4(Port6)"]
             }
         },
 
         "Ethernet48": {
-            "index": "13,13,13,13",
-            "lanes": "113,114,115,116",
+            "index": "7,7,7,7,7,7,7,7",
+            "lanes": "178,179,180,181,182,183,184,185",
             "breakout_modes": {
-                "1x400G": ["Eth13(Port13)"],
-                "2x200G": ["Eth13/1(Port13)", "Eth13/2(Port13)"],
-                "4x100G": ["Eth13/1(Port13)", "Eth13/2(Port13)", "Eth13/3(Port13)", "Eth13/4(Port13)"],
-                "1x100G[40G](2)": ["Eth13(Port13)"],
-                "2x50G(2)": ["Eth13/1(Port13)", "Eth13/2(Port13)"],
-                "4x25G[10G]": ["Eth13/1(Port13)", "Eth13/2(Port13)", "Eth13/3(Port13)", "Eth13/4(Port13)"]
-            }
-        },
-
-        "Ethernet52": {
-            "index": "14,14,14,14",
-            "lanes": "117,118,119,120",
-            "breakout_modes": {
-                "1x400G": ["Eth14(Port14)"],
-                "2x200G": ["Eth14/1(Port14)", "Eth14/2(Port14)"],
-                "4x100G": ["Eth14/1(Port14)", "Eth14/2(Port14)", "Eth14/3(Port14)", "Eth14/4(Port14)"],
-                "1x100G[40G](2)": ["Eth14(Port14)"],
-                "2x50G(2)": ["Eth14/1(Port14)", "Eth14/2(Port14)"],
-                "4x25G[10G]": ["Eth14/1(Port14)", "Eth14/2(Port14)", "Eth14/3(Port14)", "Eth14/4(Port14)"]
+                "1x400G": ["Eth7(Port7)"],
+                "2x200G": ["Eth7/1(Port7)", "Eth7/2(Port7)"],
+                "4x100G": ["Eth7/1(Port7)", "Eth7/2(Port7)", "Eth7/3(Port7)", "Eth7/4(Port7)"],
+                "1x100G[40G](4)": ["Eth7(Port7)"],
+                "2x50G(4)": ["Eth7/1(Port7)", "Eth7/2(Port7)"],
+                "4x25G[10G](4)": ["Eth7/1(Port7)", "Eth7/2(Port7)", "Eth7/3(Port7)", "Eth7/4(Port7)"]
             }
         },
 
         "Ethernet56": {
-            "index": "15,15,15,15",
-            "lanes": "109,110,111,112",
+            "index": "8,8,8,8,8,8,8,8",
+            "lanes": "186,187,188,189,190,191,192,193",
             "breakout_modes": {
-                "1x400G": ["Eth15(Port15)"],
-                "2x200G": ["Eth15/1(Port15)", "Eth15/2(Port15)"],
-                "4x100G": ["Eth15/1(Port15)", "Eth15/2(Port15)", "Eth15/3(Port15)", "Eth15/4(Port15)"],
-                "1x100G[40G](2)": ["Eth15(Port15)"],
-                "2x50G(2)": ["Eth15/1(Port15)", "Eth15/2(Port15)"],
-                "4x25G[10G]": ["Eth15/1(Port15)", "Eth15/2(Port15)", "Eth15/3(Port15)", "Eth15/4(Port15)"]
-            }
-        },
-
-        "Ethernet60": {
-            "index": "16,16,16,16",
-            "lanes": "105,106,107,108",
-            "breakout_modes": {
-                "1x400G": ["Eth16(Port16)"],
-                "2x200G": ["Eth16/1(Port16)", "Eth16/2(Port16)"],
-                "4x100G": ["Eth16/1(Port16)", "Eth16/2(Port16)", "Eth16/3(Port16)", "Eth16/4(Port16)"],
-                "1x100G[40G](2)": ["Eth16(Port16)"],
-                "2x50G(2)": ["Eth16/1(Port16)", "Eth16/2(Port16)"],
-                "4x25G[10G]": ["Eth16/1(Port16)", "Eth16/2(Port16)", "Eth16/3(Port16)", "Eth16/4(Port16)"]
+                "1x400G": ["Eth8(Port8)"],
+                "2x200G": ["Eth8/1(Port8)", "Eth8/2(Port8)"],
+                "4x100G": ["Eth8/1(Port8)", "Eth8/2(Port8)", "Eth8/3(Port8)", "Eth8/4(Port8)"],
+                "1x100G[40G](4)": ["Eth8(Port8)"],
+                "2x50G(4)": ["Eth8/1(Port8)", "Eth8/2(Port8)"],
+                "4x25G[10G](4)": ["Eth8/1(Port8)", "Eth8/2(Port8)", "Eth8/3(Port8)", "Eth8/4(Port8)"]
             }
         },
 
         "Ethernet64": {
-            "index": "17,17,17,17",
-            "lanes": "145,146,147,148",
+            "index": "9,9,9,9,9,9,9,9",
+            "lanes": "194,195,196,197,198,199,200,201",
             "breakout_modes": {
-                "1x400G": ["Eth17(Port17)"],
-                "2x200G": ["Eth17/1(Port17)", "Eth17/2(Port17)"],
-                "4x100G": ["Eth17/1(Port17)", "Eth17/2(Port17)", "Eth17/3(Port17)", "Eth17/4(Port17)"],
-                "1x100G[40G](2)": ["Eth17(Port17)"],
-                "2x50G(2)": ["Eth17/1(Port17)", "Eth17/2(Port17)"],
-                "4x25G[10G]": ["Eth17/1(Port17)", "Eth17/2(Port17)", "Eth17/3(Port17)", "Eth17/4(Port17)"]
-            }
-        },
-
-        "Ethernet68": {
-            "index": "18,18,18,18",
-            "lanes": "149,150,151,152",
-            "breakout_modes": {
-                "1x400G": ["Eth18(Port18)"],
-                "2x200G": ["Eth18/1(Port18)", "Eth18/2(Port18)"],
-                "4x100G": ["Eth18/1(Port18)", "Eth18/2(Port18)", "Eth18/3(Port18)", "Eth18/4(Port18)"],
-                "1x100G[40G](2)": ["Eth18(Port18)"],
-                "2x50G(2)": ["Eth18/1(Port18)", "Eth18/2(Port18)"],
-                "4x25G[10G]": ["Eth18/1(Port18)", "Eth18/2(Port18)", "Eth18/3(Port18)", "Eth18/4(Port18)"]
+                "1x400G": ["Eth9(Port9)"],
+                "2x200G": ["Eth9/1(Port9)", "Eth9/2(Port9)"],
+                "4x100G": ["Eth9/1(Port9)", "Eth9/2(Port9)", "Eth9/3(Port9)", "Eth9/4(Port9)"],
+                "1x100G[40G](4)": ["Eth9(Port9)"],
+                "2x50G(4)": ["Eth9/1(Port9)", "Eth9/2(Port9)"],
+                "4x25G[10G](4)": ["Eth9/1(Port9)", "Eth9/2(Port9)", "Eth9/3(Port9)", "Eth9/4(Port9)"]
             }
         },
 
         "Ethernet72": {
-            "index": "19,19,19,19",
-            "lanes": "141,142,143,144",
+            "index": "10,10,10,10,10,10,10,10",
+            "lanes": "202,203,204,205,206,207,208,209",
             "breakout_modes": {
-                "1x400G": ["Eth19(Port19)"],
-                "2x200G": ["Eth19/1(Port19)", "Eth19/2(Port19)"],
-                "4x100G": ["Eth19/1(Port19)", "Eth19/2(Port19)", "Eth19/3(Port19)", "Eth19/4(Port19)"],
-                "1x100G[40G](2)": ["Eth19(Port19)"],
-                "2x50G(2)": ["Eth19/1(Port19)", "Eth19/2(Port19)"],
-                "4x25G[10G]": ["Eth19/1(Port19)", "Eth19/2(Port19)", "Eth19/3(Port19)", "Eth19/4(Port19)"]
-            }
-        },
-
-        "Ethernet76": {
-            "index": "20,20,20,20",
-            "lanes": "137,138,139,140",
-            "breakout_modes": {
-                "1x400G": ["Eth20(Port20)"],
-                "2x200G": ["Eth20/1(Port20)", "Eth20/2(Port20)"],
-                "4x100G": ["Eth20/1(Port20)", "Eth20/2(Port20)", "Eth20/3(Port20)", "Eth20/4(Port20)"],
-                "1x100G[40G](2)": ["Eth20(Port20)"],
-                "2x50G(2)": ["Eth20/1(Port20)", "Eth20/2(Port20)"],
-                "4x25G[10G]": ["Eth20/1(Port20)", "Eth20/2(Port20)", "Eth20/3(Port20)", "Eth20/4(Port20)"]
+                "1x400G": ["Eth10(Port10)"],
+                "2x200G": ["Eth10/1(Port10)", "Eth10/2(Port10)"],
+                "4x100G": ["Eth10/1(Port10)", "Eth10/2(Port10)", "Eth10/3(Port10)", "Eth10/4(Port10)"],
+                "1x100G[40G](4)": ["Eth10(Port10)"],
+                "2x50G(4)": ["Eth10/1(Port10)", "Eth10/2(Port10)"],
+                "4x25G[10G](4)": ["Eth10/1(Port10)", "Eth10/2(Port10)", "Eth10/3(Port10)", "Eth10/4(Port10)"]
             }
         },
 
         "Ethernet80": {
-            "index": "21,21,21,21",
-            "lanes": "129,130,131,132",
+            "index": "11,11,11,11,11,11,11,11",
+            "lanes": "250,251,252,253,254,255,256,257",
             "breakout_modes": {
-                "1x400G": ["Eth21(Port21)"],
-                "2x200G": ["Eth21/1(Port21)", "Eth21/2(Port21)"],
-                "4x100G": ["Eth21/1(Port21)", "Eth21/2(Port21)", "Eth21/3(Port21)", "Eth21/4(Port21)"],
-                "1x100G[40G](2)": ["Eth21(Port21)"],
-                "2x50G(2)": ["Eth21/1(Port21)", "Eth21/2(Port21)"],
-                "4x25G[10G]": ["Eth21/1(Port21)", "Eth21/2(Port21)", "Eth21/3(Port21)", "Eth21/4(Port21)"]
-            }
-        },
-
-        "Ethernet84": {
-            "index": "22,22,22,22",
-            "lanes": "133,134,135,136",
-            "breakout_modes": {
-                "1x400G": ["Eth22(Port22)"],
-                "2x200G": ["Eth22/1(Port22)", "Eth22/2(Port22)"],
-                "4x100G": ["Eth22/1(Port22)", "Eth22/2(Port22)", "Eth22/3(Port22)", "Eth22/4(Port22)"],
-                "1x100G[40G](2)": ["Eth22(Port22)"],
-                "2x50G(2)": ["Eth22/1(Port22)", "Eth22/2(Port22)"],
-                "4x25G[10G]": ["Eth22/1(Port22)", "Eth22/2(Port22)", "Eth22/3(Port22)", "Eth22/4(Port22)"]
+                "1x400G": ["Eth11(Port11)"],
+                "2x200G": ["Eth11/1(Port11)", "Eth11/2(Port11)"],
+                "4x100G": ["Eth11/1(Port11)", "Eth11/2(Port11)", "Eth11/3(Port11)", "Eth11/4(Port11)"],
+                "1x100G[40G](4)": ["Eth11(Port11)"],
+                "2x50G(4)": ["Eth11/1(Port11)", "Eth11/2(Port11)"],
+                "4x25G[10G](4)": ["Eth11/1(Port11)", "Eth11/2(Port11)", "Eth11/3(Port11)", "Eth11/4(Port11)"]
             }
         },
 
         "Ethernet88": {
-            "index": "23,23,23,23",
-            "lanes": "153,154,155,156",
+            "index": "12,12,12,12,12,12,12,12",
+            "lanes": "242,243,244,245,246,247,248,249",
             "breakout_modes": {
-                "1x400G": ["Eth23(Port23)"],
-                "2x200G": ["Eth23/1(Port23)", "Eth23/2(Port23)"],
-                "4x100G": ["Eth23/1(Port23)", "Eth23/2(Port23)", "Eth23/3(Port23)", "Eth23/4(Port23)"],
-                "1x100G[40G](2)": ["Eth23(Port23)"],
-                "2x50G(2)": ["Eth23/1(Port23)", "Eth23/2(Port23)"],
-                "4x25G[10G]": ["Eth23/1(Port23)", "Eth23/2(Port23)", "Eth23/3(Port23)", "Eth23/4(Port23)"]
-            }
-        },
-
-        "Ethernet92": {
-            "index": "24,24,24,24",
-            "lanes": "157,158,159,160",
-            "breakout_modes": {
-                "1x400G": ["Eth24(Port24)"],
-                "2x200G": ["Eth24/1(Port24)", "Eth24/2(Port24)"],
-                "4x100G": ["Eth24/1(Port24)", "Eth24/2(Port24)", "Eth24/3(Port24)", "Eth24/4(Port24)"],
-                "1x100G[40G](2)": ["Eth24(Port24)"],
-                "2x50G(2)": ["Eth24/1(Port24)", "Eth24/2(Port24)"],
-                "4x25G[10G]": ["Eth24/1(Port24)", "Eth24/2(Port24)", "Eth24/3(Port24)", "Eth24/4(Port24)"]
+                "1x400G": ["Eth12(Port12)"],
+                "2x200G": ["Eth12/1(Port12)", "Eth12/2(Port12)"],
+                "4x100G": ["Eth12/1(Port12)", "Eth12/2(Port12)", "Eth12/3(Port12)", "Eth12/4(Port12)"],
+                "1x100G[40G](4)": ["Eth12(Port12)"],
+                "2x50G(4)": ["Eth12/1(Port12)", "Eth12/2(Port12)"],
+                "4x25G[10G](4)": ["Eth12/1(Port12)", "Eth12/2(Port12)", "Eth12/3(Port12)", "Eth12/4(Port12)"]
             }
         },
 
         "Ethernet96": {
-            "index": "25,25,25,25",
-            "lanes": "161,162,163,164",
+            "index": "13,13,13,13,13,13,13,13",
+            "lanes": "226,227,228,229,230,231,232,233",
             "breakout_modes": {
-                "1x400G": ["Eth25(Port25)"],
-                "2x200G": ["Eth25/1(Port25)", "Eth25/2(Port25)"],
-                "4x100G": ["Eth25/1(Port25)", "Eth25/2(Port25)", "Eth25/3(Port25)", "Eth25/4(Port25)"],
-                "1x100G[40G](2)": ["Eth25(Port25)"],
-                "2x50G(2)": ["Eth25/1(Port25)", "Eth25/2(Port25)"],
-                "4x25G[10G]": ["Eth25/1(Port25)", "Eth25/2(Port25)", "Eth25/3(Port25)", "Eth25/4(Port25)"]
-            }
-        },
-
-        "Ethernet100": {
-            "index": "26,26,26,26",
-            "lanes": "165,166,167,168",
-            "breakout_modes": {
-                "1x400G": ["Eth26(Port26)"],
-                "2x200G": ["Eth26/1(Port26)", "Eth26/2(Port26)"],
-                "4x100G": ["Eth26/1(Port26)", "Eth26/2(Port26)", "Eth26/3(Port26)", "Eth26/4(Port26)"],
-                "1x100G[40G](2)": ["Eth26(Port26)"],
-                "2x50G(2)": ["Eth26/1(Port26)", "Eth26/2(Port26)"],
-                "4x25G[10G]": ["Eth26/1(Port26)", "Eth26/2(Port26)", "Eth26/3(Port26)", "Eth26/4(Port26)"]
+                "1x400G": ["Eth13(Port13)"],
+                "2x200G": ["Eth13/1(Port13)", "Eth13/2(Port13)"],
+                "4x100G": ["Eth13/1(Port13)", "Eth13/2(Port13)", "Eth13/3(Port13)", "Eth13/4(Port13)"],
+                "1x100G[40G](4)": ["Eth13(Port13)"],
+                "2x50G(4)": ["Eth13/1(Port13)", "Eth13/2(Port13)"],
+                "4x25G[10G](4)": ["Eth13/1(Port13)", "Eth13/2(Port13)", "Eth13/3(Port13)", "Eth13/4(Port13)"]
             }
         },
 
         "Ethernet104": {
-            "index": "27,27,27,27",
-            "lanes": "169,170,171,172",
+            "index": "14,14,14,14,14,14,14,14",
+            "lanes": "234,235,236,237,238,239,240,241",
             "breakout_modes": {
-                "1x400G": ["Eth27(Port27)"],
-                "2x200G": ["Eth27/1(Port27)", "Eth27/2(Port27)"],
-                "4x100G": ["Eth27/1(Port27)", "Eth27/2(Port27)", "Eth27/3(Port27)", "Eth27/4(Port27)"],
-                "1x100G[40G](2)": ["Eth27(Port27)"],
-                "2x50G(2)": ["Eth27/1(Port27)", "Eth27/2(Port27)"],
-                "4x25G[10G]": ["Eth27/1(Port27)", "Eth27/2(Port27)", "Eth27/3(Port27)", "Eth27/4(Port27)"]
-            }
-        },
-
-        "Ethernet108": {
-            "index": "28,28,28,28",
-            "lanes": "173,174,175,176",
-            "breakout_modes": {
-                "1x400G": ["Eth28(Port28)"],
-                "2x200G": ["Eth28/1(Port28)", "Eth28/2(Port28)"],
-                "4x100G": ["Eth28/1(Port28)", "Eth28/2(Port28)", "Eth28/3(Port28)", "Eth28/4(Port28)"],
-                "1x100G[40G](2)": ["Eth28(Port28)"],
-                "2x50G(2)": ["Eth28/1(Port28)", "Eth28/2(Port28)"],
-                "4x25G[10G]": ["Eth28/1(Port28)", "Eth28/2(Port28)", "Eth28/3(Port28)", "Eth28/4(Port28)"]
+                "1x400G": ["Eth14(Port14)"],
+                "2x200G": ["Eth14/1(Port14)", "Eth14/2(Port14)"],
+                "4x100G": ["Eth14/1(Port14)", "Eth14/2(Port14)", "Eth14/3(Port14)", "Eth14/4(Port14)"],
+                "1x100G[40G](4)": ["Eth14(Port14)"],
+                "2x50G(4)": ["Eth14/1(Port14)", "Eth14/2(Port14)"],
+                "4x25G[10G](4)": ["Eth14/1(Port14)", "Eth14/2(Port14)", "Eth14/3(Port14)", "Eth14/4(Port14)"]
             }
         },
 
         "Ethernet112": {
-            "index": "29,29,29,29",
-            "lanes": "177,178,179,180",
+            "index": "15,15,15,15,15,15,15,15",
+            "lanes": "218,219,220,221,222,223,224,225",
             "breakout_modes": {
-                "1x400G": ["Eth29(Port29)"],
-                "2x200G": ["Eth29/1(Port29)", "Eth29/2(Port29)"],
-                "4x100G": ["Eth29/1(Port29)", "Eth29/2(Port29)", "Eth29/3(Port29)", "Eth29/4(Port29)"],
-                "1x100G[40G](2)": ["Eth29(Port29)"],
-                "2x50G(2)": ["Eth29/1(Port29)", "Eth29/2(Port29)"],
-                "4x25G[10G]": ["Eth29/1(Port29)", "Eth29/2(Port29)", "Eth29/3(Port29)", "Eth29/4(Port29)"]
-            }
-        },
-
-        "Ethernet116": {
-            "index": "30,30,30,30",
-            "lanes": "181,182,183,184",
-            "breakout_modes": {
-                "1x400G": ["Eth30(Port30)"],
-                "2x200G": ["Eth30/1(Port30)", "Eth30/2(Port30)"],
-                "4x100G": ["Eth30/1(Port30)", "Eth30/2(Port30)", "Eth30/3(Port30)", "Eth30/4(Port30)"],
-                "1x100G[40G](2)": ["Eth30(Port30)"],
-                "2x50G(2)": ["Eth30/1(Port30)", "Eth30/2(Port30)"],
-                "4x25G[10G]": ["Eth30/1(Port30)", "Eth30/2(Port30)", "Eth30/3(Port30)", "Eth30/4(Port30)"]
+                "1x400G": ["Eth15(Port15)"],
+                "2x200G": ["Eth15/1(Port15)", "Eth15/2(Port15)"],
+                "4x100G": ["Eth15/1(Port15)", "Eth15/2(Port15)", "Eth15/3(Port15)", "Eth15/4(Port15)"],
+                "1x100G[40G](4)": ["Eth15(Port15)"],
+                "2x50G(4)": ["Eth15/1(Port15)", "Eth15/2(Port15)"],
+                "4x25G[10G](4)": ["Eth15/1(Port15)", "Eth15/2(Port15)", "Eth15/3(Port15)", "Eth15/4(Port15)"]
             }
         },
 
         "Ethernet120": {
-            "index": "31,31,31,31",
-            "lanes": "185,186,187,188",
+            "index": "16,16,16,16,16,16,16,16",
+            "lanes": "210,211,212,213,214,215,216,217",
             "breakout_modes": {
-                "1x400G": ["Eth31(Port31)"],
-                "2x200G": ["Eth31/1(Port31)", "Eth31/2(Port31)"],
-                "4x100G": ["Eth31/1(Port31)", "Eth31/2(Port31)", "Eth31/3(Port31)", "Eth31/4(Port31)"],
-                "1x100G[40G](2)": ["Eth31(Port31)"],
-                "2x50G(2)": ["Eth31/1(Port31)", "Eth31/2(Port31)"],
-                "4x25G[10G]": ["Eth31/1(Port31)", "Eth31/2(Port31)", "Eth31/3(Port31)", "Eth31/4(Port31)"]
+                "1x400G": ["Eth16(Port16)"],
+                "2x200G": ["Eth16/1(Port16)", "Eth16/2(Port16)"],
+                "4x100G": ["Eth16/1(Port16)", "Eth16/2(Port16)", "Eth16/3(Port16)", "Eth16/4(Port16)"],
+                "1x100G[40G](4)": ["Eth16(Port16)"],
+                "2x50G(4)": ["Eth16/1(Port16)", "Eth16/2(Port16)"],
+                "4x25G[10G](4)": ["Eth16/1(Port16)", "Eth16/2(Port16)", "Eth16/3(Port16)", "Eth16/4(Port16)"]
             }
         },
-
-        "Ethernet124": {
-            "index": "32,32,32,32",
-            "lanes": "189,190,191,192",
-            "breakout_modes": {
-                "1x400G": ["Eth32(Port32)"],
-                "2x200G": ["Eth32/1(Port32)", "Eth32/2(Port32)"],
-                "4x100G": ["Eth32/1(Port32)", "Eth32/2(Port32)", "Eth32/3(Port32)", "Eth32/4(Port32)"],
-                "1x100G[40G](2)": ["Eth32(Port32)"],
-                "2x50G(2)": ["Eth32/1(Port32)", "Eth32/2(Port32)"],
-                "4x25G[10G]": ["Eth32/1(Port32)", "Eth32/2(Port32)", "Eth32/3(Port32)", "Eth32/4(Port32)"]
-            }
-        },
-
 
         "Ethernet128": {
-            "index": "33,33,33,33",
-            "lanes": "49,50,51,52",
+            "index": "17,17,17,17,17,17,17,17",
+            "lanes": "290,291,292,293,294,295,296,297",
             "breakout_modes": {
-                "1x400G": ["Eth33(Port33)"],
-                "2x200G": ["Eth33/1(Port33)", "Eth33/2(Port33)"],
-                "4x100G": ["Eth33/1(Port33)", "Eth33/2(Port33)", "Eth33/3(Port33)", "Eth33/4(Port33)"],
-                "1x100G[40G](2)": ["Eth33(Port33)"],
-                "2x50G(2)": ["Eth33/1(Port33)", "Eth33/2(Port33)"],
-                "4x25G[10G]": ["Eth33/1(Port33)", "Eth33/2(Port33)", "Eth33/3(Port33)", "Eth33/4(Port33)"]
-            }
-        },
-
-        "Ethernet132": {
-            "index": "34,34,34,34",
-            "lanes": "53,54,55,56",
-            "breakout_modes": {
-                "1x400G": ["Eth34(Port34)"],
-                "2x200G": ["Eth34/1(Port34)", "Eth34/2(Port34)"],
-                "4x100G": ["Eth34/1(Port34)", "Eth34/2(Port34)", "Eth34/3(Port34)", "Eth34/4(Port34)"],
-                "1x100G[40G](2)": ["Eth34(Port34)"],
-                "2x50G(2)": ["Eth34/1(Port34)", "Eth34/2(Port34)"],
-                "4x25G[10G]": ["Eth34/1(Port34)", "Eth34/2(Port34)", "Eth34/3(Port34)", "Eth34/4(Port34)"]
+                "1x400G": ["Eth17(Port17)"],
+                "2x200G": ["Eth17/1(Port17)", "Eth17/2(Port17)"],
+                "4x100G": ["Eth17/1(Port17)", "Eth17/2(Port17)", "Eth17/3(Port17)", "Eth17/4(Port17)"],
+                "1x100G[40G](4)": ["Eth17(Port17)"],
+                "2x50G(4)": ["Eth17/1(Port17)", "Eth17/2(Port17)"],
+                "4x25G[10G](4)": ["Eth17/1(Port17)", "Eth17/2(Port17)", "Eth17/3(Port17)", "Eth17/4(Port17)"]
             }
         },
 
         "Ethernet136": {
-            "index": "35,35,35,35",
-            "lanes": "57,58,59,60",
+            "index": "18,18,18,18,18,18,18,18",
+            "lanes": "298,299,300,301,302,303,304,305",
             "breakout_modes": {
-                "1x400G": ["Eth35(Port35)"],
-                "2x200G": ["Eth35/1(Port35)", "Eth35/2(Port35)"],
-                "4x100G": ["Eth35/1(Port35)", "Eth35/2(Port35)", "Eth35/3(Port35)", "Eth35/4(Port35)"],
-                "1x100G[40G](2)": ["Eth35(Port35)"],
-                "2x50G(2)": ["Eth35/1(Port35)", "Eth35/2(Port35)"],
-                "4x25G[10G]": ["Eth35/1(Port35)", "Eth35/2(Port35)", "Eth35/3(Port35)", "Eth35/4(Port35)"]
-            }
-        },
-
-        "Ethernet140": {
-            "index": "36,36,36,36",
-            "lanes": "61,62,63,64",
-            "breakout_modes": {
-                "1x400G": ["Eth36(Port36)"],
-                "2x200G": ["Eth36/1(Port36)", "Eth36/2(Port36)"],
-                "4x100G": ["Eth36/1(Port36)", "Eth36/2(Port36)", "Eth36/3(Port36)", "Eth36/4(Port36)"],
-                "1x100G[40G](2)": ["Eth36(Port36)"],
-                "2x50G(2)": ["Eth36/1(Port36)", "Eth36/2(Port36)"],
-                "4x25G[10G]": ["Eth36/1(Port36)", "Eth36/2(Port36)", "Eth36/3(Port36)", "Eth36/4(Port36)"]
+                "1x400G": ["Eth18(Port18)"],
+                "2x200G": ["Eth18/1(Port18)", "Eth18/2(Port18)"],
+                "4x100G": ["Eth18/1(Port18)", "Eth18/2(Port18)", "Eth18/3(Port18)", "Eth18/4(Port18)"],
+                "1x100G[40G](4)": ["Eth18(Port18)"],
+                "2x50G(4)": ["Eth18/1(Port18)", "Eth18/2(Port18)"],
+                "4x25G[10G](4)": ["Eth18/1(Port18)", "Eth18/2(Port18)", "Eth18/3(Port18)", "Eth18/4(Port18)"]
             }
         },
 
         "Ethernet144": {
-            "index": "37,37,37,37",
-            "lanes": "29,30,31,32",
+            "index": "19,19,19,19,19,19,19,19",
+            "lanes": "282,283,284,285,286,287,288,289",
             "breakout_modes": {
-                "1x400G": ["Eth37(Port37)"],
-                "2x200G": ["Eth37/1(Port37)", "Eth37/2(Port37)"],
-                "4x100G": ["Eth37/1(Port37)", "Eth37/2(Port37)", "Eth37/3(Port37)", "Eth37/4(Port37)"],
-                "1x100G[40G](2)": ["Eth37(Port37)"],
-                "2x50G(2)": ["Eth37/1(Port37)", "Eth37/2(Port37)"],
-                "4x25G[10G]": ["Eth37/1(Port37)", "Eth37/2(Port37)", "Eth37/3(Port37)", "Eth37/4(Port37)"]
-            }
-        },
-
-        "Ethernet148": {
-            "index": "38,38,38,38",
-            "lanes": "33,34,35,36",
-            "breakout_modes": {
-                "1x400G": ["Eth38(Port38)"],
-                "2x200G": ["Eth38/1(Port38)", "Eth38/2(Port38)"],
-                "4x100G": ["Eth38/1(Port38)", "Eth38/2(Port38)", "Eth38/3(Port38)", "Eth38/4(Port38)"],
-                "1x100G[40G](2)": ["Eth38(Port38)"],
-                "2x50G(2)": ["Eth38/1(Port38)", "Eth38/2(Port38)"],
-                "4x25G[10G]": ["Eth38/1(Port38)", "Eth38/2(Port38)", "Eth38/3(Port38)", "Eth38/4(Port38)"]
+                "1x400G": ["Eth19(Port19)"],
+                "2x200G": ["Eth19/1(Port19)", "Eth19/2(Port19)"],
+                "4x100G": ["Eth19/1(Port19)", "Eth19/2(Port19)", "Eth19/3(Port19)", "Eth19/4(Port19)"],
+                "1x100G[40G](4)": ["Eth19(Port19)"],
+                "2x50G(4)": ["Eth19/1(Port19)", "Eth19/2(Port19)"],
+                "4x25G[10G](4)": ["Eth19/1(Port19)", "Eth19/2(Port19)", "Eth19/3(Port19)", "Eth19/4(Port19)"]
             }
         },
 
         "Ethernet152": {
-            "index": "39,39,39,39",
-            "lanes": "25,26,27,28",
+            "index": "20,20,20,20,20,20,20,20",
+            "lanes": "274,275,276,277,278,279,280,281",
             "breakout_modes": {
-                "1x400G": ["Eth39(Port39)"],
-                "2x200G": ["Eth39/1(Port39)", "Eth39/2(Port39)"],
-                "4x100G": ["Eth39/1(Port39)", "Eth39/2(Port39)", "Eth39/3(Port39)", "Eth39/4(Port39)"],
-                "1x100G[40G](2)": ["Eth39(Port39)"],
-                "2x50G(2)": ["Eth39/1(Port39)", "Eth39/2(Port39)"],
-                "4x25G[10G]": ["Eth39/1(Port39)", "Eth39/2(Port39)", "Eth39/3(Port39)", "Eth39/4(Port39)"]
-            }
-        },
-
-        "Ethernet156": {
-            "index": "40,40,40,40",
-            "lanes": "41,42,43,44",
-            "breakout_modes": {
-                "1x400G": ["Eth40(Port40)"],
-                "2x200G": ["Eth40/1(Port40)", "Eth40/2(Port40)"],
-                "4x100G": ["Eth40/1(Port40)", "Eth40/2(Port40)", "Eth40/3(Port40)", "Eth40/4(Port40)"],
-                "1x100G[40G](2)": ["Eth40(Port40)"],
-                "2x50G(2)": ["Eth40/1(Port40)", "Eth40/2(Port40)"],
-                "4x25G[10G]": ["Eth40/1(Port40)", "Eth40/2(Port40)", "Eth40/3(Port40)", "Eth40/4(Port40)"]
+                "1x400G": ["Eth20(Port20)"],
+                "2x200G": ["Eth20/1(Port20)", "Eth20/2(Port20)"],
+                "4x100G": ["Eth20/1(Port20)", "Eth20/2(Port20)", "Eth20/3(Port20)", "Eth20/4(Port20)"],
+                "1x100G[40G](4)": ["Eth20(Port20)"],
+                "2x50G(4)": ["Eth20/1(Port20)", "Eth20/2(Port20)"],
+                "4x25G[10G](4)": ["Eth20/1(Port20)", "Eth20/2(Port20)", "Eth20/3(Port20)", "Eth20/4(Port20)"]
             }
         },
 
         "Ethernet160": {
-            "index": "41,41,41,41",
-            "lanes": "21,22,23,24",
+            "index": "21,21,21,21,21,21,21,21",
+            "lanes": "258,259,260,261,262,263,264,265",
             "breakout_modes": {
-                "1x400G": ["Eth41(Port41)"],
-                "2x200G": ["Eth41/1(Port41)", "Eth41/2(Port41)"],
-                "4x100G": ["Eth41/1(Port41)", "Eth41/2(Port41)", "Eth41/3(Port41)", "Eth41/4(Port41)"],
-                "1x100G[40G](2)": ["Eth41(Port41)"],
-                "2x50G(2)": ["Eth41/1(Port41)", "Eth41/2(Port41)"],
-                "4x25G[10G]": ["Eth41/1(Port41)", "Eth41/2(Port41)", "Eth41/3(Port41)", "Eth41/4(Port41)"]
-            }
-        },
-
-        "Ethernet164": {
-            "index": "42,42,42,42",
-            "lanes": "37,38,39,40",
-            "breakout_modes": {
-                "1x400G": ["Eth42(Port42)"],
-                "2x200G": ["Eth42/1(Port42)", "Eth42/2(Port42)"],
-                "4x100G": ["Eth42/1(Port42)", "Eth42/2(Port42)", "Eth42/3(Port42)", "Eth42/4(Port42)"],
-                "1x100G[40G](2)": ["Eth42(Port42)"],
-                "2x50G(2)": ["Eth42/1(Port42)", "Eth42/2(Port42)"],
-                "4x25G[10G]": ["Eth42/1(Port42)", "Eth42/2(Port42)", "Eth42/3(Port42)", "Eth42/4(Port42)"]
+                "1x400G": ["Eth21(Port21)"],
+                "2x200G": ["Eth21/1(Port21)", "Eth21/2(Port21)"],
+                "4x100G": ["Eth21/1(Port21)", "Eth21/2(Port21)", "Eth21/3(Port21)", "Eth21/4(Port21)"],
+                "1x100G[40G](4)": ["Eth21(Port21)"],
+                "2x50G(4)": ["Eth21/1(Port21)", "Eth21/2(Port21)"],
+                "4x25G[10G](4)": ["Eth21/1(Port21)", "Eth21/2(Port21)", "Eth21/3(Port21)", "Eth21/4(Port21)"]
             }
         },
 
         "Ethernet168": {
-            "index": "43,43,43,43",
-            "lanes": "17,18,19,20",
+            "index": "22,22,22,22,22,22,22,22",
+            "lanes": "266,267,268,269,270,271,272,273",
             "breakout_modes": {
-                "1x400G": ["Eth43(Port43)"],
-                "2x200G": ["Eth43/1(Port43)", "Eth43/2(Port43)"],
-                "4x100G": ["Eth43/1(Port43)", "Eth43/2(Port43)", "Eth43/3(Port43)", "Eth43/4(Port43)"],
-                "1x100G[40G](2)": ["Eth43(Port43)"],
-                "2x50G(2)": ["Eth43/1(Port43)", "Eth43/2(Port43)"],
-                "4x25G[10G]": ["Eth43/1(Port43)", "Eth43/2(Port43)", "Eth43/3(Port43)", "Eth43/4(Port43)"]
-            }
-        },
-
-        "Ethernet172": {
-            "index": "44,44,44,44",
-            "lanes": "45,46,47,48",
-            "breakout_modes": {
-                "1x400G": ["Eth44(Port44)"],
-                "2x200G": ["Eth44/1(Port44)", "Eth44/2(Port44)"],
-                "4x100G": ["Eth44/1(Port44)", "Eth44/2(Port44)", "Eth44/3(Port44)", "Eth44/4(Port44)"],
-                "1x100G[40G](2)": ["Eth44(Port44)"],
-                "2x50G(2)": ["Eth44/1(Port44)", "Eth44/2(Port44)"],
-                "4x25G[10G]": ["Eth44/1(Port44)", "Eth44/2(Port44)", "Eth44/3(Port44)", "Eth44/4(Port44)"]
+                "1x400G": ["Eth22(Port22)"],
+                "2x200G": ["Eth22/1(Port22)", "Eth22/2(Port22)"],
+                "4x100G": ["Eth22/1(Port22)", "Eth22/2(Port22)", "Eth22/3(Port22)", "Eth22/4(Port22)"],
+                "1x100G[40G](4)": ["Eth22(Port22)"],
+                "2x50G(4)": ["Eth22/1(Port22)", "Eth22/2(Port22)"],
+                "4x25G[10G](4)": ["Eth22/1(Port22)", "Eth22/2(Port22)", "Eth22/3(Port22)", "Eth22/4(Port22)"]
             }
         },
 
         "Ethernet176": {
-            "index": "45,45,45,45",
-            "lanes": "13,14,15,16",
+            "index": "23,23,23,23,23,23,23,23",
+            "lanes": "306,307,308,309,310,311,312,313",
             "breakout_modes": {
-                "1x400G": ["Eth45(Port45)"],
-                "2x200G": ["Eth45/1(Port45)", "Eth45/2(Port45)"],
-                "4x100G": ["Eth45/1(Port45)", "Eth45/2(Port45)", "Eth45/3(Port45)", "Eth45/4(Port45)"],
-                "1x100G[40G](2)": ["Eth45(Port45)"],
-                "2x50G(2)": ["Eth45/1(Port45)", "Eth45/2(Port45)"],
-                "4x25G[10G]": ["Eth45/1(Port45)", "Eth45/2(Port45)", "Eth45/3(Port45)", "Eth45/4(Port45)"]
-            }
-        },
-
-        "Ethernet180": {
-            "index": "46,46,46,46",
-            "lanes": "9,10,11,12",
-            "breakout_modes": {
-                "1x400G": ["Eth46(Port46)"],
-                "2x200G": ["Eth46/1(Port46)", "Eth46/2(Port46)"],
-                "4x100G": ["Eth46/1(Port46)", "Eth46/2(Port46)", "Eth46/3(Port46)", "Eth46/4(Port46)"],
-                "1x100G[40G](2)": ["Eth46(Port46)"],
-                "2x50G(2)": ["Eth46/1(Port46)", "Eth46/2(Port46)"],
-                "4x25G[10G]": ["Eth46/1(Port46)", "Eth46/2(Port46)", "Eth46/3(Port46)", "Eth46/4(Port46)"]
+                "1x400G": ["Eth23(Port23)"],
+                "2x200G": ["Eth23/1(Port23)", "Eth23/2(Port23)"],
+                "4x100G": ["Eth23/1(Port23)", "Eth23/2(Port23)", "Eth23/3(Port23)", "Eth23/4(Port23)"],
+                "1x100G[40G](4)": ["Eth23(Port23)"],
+                "2x50G(4)": ["Eth23/1(Port23)", "Eth23/2(Port23)"],
+                "4x25G[10G](4)": ["Eth23/1(Port23)", "Eth23/2(Port23)", "Eth23/3(Port23)", "Eth23/4(Port23)"]
             }
         },
 
         "Ethernet184": {
-            "index": "47,47,47,47",
-            "lanes": "1,2,3,4",
+            "index": "24,24,24,24,24,24,24,24",
+            "lanes": "314,315,316,317,318,319,320,321",
             "breakout_modes": {
-                "1x400G": ["Eth47(Port47)"],
-                "2x200G": ["Eth47/1(Port47)", "Eth47/2(Port47)"],
-                "4x100G": ["Eth47/1(Port47)", "Eth47/2(Port47)", "Eth47/3(Port47)", "Eth47/4(Port47)"],
-                "1x100G[40G](2)": ["Eth47(Port47)"],
-                "2x50G(2)": ["Eth47/1(Port47)", "Eth47/2(Port47)"],
-                "4x25G[10G]": ["Eth47/1(Port47)", "Eth47/2(Port47)", "Eth47/3(Port47)", "Eth47/4(Port47)"]
-            }
-        },
-
-        "Ethernet188": {
-            "index": "48,48,48,48",
-            "lanes": "5,6,7,8",
-            "breakout_modes": {
-                "1x400G": ["Eth48(Port48)"],
-                "2x200G": ["Eth48/1(Port48)", "Eth48/2(Port48)"],
-                "4x100G": ["Eth48/1(Port48)", "Eth48/2(Port48)", "Eth48/3(Port48)", "Eth48/4(Port48)"],
-                "1x100G[40G](2)": ["Eth48(Port48)"],
-                "2x50G(2)": ["Eth48/1(Port48)", "Eth48/2(Port48)"],
-                "4x25G[10G]": ["Eth48/1(Port48)", "Eth48/2(Port48)", "Eth48/3(Port48)", "Eth48/4(Port48)"]
+                "1x400G": ["Eth24(Port24)"],
+                "2x200G": ["Eth24/1(Port24)", "Eth24/2(Port24)"],
+                "4x100G": ["Eth24/1(Port24)", "Eth24/2(Port24)", "Eth24/3(Port24)", "Eth24/4(Port24)"],
+                "1x100G[40G](4)": ["Eth24(Port24)"],
+                "2x50G(4)": ["Eth24/1(Port24)", "Eth24/2(Port24)"],
+                "4x25G[10G](4)": ["Eth24/1(Port24)", "Eth24/2(Port24)", "Eth24/3(Port24)", "Eth24/4(Port24)"]
             }
         },
 
         "Ethernet192": {
-            "index": "49,49,49,49",
-            "lanes": "249,250,251,252",
+            "index": "25,25,25,25,25,25,25,25",
+            "lanes": "322,323,324,325,326,327,328,329",
             "breakout_modes": {
-                "1x400G": ["Eth49(Port49)"],
-                "2x200G": ["Eth49/1(Port49)", "Eth49/2(Port49)"],
-                "4x100G": ["Eth49/1(Port49)", "Eth49/2(Port49)", "Eth49/3(Port49)", "Eth49/4(Port49)"],
-                "1x100G[40G](2)": ["Eth49(Port49)"],
-                "2x50G(2)": ["Eth49/1(Port49)", "Eth49/2(Port49)"],
-                "4x25G[10G]": ["Eth49/1(Port49)", "Eth49/2(Port49)", "Eth49/3(Port49)", "Eth49/4(Port49)"]
-            }
-        },
-
-        "Ethernet196": {
-            "index": "50,50,50,50",
-            "lanes": "253,254,255,256",
-            "breakout_modes": {
-                "1x400G": ["Eth50(Port50)"],
-                "2x200G": ["Eth50/1(Port50)", "Eth50/2(Port50)"],
-                "4x100G": ["Eth50/1(Port50)", "Eth50/2(Port50)", "Eth50/3(Port50)", "Eth50/4(Port50)"],
-                "1x100G[40G](2)": ["Eth50(Port50)"],
-                "2x50G(2)": ["Eth50/1(Port50)", "Eth50/2(Port50)"],
-                "4x25G[10G]": ["Eth50/1(Port50)", "Eth50/2(Port50)", "Eth50/3(Port50)", "Eth50/4(Port50)"]
+                "1x400G": ["Eth25(Port25)"],
+                "2x200G": ["Eth25/1(Port25)", "Eth25/2(Port25)"],
+                "4x100G": ["Eth25/1(Port25)", "Eth25/2(Port25)", "Eth25/3(Port25)", "Eth25/4(Port25)"],
+                "1x100G[40G](4)": ["Eth25(Port25)"],
+                "2x50G(4)": ["Eth25/1(Port25)", "Eth25/2(Port25)"],
+                "4x25G[10G](4)": ["Eth25/1(Port25)", "Eth25/2(Port25)", "Eth25/3(Port25)", "Eth25/4(Port25)"]
             }
         },
 
         "Ethernet200": {
-            "index": "51,51,51,51",
-            "lanes": "245,246,247,248",
+            "index": "26,26,26,26,26,26,26,26",
+            "lanes": "330,331,332,333,334,335,336,337",
             "breakout_modes": {
-                "1x400G": ["Eth51(Port51)"],
-                "2x200G": ["Eth51/1(Port51)", "Eth51/2(Port51)"],
-                "4x100G": ["Eth51/1(Port51)", "Eth51/2(Port51)", "Eth51/3(Port51)", "Eth51/4(Port51)"],
-                "1x100G[40G](2)": ["Eth51(Port51)"],
-                "2x50G(2)": ["Eth51/1(Port51)", "Eth51/2(Port51)"],
-                "4x25G[10G]": ["Eth51/1(Port51)", "Eth51/2(Port51)", "Eth51/3(Port51)", "Eth51/4(Port51)"]
-            }
-        },
-
-        "Ethernet204": {
-            "index": "52,52,52,52",
-            "lanes": "241,242,243,244",
-            "breakout_modes": {
-                "1x400G": ["Eth52(Port52)"],
-                "2x200G": ["Eth52/1(Port52)", "Eth52/2(Port52)"],
-                "4x100G": ["Eth52/1(Port52)", "Eth52/2(Port52)", "Eth52/3(Port52)", "Eth52/4(Port52)"],
-                "1x100G[40G](2)": ["Eth52(Port52)"],
-                "2x50G(2)": ["Eth52/1(Port52)", "Eth52/2(Port52)"],
-                "4x25G[10G]": ["Eth52/1(Port52)", "Eth52/2(Port52)", "Eth52/3(Port52)", "Eth52/4(Port52)"]
+                "1x400G": ["Eth26(Port26)"],
+                "2x200G": ["Eth26/1(Port26)", "Eth26/2(Port26)"],
+                "4x100G": ["Eth26/1(Port26)", "Eth26/2(Port26)", "Eth26/3(Port26)", "Eth26/4(Port26)"],
+                "1x100G[40G](4)": ["Eth26(Port26)"],
+                "2x50G(4)": ["Eth26/1(Port26)", "Eth26/2(Port26)"],
+                "4x25G[10G](4)": ["Eth26/1(Port26)", "Eth26/2(Port26)", "Eth26/3(Port26)", "Eth26/4(Port26)"]
             }
         },
 
         "Ethernet208": {
-            "index": "53,53,53,53",
-            "lanes": "237,238,239,240",
+            "index": "27,27,27,27,27,27,27,27",
+            "lanes": "338,339,340,341,342,343,344,345",
             "breakout_modes": {
-                "1x400G": ["Eth53(Port53)"],
-                "2x200G": ["Eth53/1(Port53)", "Eth53/2(Port53)"],
-                "4x100G": ["Eth53/1(Port53)", "Eth53/2(Port53)", "Eth53/3(Port53)", "Eth53/4(Port53)"],
-                "1x100G[40G](2)": ["Eth53(Port53)"],
-                "2x50G(2)": ["Eth53/1(Port53)", "Eth53/2(Port53)"],
-                "4x25G[10G]": ["Eth53/1(Port53)", "Eth53/2(Port53)", "Eth53/3(Port53)", "Eth53/4(Port53)"]
-            }
-        },
-
-        "Ethernet212": {
-            "index": "54,54,54,54",
-            "lanes": "209,210,211,212",
-            "breakout_modes": {
-                "1x400G": ["Eth54(Port54)"],
-                "2x200G": ["Eth54/1(Port54)", "Eth54/2(Port54)"],
-                "4x100G": ["Eth54/1(Port54)", "Eth54/2(Port54)", "Eth54/3(Port54)", "Eth54/4(Port54)"],
-                "1x100G[40G](2)": ["Eth54(Port54)"],
-                "2x50G(2)": ["Eth54/1(Port54)", "Eth54/2(Port54)"],
-                "4x25G[10G]": ["Eth54/1(Port54)", "Eth54/2(Port54)", "Eth54/3(Port54)", "Eth54/4(Port54)"]
+                "1x400G": ["Eth27(Port27)"],
+                "2x200G": ["Eth27/1(Port27)", "Eth27/2(Port27)"],
+                "4x100G": ["Eth27/1(Port27)", "Eth27/2(Port27)", "Eth27/3(Port27)", "Eth27/4(Port27)"],
+                "1x100G[40G](4)": ["Eth27(Port27)"],
+                "2x50G(4)": ["Eth27/1(Port27)", "Eth27/2(Port27)"],
+                "4x25G[10G](4)": ["Eth27/1(Port27)", "Eth27/2(Port27)", "Eth27/3(Port27)", "Eth27/4(Port27)"]
             }
         },
 
         "Ethernet216": {
-            "index": "55,55,55,55",
-            "lanes": "233,234,235,236",
+            "index": "28,28,28,28,28,28,28,28",
+            "lanes": "346,347,348,349,350,351,352,353",
             "breakout_modes": {
-                "1x400G": ["Eth55(Port55)"],
-                "2x200G": ["Eth55/1(Port55)", "Eth55/2(Port55)"],
-                "4x100G": ["Eth55/1(Port55)", "Eth55/2(Port55)", "Eth55/3(Port55)", "Eth55/4(Port55)"],
-                "1x100G[40G](2)": ["Eth55(Port55)"],
-                "4x25G[10G]": ["Eth55/1(Port55)", "Eth55/2(Port55)", "Eth55/3(Port55)", "Eth55/4(Port55)"]
-            }
-        },
-
-        "Ethernet220": {
-            "index": "56,56,56,56",
-            "lanes": "217,218,219,220",
-            "breakout_modes": {
-                "1x400G": ["Eth56(Port56)"],
-                "2x200G": ["Eth56/1(Port56)", "Eth56/2(Port56)"],
-                "4x100G": ["Eth56/1(Port56)", "Eth56/2(Port56)", "Eth56/3(Port56)", "Eth56/4(Port56)"],
-                "1x100G[40G](2)": ["Eth56(Port56)"],
-                "2x50G(2)": ["Eth56/1(Port56)", "Eth56/2(Port56)"],
-                "4x25G[10G]": ["Eth56/1(Port56)", "Eth56/2(Port56)", "Eth56/3(Port56)", "Eth56/4(Port56)"]
+                "1x400G": ["Eth28(Port28)"],
+                "2x200G": ["Eth28/1(Port28)", "Eth28/2(Port28)"],
+                "4x100G": ["Eth28/1(Port28)", "Eth28/2(Port28)", "Eth28/3(Port28)", "Eth28/4(Port28)"],
+                "1x100G[40G](4)": ["Eth28(Port28)"],
+                "2x50G(4)": ["Eth28/1(Port28)", "Eth28/2(Port28)"],
+                "4x25G[10G](4)": ["Eth28/1(Port28)", "Eth28/2(Port28)", "Eth28/3(Port28)", "Eth28/4(Port28)"]
             }
         },
 
         "Ethernet224": {
-            "index": "57,57,57,57",
-            "lanes": "229,230,231,232",
+            "index": "29,29,29,29,29,29,29,29",
+            "lanes": "354,355,356,357,358,359,360,361",
             "breakout_modes": {
-                "1x400G": ["Eth57(Port57)"],
-                "2x200G": ["Eth57/1(Port57)", "Eth57/2(Port57)"],
-                "4x100G": ["Eth57/1(Port57)", "Eth57/2(Port57)", "Eth57/3(Port57)", "Eth57/4(Port57)"],
-                "1x100G[40G](2)": ["Eth57(Port57)"],
-                "2x50G(2)": ["Eth57/1(Port57)", "Eth57/2(Port57)"],
-                "4x25G[10G]": ["Eth57/1(Port57)", "Eth57/2(Port57)", "Eth57/3(Port57)", "Eth57/4(Port57)"]
-            }
-        },
-
-        "Ethernet228": {
-            "index": "58,58,58,58",
-            "lanes": "213,214,215,216",
-            "breakout_modes": {
-                "1x400G": ["Eth58(Port58)"],
-                "2x200G": ["Eth58/1(Port58)", "Eth58/2(Port58)"],
-                "4x100G": ["Eth58/1(Port58)", "Eth58/2(Port58)", "Eth58/3(Port58)", "Eth58/4(Port58)"],
-                "1x100G[40G](2)": ["Eth58(Port58)"],
-                "2x50G(2)": ["Eth58/1(Port58)", "Eth58/2(Port58)"],
-                "4x25G[10G]": ["Eth58/1(Port58)", "Eth58/2(Port58)", "Eth58/3(Port58)", "Eth58/4(Port58)"]
+                "1x400G": ["Eth29(Port29)"],
+                "2x200G": ["Eth29/1(Port29)", "Eth29/2(Port29)"],
+                "4x100G": ["Eth29/1(Port29)", "Eth29/2(Port29)", "Eth29/3(Port29)", "Eth29/4(Port29)"],
+                "1x100G[40G](4)": ["Eth29(Port29)"],
+                "2x50G(4)": ["Eth29/1(Port29)", "Eth29/2(Port29)"],
+                "4x25G[10G](4)": ["Eth29/1(Port29)", "Eth29/2(Port29)", "Eth29/3(Port29)", "Eth29/4(Port29)"]
             }
         },
 
         "Ethernet232": {
-            "index": "59,59,59,59",
-            "lanes": "225,226,227,228",
+            "index": "30,30,30,30,30,30,30,30",
+            "lanes": "362,363,364,365,366,367,368,369",
             "breakout_modes": {
-                "1x400G": ["Eth59(Port59)"],
-                "2x200G": ["Eth59/1(Port59)", "Eth59/2(Port59)"],
-                "4x100G": ["Eth59/1(Port59)", "Eth59/2(Port59)", "Eth59/3(Port59)", "Eth59/4(Port59)"],
-                "1x100G[40G](2)": ["Eth59(Port59)"],
-                "2x50G(2)": ["Eth59/1(Port59)", "Eth59/2(Port59)"],
-                "4x25G[10G]": ["Eth59/1(Port59)", "Eth59/2(Port59)", "Eth59/3(Port59)", "Eth59/4(Port59)"]
-            }
-        },
-
-        "Ethernet236": {
-            "index": "60,60,60,60",
-            "lanes": "221,222,223,224",
-            "breakout_modes": {
-                "1x400G": ["Eth60(Port60)"],
-                "2x200G": ["Eth60/1(Port60)", "Eth60/2(Port60)"],
-                "4x100G": ["Eth60/1(Port60)", "Eth60/2(Port60)", "Eth60/3(Port60)", "Eth60/4(Port60)"],
-                "1x100G[40G](2)": ["Eth60(Port60)"],
-                "2x50G(2)": ["Eth60/1(Port60)", "Eth60/2(Port60)"],
-                "4x25G[10G]": ["Eth60/1(Port60)", "Eth60/2(Port60)", "Eth60/3(Port60)", "Eth60/4(Port60)"]
+                "1x400G": ["Eth30(Port30)"],
+                "2x200G": ["Eth30/1(Port30)", "Eth30/2(Port30)"],
+                "4x100G": ["Eth30/1(Port30)", "Eth30/2(Port30)", "Eth30/3(Port30)", "Eth30/4(Port30)"],
+                "1x100G[40G](4)": ["Eth30(Port30)"],
+                "2x50G(4)": ["Eth30/1(Port30)", "Eth30/2(Port30)"],
+                "4x25G[10G](4)": ["Eth30/1(Port30)", "Eth30/2(Port30)", "Eth30/3(Port30)", "Eth30/4(Port30)"]
             }
         },
 
         "Ethernet240": {
-            "index": "61,61,61,61",
-            "lanes": "193,194,195,196",
+            "index": "31,31,31,31,31,31,31,31",
+            "lanes": "370,371,372,373,374,375,376,377",
             "breakout_modes": {
-                "1x400G": ["Eth61(Port61)"],
-                "2x200G": ["Eth61/1(Port61)", "Eth61/2(Port61)"],
-                "4x100G": ["Eth61/1(Port61)", "Eth61/2(Port61)", "Eth61/3(Port61)", "Eth61/4(Port61)"],
-                "1x100G[40G](2)": ["Eth61(Port61)"],
-                "2x50G(2)": ["Eth61/1(Port61)", "Eth61/2(Port61)"],
-                "4x25G[10G]": ["Eth61/1(Port61)", "Eth61/2(Port61)", "Eth61/3(Port61)", "Eth61/4(Port61)"]
-            }
-        },
-
-        "Ethernet244": {
-            "index": "62,62,62,62",
-            "lanes": "201,202,203,204",
-            "breakout_modes": {
-                "1x400G": ["Eth62(Port62)"],
-                "2x200G": ["Eth62/1(Port62)", "Eth62/2(Port62)"],
-                "4x100G": ["Eth62/1(Port62)", "Eth62/2(Port62)", "Eth62/3(Port62)", "Eth62/4(Port62)"],
-                "1x100G[40G](2)": ["Eth62(Port62)"],
-                "2x50G(2)": ["Eth62/1(Port62)", "Eth62/2(Port62)"],
-                "4x25G[10G]": ["Eth62/1(Port62)", "Eth62/2(Port62)", "Eth62/3(Port62)", "Eth62/4(Port62)"]
+                "1x400G": ["Eth31(Port31)"],
+                "2x200G": ["Eth31/1(Port31)", "Eth31/2(Port31)"],
+                "4x100G": ["Eth31/1(Port31)", "Eth31/2(Port31)", "Eth31/3(Port31)", "Eth31/4(Port31)"],
+                "1x100G[40G](4)": ["Eth31(Port31)"],
+                "2x50G(4)": ["Eth31/1(Port31)", "Eth31/2(Port31)"],
+                "4x25G[10G](4)": ["Eth31/1(Port31)", "Eth31/2(Port31)", "Eth31/3(Port31)", "Eth31/4(Port31)"]
             }
         },
 
         "Ethernet248": {
-            "index": "63,63,63,63",
-            "lanes": "197,198,199,200",
+            "index": "32,32,32,32,32,32,32,32",
+            "lanes": "378,379,380,381,382,383,384,385",
             "breakout_modes": {
-                "1x400G": ["Eth63(Port63)"],
-                "2x200G": ["Eth63/1(Port63)", "Eth63/2(Port63)"],
-                "4x100G": ["Eth63/1(Port63)", "Eth63/2(Port63)", "Eth63/3(Port63)", "Eth63/4(Port63)"],
-                "1x100G[40G](2)": ["Eth63(Port63)"],
-                "2x50G(2)": ["Eth63/1(Port63)", "Eth63/2(Port63)"],
-                "4x25G[10G]": ["Eth63/1(Port63)", "Eth63/2(Port63)", "Eth63/3(Port63)", "Eth63/4(Port63)"]
-            }
-        },
-
-        "Ethernet252": {
-            "index": "64,64,64,64",
-            "lanes": "205,206,207,208",
-            "breakout_modes": {
-                "1x400G": ["Eth64(Port64)"],
-                "2x200G": ["Eth64/1(Port64)", "Eth64/2(Port64)"],
-                "4x100G": ["Eth64/1(Port64)", "Eth64/2(Port64)", "Eth64/3(Port64)", "Eth64/4(Port64)"],
-                "1x100G[40G](2)": ["Eth64(Port64)"],
-                "2x50G(2)": ["Eth64/1(Port64)", "Eth64/2(Port64)"],
-                "4x25G[10G]": ["Eth64/1(Port64)", "Eth64/2(Port64)", "Eth64/3(Port64)", "Eth64/4(Port64)"]
+                "1x400G": ["Eth32(Port32)"],
+                "2x200G": ["Eth32/1(Port32)", "Eth32/2(Port32)"],
+                "4x100G": ["Eth32/1(Port32)", "Eth32/2(Port32)", "Eth32/3(Port32)", "Eth32/4(Port32)"],
+                "1x100G[40G](4)": ["Eth32(Port32)"],
+                "2x50G(4)": ["Eth32/1(Port32)", "Eth32/2(Port32)"],
+                "4x25G[10G](4)": ["Eth32/1(Port32)", "Eth32/2(Port32)", "Eth32/3(Port32)", "Eth32/4(Port32)"]
             }
         },
 
         "Ethernet256": {
+            "index": "33,33,33,33,33,33,33,33",
+            "lanes": "98,99,100,101,102,103,104,105",
+            "breakout_modes": {
+                "1x400G": ["Eth33(Port33)"],
+                "2x200G": ["Eth33/1(Port33)", "Eth33/2(Port33)"],
+                "4x100G": ["Eth33/1(Port33)", "Eth33/2(Port33)", "Eth33/3(Port33)", "Eth33/4(Port33)"],
+                "1x100G[40G](4)": ["Eth33(Port33)"],
+                "2x50G(4)": ["Eth33/1(Port33)", "Eth33/2(Port33)"],
+                "4x25G[10G](4)": ["Eth33/1(Port33)", "Eth33/2(Port33)", "Eth33/3(Port33)", "Eth33/4(Port33)"]
+            }
+        },
+
+        "Ethernet264": {
+            "index": "34,34,34,34,34,34,34,34",
+            "lanes": "106,107,108,109,110,111,112,113",
+            "breakout_modes": {
+                "1x400G": ["Eth34(Port34)"],
+                "2x200G": ["Eth34/1(Port34)", "Eth34/2(Port34)"],
+                "4x100G": ["Eth34/1(Port34)", "Eth34/2(Port34)", "Eth34/3(Port34)", "Eth34/4(Port34)"],
+                "1x100G[40G](4)": ["Eth34(Port34)"],
+                "2x50G(4)": ["Eth34/1(Port34)", "Eth34/2(Port34)"],
+                "4x25G[10G](4)": ["Eth34/1(Port34)", "Eth34/2(Port34)", "Eth34/3(Port34)", "Eth34/4(Port34)"]
+            }
+        },
+
+        "Ethernet272": {
+            "index": "35,35,35,35,35,35,35,35",
+            "lanes": "114,115,116,117,118,119,120,121",
+            "breakout_modes": {
+                "1x400G": ["Eth35(Port35)"],
+                "2x200G": ["Eth35/1(Port35)", "Eth35/2(Port35)"],
+                "4x100G": ["Eth35/1(Port35)", "Eth35/2(Port35)", "Eth35/3(Port35)", "Eth35/4(Port35)"],
+                "1x100G[40G](4)": ["Eth35(Port35)"],
+                "2x50G(4)": ["Eth35/1(Port35)", "Eth35/2(Port35)"],
+                "4x25G[10G](4)": ["Eth35/1(Port35)", "Eth35/2(Port35)", "Eth35/3(Port35)", "Eth35/4(Port35)"]
+            }
+        },
+
+        "Ethernet280": {
+            "index": "36,36,36,36,36,36,36,36",
+            "lanes": "122,123,124,125,126,127,128,129",
+            "breakout_modes": {
+                "1x400G": ["Eth36(Port36)"],
+                "2x200G": ["Eth36/1(Port36)", "Eth36/2(Port36)"],
+                "4x100G": ["Eth36/1(Port36)", "Eth36/2(Port36)", "Eth36/3(Port36)", "Eth36/4(Port36)"],
+                "1x100G[40G](4)": ["Eth36(Port36)"],
+                "2x50G(4)": ["Eth36/1(Port36)", "Eth36/2(Port36)"],
+                "4x25G[10G](4)": ["Eth36/1(Port36)", "Eth36/2(Port36)", "Eth36/3(Port36)", "Eth36/4(Port36)"]
+            }
+        },
+
+        "Ethernet288": {
+            "index": "37,37,37,37,37,37,37,37",
+            "lanes": "58,59,60,61,62,63,64,65",
+            "breakout_modes": {
+                "1x400G": ["Eth37(Port37)"],
+                "2x200G": ["Eth37/1(Port37)", "Eth37/2(Port37)"],
+                "4x100G": ["Eth37/1(Port37)", "Eth37/2(Port37)", "Eth37/3(Port37)", "Eth37/4(Port37)"],
+                "1x100G[40G](4)": ["Eth37(Port37)"],
+                "2x50G(4)": ["Eth37/1(Port37)", "Eth37/2(Port37)"],
+                "4x25G[10G](4)": ["Eth37/1(Port37)", "Eth37/2(Port37)", "Eth37/3(Port37)", "Eth37/4(Port37)"]
+            }
+        },
+
+        "Ethernet296": {
+            "index": "38,38,38,38,38,38,38,38",
+            "lanes": "66,67,68,69,70,71,72,73",
+            "breakout_modes": {
+                "1x400G": ["Eth38(Port38)"],
+                "2x200G": ["Eth38/1(Port38)", "Eth38/2(Port38)"],
+                "4x100G": ["Eth38/1(Port38)", "Eth38/2(Port38)", "Eth38/3(Port38)", "Eth38/4(Port38)"],
+                "1x100G[40G](4)": ["Eth38(Port38)"],
+                "2x50G(4)": ["Eth38/1(Port38)", "Eth38/2(Port38)"],
+                "4x25G[10G](4)": ["Eth38/1(Port38)", "Eth38/2(Port38)", "Eth38/3(Port38)", "Eth38/4(Port38)"]
+            }
+        },
+
+        "Ethernet304": {
+            "index": "39,39,39,39,39,39,39,39",
+            "lanes": "50,51,52,53,54,55,56,57",
+            "breakout_modes": {
+                "1x400G": ["Eth39(Port39)"],
+                "2x200G": ["Eth39/1(Port39)", "Eth39/2(Port39)"],
+                "4x100G": ["Eth39/1(Port39)", "Eth39/2(Port39)", "Eth39/3(Port39)", "Eth39/4(Port39)"],
+                "1x100G[40G](4)": ["Eth39(Port39)"],
+                "2x50G(4)": ["Eth39/1(Port39)", "Eth39/2(Port39)"],
+                "4x25G[10G](4)": ["Eth39/1(Port39)", "Eth39/2(Port39)", "Eth39/3(Port39)", "Eth39/4(Port39)"]
+            }
+        },
+
+        "Ethernet312": {
+            "index": "40,40,40,40,40,40,40,40",
+            "lanes": "82,83,84,85,86,87,88,89",
+            "breakout_modes": {
+                "1x400G": ["Eth40(Port40)"],
+                "2x200G": ["Eth40/1(Port40)", "Eth40/2(Port40)"],
+                "4x100G": ["Eth40/1(Port40)", "Eth40/2(Port40)", "Eth40/3(Port40)", "Eth40/4(Port40)"],
+                "1x100G[40G](4)": ["Eth40(Port40)"],
+                "2x50G(4)": ["Eth40/1(Port40)", "Eth40/2(Port40)"],
+                "4x25G[10G](4)": ["Eth40/1(Port40)", "Eth40/2(Port40)", "Eth40/3(Port40)", "Eth40/4(Port40)"]
+            }
+        },
+
+        "Ethernet320": {
+            "index": "41,41,41,41,41,41,41,41",
+            "lanes": "42,43,44,45,46,47,48,49",
+            "breakout_modes": {
+                "1x400G": ["Eth41(Port41)"],
+                "2x200G": ["Eth41/1(Port41)", "Eth41/2(Port41)"],
+                "4x100G": ["Eth41/1(Port41)", "Eth41/2(Port41)", "Eth41/3(Port41)", "Eth41/4(Port41)"],
+                "1x100G[40G](4)": ["Eth41(Port41)"],
+                "2x50G(4)": ["Eth41/1(Port41)", "Eth41/2(Port41)"],
+                "4x25G[10G](4)": ["Eth41/1(Port41)", "Eth41/2(Port41)", "Eth41/3(Port41)", "Eth41/4(Port41)"]
+            }
+        },
+
+        "Ethernet328": {
+            "index": "42,42,42,42,42,42,42,42",
+            "lanes": "74,75,76,77,78,79,80,81",
+            "breakout_modes": {
+                "1x400G": ["Eth42(Port42)"],
+                "2x200G": ["Eth42/1(Port42)", "Eth42/2(Port42)"],
+                "4x100G": ["Eth42/1(Port42)", "Eth42/2(Port42)", "Eth42/3(Port42)", "Eth42/4(Port42)"],
+                "1x100G[40G](4)": ["Eth42(Port42)"],
+                "2x50G(4)": ["Eth42/1(Port42)", "Eth42/2(Port42)"],
+                "4x25G[10G](4)": ["Eth42/1(Port42)", "Eth42/2(Port42)", "Eth42/3(Port42)", "Eth42/4(Port42)"]
+            }
+        },
+
+        "Ethernet336": {
+            "index": "43,43,43,43,43,43,43,43",
+            "lanes": "34,35,36,37,38,39,40,41",
+            "breakout_modes": {
+                "1x400G": ["Eth43(Port43)"],
+                "2x200G": ["Eth43/1(Port43)", "Eth43/2(Port43)"],
+                "4x100G": ["Eth43/1(Port43)", "Eth43/2(Port43)", "Eth43/3(Port43)", "Eth43/4(Port43)"],
+                "1x100G[40G](4)": ["Eth43(Port43)"],
+                "2x50G(4)": ["Eth43/1(Port43)", "Eth43/2(Port43)"],
+                "4x25G[10G](4)": ["Eth43/1(Port43)", "Eth43/2(Port43)", "Eth43/3(Port43)", "Eth43/4(Port43)"]
+            }
+        },
+
+        "Ethernet344": {
+            "index": "44,44,44,44,44,44,44,44",
+            "lanes": "90,91,92,93,94,95,96,97",
+            "breakout_modes": {
+                "1x400G": ["Eth44(Port44)"],
+                "2x200G": ["Eth44/1(Port44)", "Eth44/2(Port44)"],
+                "4x100G": ["Eth44/1(Port44)", "Eth44/2(Port44)", "Eth44/3(Port44)", "Eth44/4(Port44)"],
+                "1x100G[40G](4)": ["Eth44(Port44)"],
+                "2x50G(4)": ["Eth44/1(Port44)", "Eth44/2(Port44)"],
+                "4x25G[10G](4)": ["Eth44/1(Port44)", "Eth44/2(Port44)", "Eth44/3(Port44)", "Eth44/4(Port44)"]
+            }
+        },
+
+        "Ethernet352": {
+            "index": "45,45,45,45,45,45,45,45",
+            "lanes": "26,27,28,29,30,31,32,33",
+            "breakout_modes": {
+                "1x400G": ["Eth45(Port45)"],
+                "2x200G": ["Eth45/1(Port45)", "Eth45/2(Port45)"],
+                "4x100G": ["Eth45/1(Port45)", "Eth45/2(Port45)", "Eth45/3(Port45)", "Eth45/4(Port45)"],
+                "1x100G[40G](4)": ["Eth45(Port45)"],
+                "2x50G(4)": ["Eth45/1(Port45)", "Eth45/2(Port45)"],
+                "4x25G[10G](4)": ["Eth45/1(Port45)", "Eth45/2(Port45)", "Eth45/3(Port45)", "Eth45/4(Port45)"]
+            }
+        },
+
+        "Ethernet360": {
+            "index": "46,46,46,46,46,46,46,46",
+            "lanes": "18,19,20,21,22,23,24,25",
+            "breakout_modes": {
+                "1x400G": ["Eth46(Port46)"],
+                "2x200G": ["Eth46/1(Port46)", "Eth46/2(Port46)"],
+                "4x100G": ["Eth46/1(Port46)", "Eth46/2(Port46)", "Eth46/3(Port46)", "Eth46/4(Port46)"],
+                "1x100G[40G](4)": ["Eth46(Port46)"],
+                "2x50G(4)": ["Eth46/1(Port46)", "Eth46/2(Port46)"],
+                "4x25G[10G](4)": ["Eth46/1(Port46)", "Eth46/2(Port46)", "Eth46/3(Port46)", "Eth46/4(Port46)"]
+            }
+        },
+
+        "Ethernet368": {
+            "index": "47,47,47,47,47,47,47,47",
+            "lanes": "2,3,4,5,6,7,8,9",
+            "breakout_modes": {
+                "1x400G": ["Eth47(Port47)"],
+                "2x200G": ["Eth47/1(Port47)", "Eth47/2(Port47)"],
+                "4x100G": ["Eth47/1(Port47)", "Eth47/2(Port47)", "Eth47/3(Port47)", "Eth47/4(Port47)"],
+                "1x100G[40G](4)": ["Eth47(Port47)"],
+                "2x50G(4)": ["Eth47/1(Port47)", "Eth47/2(Port47)"],
+                "4x25G[10G](4)": ["Eth47/1(Port47)", "Eth47/2(Port47)", "Eth47/3(Port47)", "Eth47/4(Port47)"]
+            }
+        },
+
+        "Ethernet376": {
+            "index": "48,48,48,48,48,48,48,48",
+            "lanes": "10,11,12,13,14,15,16,17",
+            "breakout_modes": {
+                "1x400G": ["Eth48(Port48)"],
+                "2x200G": ["Eth48/1(Port48)", "Eth48/2(Port48)"],
+                "4x100G": ["Eth48/1(Port48)", "Eth48/2(Port48)", "Eth48/3(Port48)", "Eth48/4(Port48)"],
+                "1x100G[40G](4)": ["Eth48(Port48)"],
+                "2x50G(4)": ["Eth48/1(Port48)", "Eth48/2(Port48)"],
+                "4x25G[10G](4)": ["Eth48/1(Port48)", "Eth48/2(Port48)", "Eth48/3(Port48)", "Eth48/4(Port48)"]
+            }
+        },
+
+        "Ethernet384": {
+            "index": "49,49,49,49,49,49,49,49",
+            "lanes": "498,499,500,501,502,503,504,505",
+            "breakout_modes": {
+                "1x400G": ["Eth49(Port49)"],
+                "2x200G": ["Eth49/1(Port49)", "Eth49/2(Port49)"],
+                "4x100G": ["Eth49/1(Port49)", "Eth49/2(Port49)", "Eth49/3(Port49)", "Eth49/4(Port49)"],
+                "1x100G[40G](4)": ["Eth49(Port49)"],
+                "2x50G(4)": ["Eth49/1(Port49)", "Eth49/2(Port49)"],
+                "4x25G[10G](4)": ["Eth49/1(Port49)", "Eth49/2(Port49)", "Eth49/3(Port49)", "Eth49/4(Port49)"]
+            }
+        },
+
+        "Ethernet392": {
+            "index": "50,50,50,50,50,50,50,50",
+            "lanes": "506,507,508,509,510,511,512,513",
+            "breakout_modes": {
+                "1x400G": ["Eth50(Port50)"],
+                "2x200G": ["Eth50/1(Port50)", "Eth50/2(Port50)"],
+                "4x100G": ["Eth50/1(Port50)", "Eth50/2(Port50)", "Eth50/3(Port50)", "Eth50/4(Port50)"],
+                "1x100G[40G](4)": ["Eth50(Port50)"],
+                "2x50G(4)": ["Eth50/1(Port50)", "Eth50/2(Port50)"],
+                "4x25G[10G](4)": ["Eth50/1(Port50)", "Eth50/2(Port50)", "Eth50/3(Port50)", "Eth50/4(Port50)"]
+            }
+        },
+
+        "Ethernet400": {
+            "index": "51,51,51,51,51,51,51,51",
+            "lanes": "490,491,492,493,494,495,496,497",
+            "breakout_modes": {
+                "1x400G": ["Eth51(Port51)"],
+                "2x200G": ["Eth51/1(Port51)", "Eth51/2(Port51)"],
+                "4x100G": ["Eth51/1(Port51)", "Eth51/2(Port51)", "Eth51/3(Port51)", "Eth51/4(Port51)"],
+                "1x100G[40G](4)": ["Eth51(Port51)"],
+                "2x50G(4)": ["Eth51/1(Port51)", "Eth51/2(Port51)"],
+                "4x25G[10G](4)": ["Eth51/1(Port51)", "Eth51/2(Port51)", "Eth51/3(Port51)", "Eth51/4(Port51)"]
+            }
+        },
+
+        "Ethernet408": {
+            "index": "52,52,52,52,52,52,52,52",
+            "lanes": "482,483,484,485,486,487,488,489",
+            "breakout_modes": {
+                "1x400G": ["Eth52(Port52)"],
+                "2x200G": ["Eth52/1(Port52)", "Eth52/2(Port52)"],
+                "4x100G": ["Eth52/1(Port52)", "Eth52/2(Port52)", "Eth52/3(Port52)", "Eth52/4(Port52)"],
+                "1x100G[40G](4)": ["Eth52(Port52)"],
+                "2x50G(4)": ["Eth52/1(Port52)", "Eth52/2(Port52)"],
+                "4x25G[10G](4)": ["Eth52/1(Port52)", "Eth52/2(Port52)", "Eth52/3(Port52)", "Eth52/4(Port52)"]
+            }
+        },
+
+        "Ethernet416": {
+            "index": "53,53,53,53,53,53,53,53",
+            "lanes": "474,475,476,477,478,479,480,481",
+            "breakout_modes": {
+                "1x400G": ["Eth53(Port53)"],
+                "2x200G": ["Eth53/1(Port53)", "Eth53/2(Port53)"],
+                "4x100G": ["Eth53/1(Port53)", "Eth53/2(Port53)", "Eth53/3(Port53)", "Eth53/4(Port53)"],
+                "1x100G[40G](4)": ["Eth53(Port53)"],
+                "2x50G(4)": ["Eth53/1(Port53)", "Eth53/2(Port53)"],
+                "4x25G[10G](4)": ["Eth53/1(Port53)", "Eth53/2(Port53)", "Eth53/3(Port53)", "Eth53/4(Port53)"]
+            }
+        },
+
+        "Ethernet424": {
+            "index": "54,54,54,54,54,54,54,54",
+            "lanes": "418,419,420,421,422,423,424,425",
+            "breakout_modes": {
+                "1x400G": ["Eth54(Port54)"],
+                "2x200G": ["Eth54/1(Port54)", "Eth54/2(Port54)"],
+                "4x100G": ["Eth54/1(Port54)", "Eth54/2(Port54)", "Eth54/3(Port54)", "Eth54/4(Port54)"],
+                "1x100G[40G](4)": ["Eth54(Port54)"],
+                "2x50G(4)": ["Eth54/1(Port54)", "Eth54/2(Port54)"],
+                "4x25G[10G](4)": ["Eth54/1(Port54)", "Eth54/2(Port54)", "Eth54/3(Port54)", "Eth54/4(Port54)"]
+            }
+        },
+
+        "Ethernet432": {
+            "index": "55,55,55,55,55,55,55,55",
+            "lanes": "466,467,468,469,470,471,472,473",
+            "breakout_modes": {
+                "1x400G": ["Eth55(Port55)"],
+                "2x200G": ["Eth55/1(Port55)", "Eth55/2(Port55)"],
+                "4x100G": ["Eth55/1(Port55)", "Eth55/2(Port55)", "Eth55/3(Port55)", "Eth55/4(Port55)"],
+                "1x100G[40G](4)": ["Eth55(Port55)"],
+                "2x50G(4)": ["Eth55/1(Port55)", "Eth55/2(Port55)"],
+                "4x25G[10G](4)": ["Eth55/1(Port55)", "Eth55/2(Port55)", "Eth55/3(Port55)", "Eth55/4(Port55)"]
+            }
+        },
+
+        "Ethernet440": {
+            "index": "56,56,56,56,56,56,56,56",
+            "lanes": "434,435,436,437,438,439,440,441",
+            "breakout_modes": {
+                "1x400G": ["Eth56(Port56)"],
+                "2x200G": ["Eth56/1(Port56)", "Eth56/2(Port56)"],
+                "4x100G": ["Eth56/1(Port56)", "Eth56/2(Port56)", "Eth56/3(Port56)", "Eth56/4(Port56)"],
+                "1x100G[40G](4)": ["Eth56(Port56)"],
+                "2x50G(4)": ["Eth56/1(Port56)", "Eth56/2(Port56)"],
+                "4x25G[10G](4)": ["Eth56/1(Port56)", "Eth56/2(Port56)", "Eth56/3(Port56)", "Eth56/4(Port56)"]
+            }
+        },
+
+        "Ethernet448": {
+            "index": "57,57,57,57,57,57,57,57",
+            "lanes": "458,459,460,461,462,463,464,465",
+            "breakout_modes": {
+                "1x400G": ["Eth57(Port57)"],
+                "2x200G": ["Eth57/1(Port57)", "Eth57/2(Port57)"],
+                "4x100G": ["Eth57/1(Port57)", "Eth57/2(Port57)", "Eth57/3(Port57)", "Eth57/4(Port57)"],
+                "1x100G[40G](4)": ["Eth57(Port57)"],
+                "2x50G(4)": ["Eth57/1(Port57)", "Eth57/2(Port57)"],
+                "4x25G[10G](4)": ["Eth57/1(Port57)", "Eth57/2(Port57)", "Eth57/3(Port57)", "Eth57/4(Port57)"]
+            }
+        },
+
+        "Ethernet456": {
+            "index": "58,58,58,58,58,58,58,58",
+            "lanes": "426,427,428,429,430,431,432,433",
+            "breakout_modes": {
+                "1x400G": ["Eth58(Port58)"],
+                "2x200G": ["Eth58/1(Port58)", "Eth58/2(Port58)"],
+                "4x100G": ["Eth58/1(Port58)", "Eth58/2(Port58)", "Eth58/3(Port58)", "Eth58/4(Port58)"],
+                "1x100G[40G](4)": ["Eth58(Port58)"],
+                "2x50G(4)": ["Eth58/1(Port58)", "Eth58/2(Port58)"],
+                "4x25G[10G](4)": ["Eth58/1(Port58)", "Eth58/2(Port58)", "Eth58/3(Port58)", "Eth58/4(Port58)"]
+            }
+        },
+
+        "Ethernet464": {
+            "index": "59,59,59,59,59,59,59,59",
+            "lanes": "450,451,452,453,454,455,456,457",
+            "breakout_modes": {
+                "1x400G": ["Eth59(Port59)"],
+                "2x200G": ["Eth59/1(Port59)", "Eth59/2(Port59)"],
+                "4x100G": ["Eth59/1(Port59)", "Eth59/2(Port59)", "Eth59/3(Port59)", "Eth59/4(Port59)"],
+                "1x100G[40G](4)": ["Eth59(Port59)"],
+                "2x50G(4)": ["Eth59/1(Port59)", "Eth59/2(Port59)"],
+                "4x25G[10G](4)": ["Eth59/1(Port59)", "Eth59/2(Port59)", "Eth59/3(Port59)", "Eth59/4(Port59)"]
+            }
+        },
+
+        "Ethernet472": {
+            "index": "60,60,60,60,60,60,60,60",
+            "lanes": "442,443,444,445,446,447,448,449",
+            "breakout_modes": {
+                "1x400G": ["Eth60(Port60)"],
+                "2x200G": ["Eth60/1(Port60)", "Eth60/2(Port60)"],
+                "4x100G": ["Eth60/1(Port60)", "Eth60/2(Port60)", "Eth60/3(Port60)", "Eth60/4(Port60)"],
+                "1x100G[40G](4)": ["Eth60(Port60)"],
+                "2x50G(4)": ["Eth60/1(Port60)", "Eth60/2(Port60)"],
+                "4x25G[10G](4)": ["Eth60/1(Port60)", "Eth60/2(Port60)", "Eth60/3(Port60)", "Eth60/4(Port60)"]
+            }
+        },
+
+        "Ethernet480": {
+            "index": "61,61,61,61,61,61,61,61",
+            "lanes": "386,387,388,389,390,391,392,393",
+            "breakout_modes": {
+                "1x400G": ["Eth61(Port61)"],
+                "2x200G": ["Eth61/1(Port61)", "Eth61/2(Port61)"],
+                "4x100G": ["Eth61/1(Port61)", "Eth61/2(Port61)", "Eth61/3(Port61)", "Eth61/4(Port61)"],
+                "1x100G[40G](4)": ["Eth61(Port61)"],
+                "2x50G(4)": ["Eth61/1(Port61)", "Eth61/2(Port61)"],
+                "4x25G[10G](4)": ["Eth61/1(Port61)", "Eth61/2(Port61)", "Eth61/3(Port61)", "Eth61/4(Port61)"]
+            }
+        },
+
+        "Ethernet488": {
+            "index": "62,62,62,62,62,62,62,62",
+            "lanes": "402,403,404,405,406,407,408,409",
+            "breakout_modes": {
+                "1x400G": ["Eth62(Port62)"],
+                "2x200G": ["Eth62/1(Port62)", "Eth62/2(Port62)"],
+                "4x100G": ["Eth62/1(Port62)", "Eth62/2(Port62)", "Eth62/3(Port62)", "Eth62/4(Port62)"],
+                "1x100G[40G](4)": ["Eth62(Port62)"],
+                "2x50G(4)": ["Eth62/1(Port62)", "Eth62/2(Port62)"],
+                "4x25G[10G](4)": ["Eth62/1(Port62)", "Eth62/2(Port62)", "Eth62/3(Port62)", "Eth62/4(Port62)"]
+            }
+        },
+
+        "Ethernet496": {
+            "index": "63,63,63,63,63,63,63,63",
+            "lanes": "394,395,396,397,398,399,400,401",
+            "breakout_modes": {
+                "1x400G": ["Eth63(Port63)"],
+                "2x200G": ["Eth63/1(Port63)", "Eth63/2(Port63)"],
+                "4x100G": ["Eth63/1(Port63)", "Eth63/2(Port63)", "Eth63/3(Port63)", "Eth63/4(Port63)"],
+                "1x100G[40G](4)": ["Eth63(Port63)"],
+                "2x50G(4)": ["Eth63/1(Port63)", "Eth63/2(Port63)"],
+                "4x25G[10G](4)": ["Eth63/1(Port63)", "Eth63/2(Port63)", "Eth63/3(Port63)", "Eth63/4(Port63)"]
+            }
+        },
+
+        "Ethernet504": {
+            "index": "64,64,64,64,64,64,64,64",
+            "lanes": "410,411,412,413,414,415,416,417",
+            "breakout_modes": {
+                "1x400G": ["Eth64(Port64)"],
+                "2x200G": ["Eth64/1(Port64)", "Eth64/2(Port64)"],
+                "4x100G": ["Eth64/1(Port64)", "Eth64/2(Port64)", "Eth64/3(Port64)", "Eth64/4(Port64)"],
+                "1x100G[40G](4)": ["Eth64(Port64)"],
+                "2x50G(4)": ["Eth64/1(Port64)", "Eth64/2(Port64)"],
+                "4x25G[10G](4)": ["Eth64/1(Port64)", "Eth64/2(Port64)", "Eth64/3(Port64)", "Eth64/4(Port64)"]
+            }
+        },
+
+        "Ethernet512": {
             "index": "65",
-            "lanes": "257",
+            "lanes": "514",
             "breakout_modes": {
                 "1x10G[1G]": ["Eth65(Port65)"]
             }
         },
 
-        "Ethernet257": {
+        "Ethernet513": {
             "index": "66",
-            "lanes": "258",
+            "lanes": "516",
             "breakout_modes": {
                 "1x10G[1G]": ["Eth66(Port66)"]
             }
         }
     }
 }
-


### PR DESCRIPTION
#### Why I did it
Fixed the pytest item failed, and found sai config need to modify(because using ec-sai)

#### How I did it
Fixed pytest: modify platform.json.
sai-config: fixed platform.json about sfp interface and port config.
and modify th4-as9736-64x400G.config.yml for bcm config setting.

#### How to verify it
Using correct sai-config, that show or sfpshow command can get information.

```
ex:
root@as9736-64d-1:~# sfpshow presence
Port         Presence
-----------  -----------
Ethernet0    Present
Ethernet8    Present
Ethernet16   Present
Ethernet24   Present
Ethernet32   Present
Ethernet40   Present
Ethernet48   Present
Ethernet56   Present
Ethernet64   Present
Ethernet72   Present
Ethernet80   Present
Ethernet88   Present
Ethernet96   Present
Ethernet104  Present
Ethernet112  Present
Ethernet120  Present
Ethernet128  Present
Ethernet136  Present
Ethernet144  Present
Ethernet152  Present
Ethernet160  Present
Ethernet168  Present
Ethernet176  Present
Ethernet184  Present
Ethernet192  Present
Ethernet200  Present
Ethernet208  Present
Ethernet216  Present
Ethernet224  Present
Ethernet232  Present
Ethernet240  Present
Ethernet248  Present
Ethernet256  Not present
Ethernet264  Not present
Ethernet272  Not present
Ethernet280  Not present
Ethernet288  Not present
Ethernet296  Not present
Ethernet304  Not present
Ethernet312  Not present
Ethernet320  Not present
Ethernet328  Not present
Ethernet336  Not present
Ethernet344  Not present
Ethernet352  Not present
Ethernet360  Not present
Ethernet368  Not present
Ethernet376  Not present
Ethernet384  Not present
Ethernet392  Not present
Ethernet400  Not present
Ethernet408  Not present
Ethernet416  Not present
Ethernet424  Not present
Ethernet432  Not present
Ethernet440  Not present
Ethernet448  Not present
Ethernet456  Not present
Ethernet464  Not present
Ethernet472  Not present
Ethernet480  Not present
Ethernet488  Not present
Ethernet496  Not present
Ethernet504  Not present
Ethernet512  Not present
Ethernet513  Not present
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

