### PR TITLE
Fix the issue that device become slow after enabling TACACS authentication.

### DIFF
--- a/src/tacacs/nss/patch/0011-Lookup-etc-passwd-first-to-accelerate-the-getpwnam-p.patch
+++ b/src/tacacs/nss/patch/0011-Lookup-etc-passwd-first-to-accelerate-the-getpwnam-p.patch
@@ -1,0 +1,49 @@
+From fd237afe04f2418ddd74d6d4ac32b5cfce9a4969 Mon Sep 17 00:00:00 2001
+From: Steven Guo <steven_guo@edge-core.com>
+Date: Tue, 27 Sep 2022 15:27:42 +0800
+Subject: Lookup /etc/passwd first to accelerate the getpwnam
+ process.
+
+In getpwnam function, it tries to get user from tacacs servers if the user is tacacs user.
+The lookup process will take long time if there are some unreachable servers.
+
+To avoid spending lot of time on trying to make connection to an unreachable server, lookup
+user in /etc/passwd first to accelerate the lookup process.
+---
+ nss_tacplus.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/nss_tacplus.c b/nss_tacplus.c
+index 2de00a6..a276557 100644
+--- a/nss_tacplus.c
++++ b/nss_tacplus.c
+@@ -817,6 +817,8 @@ enum nss_status _nss_tacplus_getpwnam_r(const char *name, struct passwd *pw,
+     enum nss_status status = NSS_STATUS_NOTFOUND;
+     int result;
+     struct pwbuf pbuf;
++    bool found = false;
++    int ret = 0;
+ 
+     /*
+      * When filename completion is used with the tab key in bash, getpwnam
+@@ -847,6 +849,17 @@ enum nss_status _nss_tacplus_getpwnam_r(const char *name, struct passwd *pw,
+         pbuf.buflen = buflen;
+         pbuf.errnop = errnop;
+ 
++        /*
++         *  For the logged-in user, use the local file instead of sending TACACS
++         *  request to speed up.
++         */
++        ret = lookup_pw_local(name, &pbuf, &found);
++        if(0 == ret && found) {
++            syslog(LOG_DEBUG, "%s: get TACACS user information (%s) from local", nssname, name);
++            return NSS_STATUS_SUCCESS;
++        }
++
++        /* Send the TACACS request only for authentication process. */
+         if(0 == lookup_tacacs_user(&pbuf)) {
+             status = NSS_STATUS_SUCCESS;
+             if(debug)
+-- 
+2.25.1
+

--- a/src/tacacs/nss/patch/series
+++ b/src/tacacs/nss/patch/series
@@ -8,3 +8,4 @@
 0008-do-not-create-or-modify-local-user-if-there-is-no-pr.patch
 0009-fix-compile-error-strncpy.patch
 0010-Send-remote-address-in-TACACS-authorization-message.patch
+0011-Lookup-etc-passwd-first-to-accelerate-the-getpwnam-p.patch


### PR DESCRIPTION


What I did
Fix the issue that device become slow after enabling TACACS authentication.

Why I did it
In getpwnam function of libnss-tacacs, it tries to get user from tacacs servers if the user is tacacs user. The lookup process will take long time if there are some unreachable servers. To avoid spending lot of time on trying to make connection to an unreachable server, lookup user in /etc/passwd first to accelerate the lookup process.

How to verify it
Configure AAA and login by tacacsplus, check the response time become normal, also run few test cases to ensure the modification doesn't have side effect.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

