### PR TITLE
[AS9817-64D] Fix incorrect LED status of 'System status LED'

### DIFF
--- a/device/accton/x86_64-accton_as9817_64d-r0/system_health_monitoring_config.json
+++ b/device/accton/x86_64-accton_as9817_64d-r0/system_health_monitoring_config.json
@@ -7,7 +7,7 @@
     "polling_interval": 60,
     "led_color": {
         "fault": "STATUS_LED_COLOR_RED",
-        "normal": "STATUS_LED_COLOR_GREEN",
-        "booting": "STATUS_LED_COLOR_GREEN"
+        "normal": "STATUS_LED_COLOR_OFF",
+        "booting": "STATUS_LED_COLOR_OFF"
     }
 }


### PR DESCRIPTION
#### Why I did it
Due to the system's bootup time exceeding the configuration, healthd will turn the LED to STATUS_LED_COLOR_RED. When the system is OK, healthd will turn the LED to normal. However, the normal state is defined as STATUS_LED_COLOR_GREEN in the system_health_monitoring_config.json, but the platform API (chassis.py) only supports STATUS_LED_COLOR_OFF and STATUS_LED_COLOR_RED.

#### How I did it
Change STATUS_LED_COLOR_GREEN to STATUS_LED_COLOR_OFF in the system_health_monitoring_config.json file.

#### How to verify it
Execute 'show system-health summary' command to monitor 'System status LED'

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

