### PR TITLE
used parent script PID for logger calls (#19219)

### DIFF
--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -11,7 +11,7 @@ ARP_UPDATE_VARS_FILE="/usr/share/sonic/templates/arp_update_vars.j2"
 
 # Overload `logger` command to include arp_update tag
 logger () {
-    command logger -t "arp_update" "$@"
+    command logger -i "$$" -t "arp_update" "$@"
 }
 
 while /bin/true; do


### PR DESCRIPTION
Use the "--id=$$" option in the arp_update script, which tells rsyslogd that
the messages are generated by the same process and prevent the redundant memory
for rate limit data structure from being allocated.