### PR TITLE
fix non canonical format of IPv6 address string in bgpcfgd

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
@@ -336,6 +336,15 @@ class BGPPeerMgrBase(Manager):
                  If the interface has not been set, return None
         """
         local_addresses = self.directory.get_slot("LOCAL", "local_addresses")
+
+        # Handle local_addr string that is not represented in canonical text format, especially for IPv6 addresses
+        try:
+            ip = netaddr.IPAddress(str(local_addr))
+        except (netaddr.NotRegisteredError, netaddr.AddrFormatError, netaddr.AddrConversionError):
+            log_warn("IP Address '%s' format is wrong" % (local_addr))
+            return None
+        local_addr = str(ip)
+
         # Check if the local address of this bgp session has been set
         if local_addr not in local_addresses:
             return None


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
IPv6 addresses text used in cfgdb may not follow the canonical IPv6 text format. When performing IPv6 addresses equivalent check with string, need to make sure that both of them are in the shortest form defined in rfc 5952
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

