### PR TITLE
Including init-functions for ntp log_daemon_msg

### DIFF
--- a/files/image_config/ntp/ntp-systemd-wrapper
+++ b/files/image_config/ntp/ntp-systemd-wrapper
@@ -5,6 +5,7 @@
 # When management VRF is enabled, the NTP application should be started using "ip vrf exec mgmt".
 # Check has been added to verify the management VRF enabled status and use "ip vrf exec mgmt"  when it is enabled.
 # This file will be copied to /usr/lib/ntp/ntp-systemd-wrapper file that gets created during build process.
+. /lib/lsb/init-functions
 
 DAEMON=/usr/sbin/ntpd
 PIDFILE=/var/run/ntpd.pid


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Eliminating function not found warning message in the syslog during ntpd is start

