### PR TITLE
JIRA-JRTC-19702: [AS7726-32X]Sync platform.json

### DIFF
--- a/device/accton/x86_64-accton_as7726_32x-r0/platform.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/platform.json
@@ -1,10 +1,10 @@
 {
     "chassis": {
         "name": "7726-32X",
-        "thermal_manager":false,
+        "thermal_manager": false,
         "status_led": {
             "controllable": true,
-            "colors": ["green", "red", "off"]
+            "colors": ["STATUS_LED_COLOR_GREEN", "STATUS_LED_COLOR_RED", "STATUS_LED_COLOR_OFF"]
         },
         "components": [
             {
@@ -155,6 +155,9 @@
                     "controllable": false
                 },
                 "num_fans" : 2,
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
                         "name": "FAN-1F",
@@ -184,6 +187,9 @@
                     "controllable": false
                 },
                 "num_fans" : 2,
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
                         "name": "FAN-2F",
@@ -213,6 +219,9 @@
                     "controllable": false
                 },
                 "num_fans" : 2,
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
                         "name": "FAN-3F",
@@ -242,6 +251,9 @@
                     "controllable": false
                 },
                 "num_fans" : 2,
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
                         "name": "FAN-4F",
@@ -271,6 +283,9 @@
                     "controllable": false
                 },
                 "num_fans" : 2,
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
                         "name": "FAN-5F",
@@ -300,6 +315,9 @@
                     "controllable": false
                 },
                 "num_fans" : 2,
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
                         "name": "FAN-6F",


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Sync platform.json to fix platform api test error on as7726-32x platform.
#### How I did it
Sync the following commits:
 0d68ccf91
 e8ab4b358
 39c194b6f
 d0cd2d21d
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Sync the following commits:
 0d68ccf91
 e8ab4b358
 39c194b6f
 d0cd2d21d

1. Skip status led test due to lack of support by setting "controllable" as false.

Cross Reference:
https://gerrit.edge-core.com/#/c/sonic-buildimage/+/33500/ https://github.com/edge-core/sonic-buildimage/blob/202211.0/device/accton/x86_64-accton_as7726_32x-r0/platform.json

2. Skip chassis status led test

Current implementation:

SYSLED_MODES = {
    "0" : "STATUS_LED_COLOR_OFF",
    "1" : "STATUS_LED_COLOR_GREEN",
    "3" : "STATUS_LED_COLOR_RED"
}

Test Case Default LED Color for testing:
FAULT_LED_COLOR_LIST = [
    "amber",
    "red"
]

NORMAL_LED_COLOR_LIST = [
    "green"
]

OFF_LED_COLOR_LIST = [
    "off"
]

The test case does not match the implementation. Update platform.json by setting the appropriate value to skip the test.
#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

