### PR TITLE
Check and install sonic-platform package when pmon container is run very time

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -84,7 +84,7 @@ RUN apt-get purge -y           \
            /python-wheels      \
            ~/.cache
 
-COPY ["lm-sensors.sh", "/usr/bin/"]
+COPY ["lm-sensors.sh", "start.sh", "/usr/bin/"]
 COPY ["docker-pmon.supervisord.conf.j2", "docker_init.j2", "/usr/share/sonic/templates/"]
 COPY ["ssd_tools/*", "/usr/bin/"]
 COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -28,6 +28,17 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 dependent_startup=true
 
+[program:start]
+command=/usr/bin/start.sh
+priority=2
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog
+startsecs=0
+dependent_startup=true
+dependent_startup_wait_for=rsyslogd:running
+
 {% if not skip_chassisd and IS_MODULAR_CHASSIS == 1 %}
 [program:chassisd]
 command=/usr/local/bin/chassisd
@@ -38,7 +49,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=10
 dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
+dependent_startup_wait_for=start:exited
 {% endif %}
 
 {% if not skip_chassis_db_init %}
@@ -51,7 +62,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=0
 dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
+dependent_startup_wait_for=start:exited
 {% endif %}
 
 {% if not skip_sensors and HAVE_SENSORS_CONF == 1 %}
@@ -64,7 +75,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=0
 dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
+dependent_startup_wait_for=start:exited
 {% endif %}
 
 {% if not skip_fancontrol and HAVE_FANCONTROL_CONF == 1 %}
@@ -77,12 +88,12 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=10
 dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
+dependent_startup_wait_for=start:exited
 {% endif %}
 
 {% if not skip_ledd %}
 [program:ledd]
-command={% if API_VERSION == 3 and 'ledd' not in python2_daemons %}python3 {% else %} python2 {% endif %}/usr/local/bin/ledd
+command=python3 /usr/local/bin/ledd
 priority=5
 autostart=false
 autorestart=unexpected
@@ -90,7 +101,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=10
 dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
+dependent_startup_wait_for=start:exited
 {% endif %}
 
 {% if not skip_xcvrd %}
@@ -109,7 +120,7 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=10
 dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
+dependent_startup_wait_for=start:exited
 {% endif %}
 
 {% if DEVICE_METADATA and 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %}
@@ -127,13 +138,13 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=10
 dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
+dependent_startup_wait_for=start:exited
 {% endif %}
 {% endif %}
 
 {% if not skip_psud %}
 [program:psud]
-command={% if API_VERSION == 3 and 'psud' not in python2_daemons %}python3 {% else %} python2 {% endif %}/usr/local/bin/psud
+command=python3 /usr/local/bin/psud
 priority=8
 autostart=false
 autorestart=unexpected
@@ -141,12 +152,12 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=10
 dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
+dependent_startup_wait_for=start:exited
 {% endif %}
 
 {% if not skip_syseepromd %}
 [program:syseepromd]
-command={% if API_VERSION == 3 and 'syseepromd' not in python2_daemons %}python3 {% else %} python2 {% endif %}/usr/local/bin/syseepromd
+command=python3 /usr/local/bin/syseepromd
 priority=9
 autostart=false
 autorestart=unexpected
@@ -154,12 +165,12 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=10
 dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
+dependent_startup_wait_for=start:exited
 {% endif %}
 
 {% if not skip_thermalctld %}
 [program:thermalctld]
-command={% if API_VERSION == 3 and 'thermalctld' not in python2_daemons %}python3 {% else %} python2 {% endif %}/usr/local/bin/thermalctld
+command=python3 /usr/local/bin/thermalctld
 priority=10
 autostart=false
 autorestart=unexpected
@@ -168,7 +179,7 @@ stderr_logfile=syslog
 startsecs=10
 startretries=50
 dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
+dependent_startup_wait_for=start:exited
 {% endif %}
 
 {% if not skip_pcied %}
@@ -181,5 +192,5 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 startsecs=10
 dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
+dependent_startup_wait_for=start:exited
 {% endif %}

--- a/dockers/docker-platform-monitor/docker_init.j2
+++ b/dockers/docker-platform-monitor/docker_init.j2
@@ -14,8 +14,6 @@ MODULAR_CHASSISDB_CONF_FILE="/usr/share/sonic/platform/chassisdb.conf"
 HAVE_SENSORS_CONF=0
 HAVE_FANCONTROL_CONF=0
 IS_MODULAR_CHASSIS=0
-# Default use python2 version
-SONIC_PLATFORM_API_PYTHON_VERSION=2
 
 declare -r EXIT_SUCCESS="0"
 
@@ -41,43 +39,6 @@ if [ -e /usr/share/sonic/platform/platform_wait ]; then
     fi
 fi
 
-# If the Python 2 sonic-platform package is not installed, try to install it
-python2 -c "import sonic_platform" > /dev/null 2>&1 || pip2 show sonic-platform > /dev/null 2>&1
-if [ $? -ne 0 ]; then
-    SONIC_PLATFORM_WHEEL="/usr/share/sonic/platform/sonic_platform-1.0-py2-none-any.whl"
-    echo "sonic-platform package not installed, attempting to install..."
-    if [ -e ${SONIC_PLATFORM_WHEEL} ]; then
-       pip2 install ${SONIC_PLATFORM_WHEEL}
-       if [ $? -eq 0 ]; then
-          echo "Successfully installed ${SONIC_PLATFORM_WHEEL}"
-       else
-          echo "Error: Failed to install ${SONIC_PLATFORM_WHEEL}"
-       fi
-    else
-       echo "Error: Unable to locate ${SONIC_PLATFORM_WHEEL}"
-    fi
-fi
-
-# If the Python 3 sonic-platform package is not installed, try to install it
-python3 -c "import sonic_platform" > /dev/null 2>&1 || pip3 show sonic-platform > /dev/null 2>&1
-if [ $? -ne 0 ]; then
-    SONIC_PLATFORM_WHEEL="/usr/share/sonic/platform/sonic_platform-1.0-py3-none-any.whl"
-    echo "sonic-platform package not installed, attempting to install..."
-    if [ -e ${SONIC_PLATFORM_WHEEL} ]; then
-       pip3 install ${SONIC_PLATFORM_WHEEL}
-       if [ $? -eq 0 ]; then
-          echo "Successfully installed ${SONIC_PLATFORM_WHEEL}"
-          SONIC_PLATFORM_API_PYTHON_VERSION=3
-       else
-          echo "Error: Failed to install ${SONIC_PLATFORM_WHEEL}"
-       fi
-    else
-       echo "Error: Unable to locate ${SONIC_PLATFORM_WHEEL}"
-    fi
-else
-    SONIC_PLATFORM_API_PYTHON_VERSION=3
-fi
-
 {% if CONFIGURED_PLATFORM == "mellanox" %}
 SENSORS_CONF_PATH_GETTER="/usr/share/sonic/platform/get_sensors_conf_path"
 if [ -e $SENSORS_CONF_PATH_GETTER ]; then
@@ -101,7 +62,7 @@ if [ -e $MODULAR_CHASSISDB_CONF_FILE ]; then
     IS_MODULAR_CHASSIS=1
 fi
 
-confvar="{\"HAVE_SENSORS_CONF\":$HAVE_SENSORS_CONF, \"HAVE_FANCONTROL_CONF\":$HAVE_FANCONTROL_CONF, \"API_VERSION\":$SONIC_PLATFORM_API_PYTHON_VERSION, \"IS_MODULAR_CHASSIS\":$IS_MODULAR_CHASSIS}"
+confvar="{\"HAVE_SENSORS_CONF\":$HAVE_SENSORS_CONF, \"HAVE_FANCONTROL_CONF\":$HAVE_FANCONTROL_CONF, \"IS_MODULAR_CHASSIS\":$IS_MODULAR_CHASSIS}"
 
 if [ -e $PMON_DAEMON_CONTROL_FILE ];
 then

--- a/dockers/docker-platform-monitor/start.sh
+++ b/dockers/docker-platform-monitor/start.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+SONIC_PLATFORM_WHEEL="/usr/share/sonic/platform/sonic_platform-1.0-py3-none-any.whl"
+# If the Python 3 sonic-platform package is not installed, try to install it
+python3 -c "import sonic_platform" > /dev/null 2>&1 || pip3 show sonic-platform > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "sonic-platform package not installed, attempting to install..."
+    if [ -e ${SONIC_PLATFORM_WHEEL} ]; then
+        pip3 install ${SONIC_PLATFORM_WHEEL}
+        if [ $? -eq 0 ]; then
+            echo "Successfully installed ${SONIC_PLATFORM_WHEEL}"
+        else
+            echo "Error: Failed to install ${SONIC_PLATFORM_WHEEL}"
+        fi
+    else
+        echo "Error: Unable to locate ${SONIC_PLATFORM_WHEEL}"
+    fi
+else
+    # Check that the sonic-platform package is installed correctly.
+    # Otherwise, force re-install the sonic-platform package.
+    python_lib_path=$(pip3 show sonic-platform | grep Location | cut -d ' ' -f 2)
+    metadata_path="${python_lib_path}/sonic_platform-1.0.dist-info/METADATA"
+    if [ ! -s $metadata_path ]; then
+        echo "sonic-platform package is installed incompletely, force re-install again !!"
+        pip3 install --force-reinstall ${SONIC_PLATFORM_WHEEL}
+        if [ $? -eq 0 ]; then
+            echo "Successfully re-installed ${SONIC_PLATFORM_WHEEL}"
+        else
+            echo "Error: Failed to re-install ${SONIC_PLATFORM_WHEEL}"
+        fi
+    else
+        echo "sonic-platform package has already been installed"
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
Originally, the sonic-platform package will only be installed during the creation of pmon. If the switch is powered off during the creation and initialization of pmon, the process to install sonic-platform package will be terminated and the sonic-platform package will not be reinstalled when pmon container is restarted.

The sonic-platform package is the base module in pmon container. The daemon can not be run correctlly if the sonic-platform package is not installed.

Modification:
- Remove the python version v2 and v3 check when generate supervisord.conf in pmon
- Installed the sonic-platform package if it is not existed when pmon container is run.
- Check the METADATA if the sonic_platform package has been installed. According to the description in the following link: https://packaging.python.org/en/latest/specifications/recording-installed-packages/#the-metadata-file 
  The METADATA should be created after a package is installed and its size should not be zero.
- Let the related daemons be started after the sonic-platform package installation check is done.


