### PR TITLE
[logrotate] Check orchagent status before sending SIGHUP

### DIFF
--- a/files/image_config/logrotate/rsyslog.j2
+++ b/files/image_config/logrotate/rsyslog.j2
@@ -106,14 +106,23 @@
             if [ -f "$ASIC_CONF" ]; then
                 . $ASIC_CONF
             fi
-            if [ $NUM_ASIC -gt 1 ]; then
+            if [ ! -z $NUM_ASIC ] && [ $NUM_ASIC -gt 1 ]; then
                 log_file=$1
                 log_file_name=${log_file#/var/log/swss/}
-                logger -p syslog.info -t "logrotate" "Sending SIGHUP to OA log_file_name: $log_file_name"
-                pgrep -xa orchagent | grep $log_file_name | awk '{ print $1; }' | xargs /bin/kill -HUP 2>/dev/null || true
+                OA_PID=$(pgrep -xa orchagent | grep $log_file_name | awk '{ print $1; }')
             else
-                logger -p syslog.info -t "logrotate" "Sending SIGHUP to OA log_file_name: $1"
-                pgrep -x orchagent | xargs /bin/kill -HUP 2>/dev/null || true
+                log_file_name=$1
+                OA_PID=$(pgrep -x orchagent)
+            fi
+            if [ ! -z $OA_PID ]; then
+                # To avoid the condition that SIGHUP is sent before the registration of SIGHUP
+                # handler, send SIGHUP handler when the process has been up for more than 10 seconds
+                etimes=$(ps -p $OA_PID -o etimes | sed -n 2p)
+                if [ ! -z $etimes ] && [ $((etimes)) -lt 10 ]; then
+                   sleep $((10 - etimes))
+                fi
+                logger -p syslog.info -t "logrotate" "Sending SIGHUP to OA log_file_name: $log_file_name"
+                /bin/kill -HUP $OA_PID 2>/dev/null || true
             fi
         else
             /bin/kill -HUP $(cat /var/run/rsyslogd.pid)


### PR DESCRIPTION
Sending SIGHUP before orchagent registers the handler for SIGHUP would kill orchagent. Before sending SIGHUP, it must wait until orchagent has been running for 10 seconds.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

