### PR TITLE
[Platform][AS9716-32D]: Fix some pytest cases of test_thermal failed.

### DIFF
--- a/device/accton/x86_64-accton_as9716_32d-r0/platform.json
+++ b/device/accton/x86_64-accton_as9716_32d-r0/platform.json
@@ -425,7 +425,39 @@
                 "high-crit-threshold": false
             },
             {
-                "name": "coretemp-isa-0000",
+                "name": "CPU_Package_temp",
+                "controllable": false,
+                "low-threshold": false,
+                "high-threshold": true,
+                "low-crit-threshold": false,
+                "high-crit-threshold": true
+            },
+            {
+                "name": "CPU_Core_0_temp",
+                "controllable": false,
+                "low-threshold": false,
+                "high-threshold": true,
+                "low-crit-threshold": false,
+                "high-crit-threshold": true
+            },
+            {
+                "name": "CPU_Core_1_temp",
+                "controllable": false,
+                "low-threshold": false,
+                "high-threshold": true,
+                "low-crit-threshold": false,
+                "high-crit-threshold": true
+            },
+            {
+                "name": "CPU_Core_2_temp",
+                "controllable": false,
+                "low-threshold": false,
+                "high-threshold": true,
+                "low-crit-threshold": false,
+                "high-crit-threshold": true
+            },
+            {
+                "name": "CPU_Core_3_temp",
                 "controllable": false,
                 "low-threshold": false,
                 "high-threshold": true,


### PR DESCRIPTION
Why I did it:
    The below pytest cases of test_thermal.py are failed.
    - platform_tests/api/test_thermal.py::TestThermalApi::test_get_name
    - platform_tests/api/test_thermal.py::TestThermalApi::test_get_minimum_recorded
    - platform_tests/api/test_thermal.py::TestThermalApi::test_get_maximum_recorded
    - platform_tests/api/test_thermal.py::TestThermalApi::test_get_low_threshold
    - platform_tests/api/test_thermal.py::TestThermalApi::test_get_high_threshold
    - platform_tests/api/test_thermal.py::TestThermalApi::test_get_low_critical_threshold
    - platform_tests/api/test_thermal.py::TestThermalApi::test_get_high_critical_threshold
    - platform_tests/api/test_thermal.py::TestThermalApi::test_set_low_threshold
    - platform_tests/api/test_thermal.py::TestThermalApi::test_set_high_threshold

    The root case is the defined thermal names in platform.json are inconsistent with pddf-device.json.
    It leads pytest cannot find the below expected thermal names.
    - CPU_Package_temp
    - CPU_Core_0_temp
    - CPU_Core_1_temp
    - CPU_Core_2_temp
    - CPU_Core_3_temp

How I dit it:
    Add correct thermal names into platform.json according to pddf-device.json (TEMP8 ~ TEMP12)

How to verify it:
    Re-run the pytest and the result is pass.


