### PR TITLE
[Platform][AS9716-32D]: Fix syncd init failed during system boot-up phase

### DIFF
--- a/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D-100G/th3-as9716-32x100G.config.bcm
+++ b/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D-100G/th3-as9716-32x100G.config.bcm
@@ -40,6 +40,11 @@ sram_scan_enable.0=0
 tdma_timeout_usec.0=15000000
 tslam_timeout_usec.0=15000000
 
+# Broadcom community sai
+bcm_tunnel_term_compatible_mode.0=1
+sai_tunnel_support=2
+sai_tunnel_global_sip_mask_enable=1
+
 #firmware load method, use fast load
 load_firmware=0x2
 

--- a/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D/th3-as9716-32x400G.config.bcm
+++ b/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D/th3-as9716-32x400G.config.bcm
@@ -33,6 +33,11 @@ sram_scan_enable.0=0
 tdma_timeout_usec.0=15000000
 tslam_timeout_usec.0=15000000
 
+# Broadcom community sai
+bcm_tunnel_term_compatible_mode.0=1
+sai_tunnel_support=2
+sai_tunnel_global_sip_mask_enable=1
+
 #BC0#
 dport_map_port_1=81
 dport_map_port_2=82


### PR DESCRIPTION
Why I did it:

- syncd init failed during system boot-up phase.
  And syslog includes the below error logs:
  - `ERR syncd#syncd: :- sendApiResponse: api SAI_COMMON_API_CREATE failed in syncd mode: SAI_STATUS_NOT_SUPPORTED`
  - `ERR syncd#syncd: :- processQuadEvent: attr: SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_VR_ID: oid:0x3000000000022`
  - `ERR syncd#syncd: :- processQuadEvent: attr: SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE: SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2MP`
  - `ERR syncd#syncd: :- processQuadEvent: attr: SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TUNNEL_TYPE: SAI_TUNNEL_TYPE_IPINIP`
  - `ERR syncd#syncd: :- processQuadEvent: attr: SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_ACTION_TUNNEL_ID: oid:0x2a000000000525`
  - `ERR syncd#syncd: :- processQuadEvent: attr: SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_DST_IP: 10.0.0.0`

How I dit it:
- For Broadcom community SAI, fine-tune Broadcom configuration files for Accton-AS9716-32D and Accton-AS9716-32D-100G.

How to verify it:

- Boot-up system and check syncd is working normally and no see error logs.


