### PR TITLE
Add to support pmon.service restart when syncd.service restart

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -91,7 +91,7 @@ function startplatform() {
 function waitplatform() {
 
     BOOT_TYPE=`getBootType`
-    if [[ x"$sonic_asic_platform" == x"mellanox" ]]; then
+    if [[ x"$sonic_asic_platform" == x"mellanox" ]] || [[ x"$sonic_asic_platform" == x"broadcom" ]]; then
         if [[ x"$BOOT_TYPE" = @(x"fast"|x"warm"|x"fastfast") ]]; then
             PMON_TIMER_STATUS=$(systemctl is-active pmon.timer)
             if [[ x"$PMON_TIMER_STATUS" = x"inactive" ]]; then


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Why I did it
The pmon service is not restarted after restarting swss service.

How I did it
Adds a condition into syncd.sh to restart the pmon.service when syncd restart.

How to verify it
Restart swss service and confirm the pmon service is also restart.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

