### PR TITLE
[AS4625] Skip test_platform_info.py::test_thermal_control_load test items

### DIFF
--- a/device/accton/x86_64-accton_as4625_54p-r0/platform.json
+++ b/device/accton/x86_64-accton_as4625_54p-r0/platform.json
@@ -1,6 +1,7 @@
 {
     "chassis": {
         "name": "4625-54P",
+        "thermal_manager": false,
         "components": [
             {
                 "name": "MB_CPLD"

--- a/device/accton/x86_64-accton_as4625_54t-r0/platform.json
+++ b/device/accton/x86_64-accton_as4625_54t-r0/platform.json
@@ -1,6 +1,7 @@
 {
     "chassis": {
         "name": "4625-54T",
+        "thermal_manager": false,
         "components": [
             {
                 "name": "MB_CPLD"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The thermal_manager is not supported in as4625 related platforms. Skip the related test items.
#### How I did it
In platform.json, set thermal_mamager field to false to skip related test items.
#### How to verify it
Run sonic-mgmt test_platform_info test case.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

