### PR TITLE
[AS5835-54X] support fan direction of DC PSU

### DIFF
--- a/device/accton/x86_64-accton_as5835_54x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as5835_54x-r0/pddf/pddf-device.json
@@ -165,7 +165,6 @@
             "attr_list": 
             [  
                 { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
-                { "attr_name":"psu_model_name", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
                 { "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x2", "attr_cmpval":"0x2", "attr_len":"1"},
                 { "attr_name":"psu_mfr_id", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
                 { "attr_name":"psu_fan_dir", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
@@ -189,7 +188,8 @@
             "topo_info":{ "parent_bus":"0xb", "dev_addr":"0x50", "dev_type":"psu_eeprom"},
             "attr_list": 
             [  
-                { "attr_name":"psu_serial_num", "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"19" }
+                { "attr_name":"psu_serial_num", "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"19" },
+                { "attr_name":"psu_model_name", "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x20", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"12" }
             ]
         }
     },
@@ -217,7 +217,6 @@
             "attr_list": 
             [  
                 { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x10", "attr_cmpval":"0x0", "attr_len":"1"},
-                { "attr_name":"psu_model_name", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
                 { "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x20", "attr_cmpval":"0x20", "attr_len":"1"},
                 { "attr_name":"psu_mfr_id", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
                 { "attr_name":"psu_fan_dir", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
@@ -241,7 +240,8 @@
             "topo_info":{ "parent_bus":"0xc", "dev_addr":"0x53", "dev_type":"psu_eeprom"},
             "attr_list": 
             [  
-                { "attr_name":"psu_serial_num", "attr_devaddr":"0x53", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"19" }
+                { "attr_name":"psu_serial_num", "attr_devaddr":"0x53", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"19" },
+                { "attr_name":"psu_model_name", "attr_devaddr":"0x53", "attr_devtype":"eeprom", "attr_offset":"0x20", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"12" }
             ]
         }
     },

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/modules/pddf_custom_psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/modules/pddf_custom_psu.c
@@ -9,10 +9,31 @@
 #include <linux/sysfs.h>
 #include <linux/slab.h>
 #include <linux/dmi.h>
+#include "pddf_client_defs.h"
 #include "pddf_psu_defs.h"
+#include "pddf_psu_driver.h"
+#include "pddf_psu_api.h"
 
 ssize_t pddf_show_custom_psu_v_out(struct device *dev, struct device_attribute *da, char *buf);
 extern PSU_SYSFS_ATTR_DATA access_psu_v_out;
+int pddf_post_get_custom_psu_model_name(void *i2c_client, PSU_DATA_ATTR *adata, void *data);
+extern PSU_SYSFS_ATTR_DATA access_psu_model_name;
+int pddf_post_get_custom_psu_fan_dir(void *i2c_client, PSU_DATA_ATTR *adata, void *data);
+extern PSU_SYSFS_ATTR_DATA access_psu_fan_dir;
+int pddf_custom_psu_post_probe(struct i2c_client *client, const struct i2c_device_id *dev_id);
+int pddf_custom_psu_post_remove(struct i2c_client *client);
+extern struct pddf_ops_t pddf_psu_ops;
+
+const char FAN_DIR_F2B[] = "F2B\0";
+const char FAN_DIR_B2F[] = "B2F\0";
+
+static LIST_HEAD(psu_eeprom_client_list);
+static struct mutex     list_lock;
+
+struct psu_eeprom_client_node {
+	struct i2c_client *client;
+	struct list_head   list;
+};
 
 static int two_complement_to_int(u16 data, u8 valid_bit, int mask)
 {
@@ -95,11 +116,147 @@ ssize_t pddf_show_custom_psu_v_out(struct device *dev, struct device_attribute *
 }
 
 
+int pddf_post_get_custom_psu_model_name(void *i2c_client, PSU_DATA_ATTR *adata, void *data)
+{
+    struct psu_attr_info *sysfs_attr_info = (struct psu_attr_info *)data;
+
+    if (strlen(sysfs_attr_info->val.strval) > 8) {
+        sysfs_attr_info->val.strval[8] = '-';
+    }
+
+    return 0;
+}
+
+/*
+ * Get the PSU EEPROM I2C client with the same bus number.
+ */
+static struct i2c_client *find_psu_eeprom_client(struct i2c_client *pmbus_client)
+{
+    struct list_head *list_node = NULL;
+    struct psu_eeprom_client_node *psu_eeprom_node = NULL;
+    struct i2c_client *eeprom_client = NULL;
+
+    mutex_lock(&list_lock);
+    list_for_each(list_node, &psu_eeprom_client_list) {
+        psu_eeprom_node = list_entry(list_node, struct psu_eeprom_client_node, list);
+        /* Check if the bus adapter is the same or not. */
+        if (psu_eeprom_node->client->adapter == pmbus_client->adapter) {
+            eeprom_client = psu_eeprom_node->client;
+            break;
+        }
+    }
+    mutex_unlock(&list_lock);
+
+    return eeprom_client;
+}
+
+int pddf_post_get_custom_psu_fan_dir(void *i2c_client, PSU_DATA_ATTR *adata, void *data)
+{
+    int i;
+    struct i2c_client *client = (struct i2c_client *)i2c_client;
+    struct psu_attr_info *psu_fan_dir_attr_info = (struct psu_attr_info *)data;
+    struct psu_data *psu_eeprom_client_data = NULL;
+    struct psu_attr_info *psu_eeprom_model_name = NULL;
+    struct i2c_client *psu_eeprom_client = NULL;
+
+    psu_eeprom_client = find_psu_eeprom_client(client);
+    if (!psu_eeprom_client) {
+        return 0;
+    }
+
+    /*
+     * Get the model name from the PSU EEPROM I2C client.
+     */
+    psu_eeprom_client_data = i2c_get_clientdata(psu_eeprom_client);
+    if (!psu_eeprom_client_data) {
+        return 0;
+    }
+    for (i = 0; i < psu_eeprom_client_data->num_attr; i++) {
+        if (strcmp(psu_eeprom_client_data->attr_info[i].name, "psu_model_name") == 0) {
+            psu_eeprom_model_name = &psu_eeprom_client_data->attr_info[i];
+            break;
+        }
+    }
+    if (!psu_eeprom_model_name) {
+        return 0;
+    }
+
+    /*
+     * Compare the model name, then replace the content of psu_fan_dir.
+     */
+    if (strcmp(psu_eeprom_model_name->val.strval, "YM-2401H-CR") == 0) {
+        strscpy(psu_fan_dir_attr_info->val.strval, 
+                FAN_DIR_F2B, 
+                sizeof(psu_fan_dir_attr_info->val.strval));
+    } else if (strcmp(psu_eeprom_model_name->val.strval, "YM-2401H-DR") == 0) {
+        strscpy(psu_fan_dir_attr_info->val.strval, 
+                FAN_DIR_B2F, 
+                sizeof(psu_fan_dir_attr_info->val.strval));
+    }
+
+    return 0;
+}
+
+int pddf_custom_psu_post_probe(struct i2c_client *client, const struct i2c_device_id *dev_id)
+{
+    struct psu_eeprom_client_node *psu_eeprom_node;
+
+    if (strcmp(dev_id->name, "psu_eeprom") != 0) {
+        return 0;
+    }
+
+    psu_eeprom_node = kzalloc(sizeof(struct psu_eeprom_client_node), GFP_KERNEL);
+    if (!psu_eeprom_node) {
+        dev_dbg(&client->dev, "Can't allocate psu_eeprom_client_node (0x%x)\n", client->addr);
+        return -ENOMEM;
+    }
+
+    psu_eeprom_node->client = client;
+
+    mutex_lock(&list_lock);
+    list_add(&psu_eeprom_node->list, &psu_eeprom_client_list);
+    mutex_unlock(&list_lock);
+
+    return 0;
+}
+
+int pddf_custom_psu_post_remove(struct i2c_client *client)
+{
+    struct list_head    *list_node = NULL;
+    struct psu_eeprom_client_node *psu_eeprom_node = NULL;
+    int found = 0;
+
+    mutex_lock(&list_lock);
+
+    list_for_each(list_node, &psu_eeprom_client_list) {
+        psu_eeprom_node = list_entry(list_node, struct psu_eeprom_client_node, list);
+
+        if (psu_eeprom_node->client == client) {
+            list_del_init(&psu_eeprom_node->list);
+            found = 1;
+            break;
+        }
+    }
+
+    if (found) {
+        kfree(psu_eeprom_node);
+    }
+
+    mutex_unlock(&list_lock);
+
+    return 0;
+}
+
 
 static int __init pddf_custom_psu_init(void)
 {
+    mutex_init(&list_lock);
     access_psu_v_out.show = pddf_show_custom_psu_v_out;
     access_psu_v_out.do_get = NULL;
+    access_psu_model_name.post_get = pddf_post_get_custom_psu_model_name;
+    access_psu_fan_dir.post_get = pddf_post_get_custom_psu_fan_dir;
+    pddf_psu_ops.post_probe = pddf_custom_psu_post_probe;
+    pddf_psu_ops.post_remove = pddf_custom_psu_post_remove;
     return 0;
 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
AS5835-54X has DC F2B PSU: YM-2401HCR.
When using this DC PSU, "show platform fan" shows wrong PSU FAN direction as "intake".
```
admin@sonic:~$ show plat fan
  Drawer    LED          FAN    Speed    Direction    Presence    Status          Timestamp
--------  -----  -----------  -------  -----------  ----------  --------  -----------------
FanTray1  green       FAN-1F      40%      exhaust     Present        OK  20240701 06:34:14
FanTray1  green       FAN-1R      40%      exhaust     Present        OK  20240701 06:34:14
FanTray2  green       FAN-2F      40%      exhaust     Present        OK  20240701 06:34:14
FanTray2  green       FAN-2R      40%      exhaust     Present        OK  20240701 06:34:14
FanTray3  green       FAN-3F      40%      exhaust     Present        OK  20240701 06:34:14
FanTray3  green       FAN-3R      40%      exhaust     Present        OK  20240701 06:34:14
FanTray4  green       FAN-4F      40%      exhaust     Present        OK  20240701 06:34:14
FanTray4  green       FAN-4R      40%      exhaust     Present        OK  20240701 06:34:14
FanTray5  green       FAN-5F      40%      exhaust     Present        OK  20240701 06:34:14
FanTray5  green       FAN-5R      40%      exhaust     Present        OK  20240701 06:34:14
     N/A  green  PSU-1 FAN-1      38%       intake     Present        OK  20240701 06:34:15
     N/A  green  PSU-2 FAN-1      13%      exhaust     Present        OK  20240701 06:34:21
admin@sonic:~$
admin@sonic:~$ show plat psu
PSU    Model     Serial              HW Rev      Voltage (V)    Current (A)    Power (W)  Status    LED
-----  --------  ------------------  --------  -------------  -------------  -----------  --------  -----
PSU 1  YM-2401H  SB060T702331000174  N/A               12.09           2.25        30.69  OK        green
PSU 2  YM-1401A  SA060V061911000380  N/A               11.71           3.38        46.00  OK        green 
```

#### How I did it
Replace the PSU fan direction based on the PSU EEPROM model name.

DC PSU F2B: YM-2401HCR
DC PSU B2F: YM-2401HDR

#### How to verify it
```
root@sonic:/home/admin# show version
SONiC Software Version: SONiC.202211.0.0-dirty-20240710.054506
Distribution: Debian 11.10
Kernel: 5.10.0-18-2-amd64
Build commit: 67b19b544
Build date: Wed Jul 10 05:50:36 UTC 2024
Built by: ubuntu@ip-10-5-1-241
Platform: x86_64-accton_as5835_54x-r0
HwSKU: Accton-AS5835-54X
ASIC: broadcom
ASIC Count: 1
Serial Number: 00000000000000
Model Number: 0000000000000
Hardware Revision: N/A
Uptime: 06:47:19 up 8 min,  1 user,  load average: 1.83, 1.82, 1.03
Date: Wed 10 Jul 2024 06:47:19
Docker images:
REPOSITORY                    TAG                                IMAGE ID       SIZE
docker-macsec                 latest                             07d67cc26c5c   513MB
docker-dhcp-relay             latest                             adcb7b4b2c3b   505MB
docker-gbsyncd-broncos        202211.0.0-dirty-20240710.054506   ef63feaf9ee0   542MB
docker-gbsyncd-broncos        latest                             ef63feaf9ee0   542MB
docker-gbsyncd-credo          202211.0.0-dirty-20240710.054506   e925ae0757df   515MB
docker-gbsyncd-credo          latest                             e925ae0757df   515MB
docker-syncd-brcm             202211.0.0-dirty-20240710.054506   2aa5f43a0f95   790MB
docker-syncd-brcm             latest                             2aa5f43a0f95   790MB
docker-sonic-telemetry        202211.0.0-dirty-20240710.054506   cedf27b3793b   793MB
docker-sonic-telemetry        latest                             cedf27b3793b   793MB
docker-teamd                  202211.0.0-dirty-20240710.054506   19558ef90900   511MB
docker-teamd                  latest                             19558ef90900   511MB
docker-snmp                   202211.0.0-dirty-20240710.054506   1e51271f23c9   540MB
docker-snmp                   latest                             1e51271f23c9   540MB
docker-router-advertiser      202211.0.0-dirty-20240710.054506   975ad12ac9bc   495MB
docker-router-advertiser      latest                             975ad12ac9bc   495MB
docker-platform-monitor       202211.0.0-dirty-20240710.054506   4b0f5270895f   622MB
docker-platform-monitor       latest                             4b0f5270895f   622MB
docker-sonic-p4rt             202211.0.0-dirty-20240710.054506   ff7bb7f9e08d   577MB
docker-sonic-p4rt             latest                             ff7bb7f9e08d   577MB
docker-orchagent              202211.0.0-dirty-20240710.054506   850806bac684   530MB
docker-orchagent              latest                             850806bac684   530MB
docker-mux                    202211.0.0-dirty-20240710.054506   c45a0e579d70   543MB
docker-mux                    latest                             c45a0e579d70   543MB
docker-lldp                   202211.0.0-dirty-20240710.054506   943f1342bc9f   537MB
docker-lldp                   latest                             943f1342bc9f   537MB
docker-fpm-frr                202211.0.0-dirty-20240710.054506   ccdcf4be61e9   541MB
docker-fpm-frr                latest                             ccdcf4be61e9   541MB
docker-eventd                 202211.0.0-dirty-20240710.054506   a167f5316bf7   495MB
docker-eventd                 latest                             a167f5316bf7   495MB
docker-database               202211.0.0-dirty-20240710.054506   9c6e60442cf4   495MB
docker-database               latest                             9c6e60442cf4   495MB
docker-sonic-mgmt-framework   202211.0.0-dirty-20240710.054506   77a562606f91   564MB
docker-sonic-mgmt-framework   latest                             77a562606f91   564MB
docker-sflow                  202211.0.0-dirty-20240710.054506   e7fa0fb65492   429MB
docker-sflow                  latest                             e7fa0fb65492   429MB
docker-nat                    202211.0.0-dirty-20240710.054506   3090ea3c3c4b   431MB
docker-nat                    latest                             3090ea3c3c4b   431MB
root@sonic:/home/admin# show platform fan
  Drawer    LED          FAN    Speed    Direction    Presence    Status          Timestamp
--------  -----  -----------  -------  -----------  ----------  --------  -----------------
FanTray1  green       FAN-1F      40%      exhaust     Present        OK  20240710 06:47:03
FanTray1  green       FAN-1R      40%      exhaust     Present        OK  20240710 06:47:03
FanTray2  green       FAN-2F      40%      exhaust     Present        OK  20240710 06:47:03
FanTray2  green       FAN-2R      40%      exhaust     Present        OK  20240710 06:47:03
FanTray3  green       FAN-3F      40%      exhaust     Present        OK  20240710 06:47:03
FanTray3  green       FAN-3R      40%      exhaust     Present        OK  20240710 06:47:03
FanTray4  green       FAN-4F      40%      exhaust     Present        OK  20240710 06:47:03
FanTray4  green       FAN-4R      40%      exhaust     Present        OK  20240710 06:47:03
FanTray5  green       FAN-5F      40%      exhaust     Present        OK  20240710 06:47:03
FanTray5  green       FAN-5R      40%      exhaust     Present        OK  20240710 06:47:03
     N/A    N/A  PSU-1 FAN-1      16%      exhaust     Present        OK  20240710 06:47:03
     N/A    N/A  PSU-2 FAN-1      61%      exhaust     Present        OK  20240710 06:47:03
root@sonic:/home/admin# show platform psu
PSU    Model        Serial              HW Rev      Voltage (V)    Current (A)    Power (W)  Status    LED
-----  -----------  ------------------  --------  -------------  -------------  -----------  --------  -----
PSU 1  YM-1401A-BR  SA060V061911000339  N/A               11.89           3.97        45.00  OK        green
PSU 2  YM-2401H-CR  SB000T701748000048  N/A               12.16           2.38        29.69  OK        green
root@sonic:/home/admin# cat /sys/bus/i2c/devices/12-0053/psu_model_name
YM-2401H-CR
root@sonic:/home/admin# cat /sys/bus/i2c/devices/12-005b/psu_fan_dir
F2B
root@sonic:/home/admin#
root@sonic:/home/admin# pddf_psuutil mfrinfo
PSU    Status    Manufacturer ID    Model        Serial              Fan Airflow Direction
-----  --------  -----------------  -----------  ------------------  -----------------------
PSU-1  OK        3Y POWER           YM-1401A-BR  SA060V061911000339  exhaust
PSU-2  OK        3Y POWER           YM-2401H-CR  SB000T701748000048  exhaust
root@sonic:/home/admin# pddf_psuutil seninfo
PSU    Status      Output Voltage (V)    Output Current (A)    Output Power (W)    Temperature1 (C)    Fan1 Speed (RPM)
-----  --------  --------------------  --------------------  ------------------  ------------------  ------------------
PSU-1  OK                       11.99                  4.60               44.00               30.00                3000
PSU-2  OK                       12.12                  2.72               30.38               29.00               10992
root@sonic:/home/admin#
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

