### PR TITLE
[AS4625-54P/T] sync log to SSD before OTP shutdown

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as4625-54t/utils/accton_as4625_54t_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4625-54t/utils/accton_as4625_54t_monitor.py
@@ -21,6 +21,7 @@ try:
     import logging.config
     import logging.handlers
     import time
+    import subprocess
     import sonic_platform.platform
     from sonic_platform.helper import APIHelper
 except ImportError as e:
@@ -267,15 +268,38 @@ class device_monitor(object):
                 logging.info('Alarm for temperature high is cleared')
 
         if self.shutdown is True:
+            #
+            # Because the R0A hardware does not have the system thermal 
+            # shutdown (0x27) function, the power control (0x03) function
+            # is used for thermal shutdown. So for the R0A hardware, this 
+            # thermal_shutdown sysfs is not functional.
+            #
+
             # critical case*/
             logging.critical(
                 'Alarm-Critical for temperature critical is detected, trigger thermal shutdown')
+
+            # Sync log buffer to disk for hardware revision R01 and above
+            cmd_str="sync"
+            status, output = subprocess.getstatusoutput(cmd_str)
+            cmd_str="/sbin/fstrim -av"
+            status, output = subprocess.getstatusoutput(cmd_str)
+            time.sleep(3)
+
             path = I2C_PATH.format('0', '64') + 'thermal_shutdown'
             time.sleep(2)
             self._api_helper.write_txt_file(path, 1)
 
             logging.critical(
                 'Alarm-Critical for temperature critical is detected, shutdown DUT')
+
+            # Sync log buffer to disk for hardware revision R0A
+            cmd_str="sync"
+            status, output = subprocess.getstatusoutput(cmd_str)
+            cmd_str="/sbin/fstrim -av"
+            status, output = subprocess.getstatusoutput(cmd_str)
+            time.sleep(3)
+
             path = I2C_PATH.format('0', '64') + 'pwr_enable_mb'
             time.sleep(2)
             self._api_helper.write_txt_file(path, 0)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The shutdown message will be lost during OTP shutdown.

#### How I did it
sync log to SSD before OTP shutdown

#### How to verify it
### Setup Test Environment
1. Modify /usr/local/lib/python3.9/dist-packages/sonic_platform/thermal.py:{}init{}(...)
`self.hwmon_path = "/home/admin/"`
2. Add following to /etc/rc.local
   ```
   echo 31000 > /home/admin/temp1_input
   exit 0 
   ```
3. Reboot

### Before Modification
1. Produce fake temperature data
    ```
    admin@as4625-54t-1:~$ sudo su
    root@as4625-54t-1:/home/admin# cat /dev/null > /var/log/syslog
    root@as4625-54t-1:/home/admin#
    root@as4625-54t-1:/home/admin# echo 85000 > temp1_input
    root@as4625-54t-1:/home/admin#
    ```
2. Power Cycling
    Log : 
[AS4625-54T_Before_Modification.log](https://github.com/user-attachments/files/16245459/AS4625-54T_Before_Modification.log)
[AS4625-54P_Before_Modification.log](https://github.com/user-attachments/files/16245661/AS4625-54P_Before_Modification.log)

### After Modification
1. Add the following code to /usr/local/bin/accton_as4625_54t_monitor.py:manage_fans()
```
......
    import subprocess
    import sonic_platform.platform
            ......
        if self.shutdown is True:
            # critical case*/
            logging.critical(
                'Alarm-Critical for temperature critical is detected, trigger thermal shutdown')
            ## Sync log buffer to disk
            cmd_str="sync"
            status, output = subprocess.getstatusoutput(cmd_str)
            cmd_str="/sbin/fstrim -av"
            status, output = subprocess.getstatusoutput(cmd_str)
            time.sleep(3)
 
            path = I2C_PATH.format('0', '64') + 'thermal_shutdown'
            time.sleep(2)
            self._api_helper.write_txt_file(path, 1)
 
            logging.critical(
                'Alarm-Critical for temperature critical is detected, shutdown DUT')
            ## Sync log buffer to disk
            cmd_str="sync"
            status, output = subprocess.getstatusoutput(cmd_str)
            cmd_str="/sbin/fstrim -av"
            status, output = subprocess.getstatusoutput(cmd_str)
            time.sleep(3)
 
            path = I2C_PATH.format('0', '64') + 'pwr_enable_mb'
            time.sleep(2)
            self._api_helper.write_txt_file(path, 0)
```
2. Produce fake temperature data
    ```
    root@as4625-54t-1:/home/admin# systemctl restart as4625-54t-platform-monitor.service
    root@as4625-54t-1:/home/admin# cat /dev/null > /var/log/syslog
    root@as4625-54t-1:/home/admin# echo 85000 > temp1_input
    root@as4625-54t-1:/home/admin# 
    root@as4625-54t-1:/home/admin# 
    ```
3. Power Cycling
    Log : 
[AS4625-54T_After_Modification.log](https://github.com/user-attachments/files/16245638/AS4625-54T_After_Modification.log)
[AS4625-54P_After_Modification.log](https://github.com/user-attachments/files/16245664/AS4625-54P_After_Modification.log)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

