### PR TITLE
[Edgecore][device][platform] Fan-control before do shutdown, need to …

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as9736-64d/utils/accton_as9736_64d_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9736-64d/utils/accton_as9736_64d_monitor.py
@@ -18,6 +18,7 @@
 #    mm/dd/yyyy (A.D.)#
 #    07/12/2022: Michael_Shih create for as9736_64d thermal plan
 #    12/12/2023: Add detect temp of xcvr, and implement shutdown function.
+#    23/01/2024: Sync the log buffer to the disk before powering off the DUT.
 # ------------------------------------------------------------------
 
 try:
@@ -198,6 +199,15 @@ def stop_syncd_service():
     if status:
         logging.warning("Mask syncd.service failed")
         return False
+
+    return (status == 0)
+
+def sync_log_buffer_to_disk():
+    cmd_str=["sync"]
+    (status, output) = getstatusoutput_noshell(cmd_str)
+    cmd_str=["/sbin/fstrim", "-av"]
+    (status, output) = getstatusoutput_noshell(cmd_str)
+    time.sleep(3)
 
     return (status == 0)
 
@@ -516,6 +526,7 @@ class device_monitor(object):
                     send_cpu_shutdown_warning = 1
                     stop_syncd_service()
                     logging.critical("CPU sensor for temperature high is detected, shutdown DUT.")
+                    sync_log_buffer_to_disk()
                     shutdown_except_cpu()
                     return True
 


### PR DESCRIPTION
#### Why I did it
After doing cpu shutown and power-cycle, we'll find syslog loss shutdown message.
So need to do sync buffer to disk command first.

#### How I did it
Before DUT shutdown, need to do sync command to save log buffer to disk.

#### How to verify it
Let DUT shutdown, and power-cycle, and the CPU shutdown message is still on syslog, 
it can prove the modify is succeeded.

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog


#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes


#### A picture of a cute animal (not mandatory but encouraged)

