### PR TITLE
JIRA-JRTC-19277: [sonic-mgmt][Pytest][sfp] Failed in 202311.0 regress…

### DIFF
--- a/device/accton/x86_64-accton_as4630_54pe-r0/Accton-AS4630-54PE/hwsku.json
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/Accton-AS4630-54PE/hwsku.json
@@ -2,242 +2,290 @@
     "interfaces": {
         "Ethernet0": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet1": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet2": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet3": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet4": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet5": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet6": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet7": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet8": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet9": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet10": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet11": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet12": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet13": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet14": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet15": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet16": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet17": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet18": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet19": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet20": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet21": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet22": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet23": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet24": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet25": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet26": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet27": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet28": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet29": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet30": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet31": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet32": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet33": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet34": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet35": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet36": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet37": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet38": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet39": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet40": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet41": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet42": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet43": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet44": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet45": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet46": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet47": {
             "default_brkout_mode": "1x1G",
-            "autoneg": "on"
+            "autoneg": "on",
+            "port_type": "RJ45"
         },
 
         "Ethernet48": {


### PR DESCRIPTION
…ion test

cherry-pick commit:
35809570dd469d0bf7e574f1b8854dac465304f4: Support port type rj45 on AS4630-54PE

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix RJ45 port parsing incorrect issue
#### How I did it
Support port type rj45 on AS4630-54PE (Sync from 202211 branch)
#### How to verify it
Run and pass pytest test_sfp item
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

