### PR TITLE
Fix the Pytest issues in the 202311.X branch

### DIFF
--- a/device/accton/x86_64-accton_as4625_54t-r0/platform.json
+++ b/device/accton/x86_64-accton_as4625_54t-r0/platform.json
@@ -95,9 +95,18 @@
         "psus": [
             {
                 "name": "PSU-1",
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
-                        "name": "PSU-1 FAN-1"
+                        "name": "PSU-1 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [
@@ -123,9 +132,18 @@
             },
             {
                 "name": "PSU-2",
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
-                        "name": "PSU-2 FAN-1"
+                        "name": "PSU-2 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [

--- a/device/accton/x86_64-accton_as4630_54pe-r0/platform.json
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/platform.json
@@ -114,7 +114,13 @@
                 },
                 "fans": [
                     {
-                        "name": "PSU-1 FAN-1"
+                        "name": "PSU-1 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [
@@ -134,7 +140,13 @@
                 },
                 "fans": [
                     {
-                        "name": "PSU-2 FAN-1"
+                        "name": "PSU-2 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [

--- a/device/accton/x86_64-accton_as7326_56x-r0/platform.json
+++ b/device/accton/x86_64-accton_as7326_56x-r0/platform.json
@@ -233,9 +233,18 @@
         "psus": [
             {
                 "name": "PSU-1",
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
-                        "name": "PSU-1 FAN-1"
+                        "name": "PSU-1 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [
@@ -253,9 +262,18 @@
             },
             {
                 "name": "PSU-2",
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
-                        "name": "PSU-2 FAN-1"
+                        "name": "PSU-2 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [

--- a/device/accton/x86_64-accton_as7726_32x-r0/platform.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/platform.json
@@ -332,7 +332,13 @@
                 },
                 "fans": [
                     {
-                        "name": "PSU-1 FAN-1"
+                        "name": "PSU-1 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [
@@ -351,7 +357,13 @@
                 },
                 "fans": [
                     {
-                        "name": "PSU-2 FAN-1"
+                        "name": "PSU-2 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [

--- a/device/accton/x86_64-accton_as9736_64d-r0/platform.json
+++ b/device/accton/x86_64-accton_as9736_64d-r0/platform.json
@@ -152,7 +152,13 @@
                 },
                 "fans": [
                     {
-                        "name": "PSU-1 FAN-1"
+                        "name": "PSU-1 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [
@@ -175,7 +181,13 @@
                 },
                 "fans": [
                     {
-                        "name": "PSU-2 FAN-1"
+                        "name": "PSU-2 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/sfp.py
@@ -196,3 +196,25 @@ class Sfp(PddfSfp):
         except NotImplementedError:
             pass
         return self.__get_error_description()
+
+    def get_reset_status(self):
+        """
+        Retrieves the reset status of SFP
+
+        Returns:
+            A Boolean, True if reset enabled, False if disabled
+        """
+        if self.sfp_type == "QSFP28":
+            return super().get_reset_status()
+        return False
+
+    def reset(self):
+        """
+        Reset SFP and return all user module settings to their default srate.
+
+        Returns:
+            A boolean, True if successful, False if not
+        """
+        if self.sfp_type == "QSFP28":
+            return super().reset()
+        return False


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the following pytest issues
AS4625-54T :
test_psu.py::TestPsuApi::test_led [FAILED]
test_psu_fans.py::TestPsuFans::test_get_fans_target_speed [FAILED]
test_psu_fans.py::TestPsuFans::test_set_fans_led [FAILED]

AS4630-54PE:
test_psu_fans.py::TestPsuFans::test_get_fans_target_speed [FAILED]
test_psu_fans.py::TestPsuFans::test_set_fans_led [FAILED]

AS7326-56X:
test_psu.py::TestPsuApi::test_led [FAILED]
test_psu_fans.py::TestPsuFans::test_get_fans_target_speed [FAILED]
test_psu_fans.py::TestPsuFans::test_set_fans_led [FAILED]
test_sfp.py::TestSfpApi::test_reset [FAILED]
test_sfp.py::TestSfpApi::test_get_reset_status [FAILED]

AS7726-32X:
test_psu_fans.py::TestPsuFans::test_get_fans_target_speed [FAILED]
test_psu_fans.py::TestPsuFans::test_set_fans_led [FAILED]

AS9736-64D:
test_psu_fans.py::TestPsuFans::test_get_fans_target_speed [FAILED]
test_psu_fans.py::TestPsuFans::test_set_fans_led [FAILED]

#### How I did it
AS4625-54T ==> Adjust the platform.json file

AS4630-54PE ==> Adjust the platform.json file

AS7326-56X:
test_psu.py::TestPsuApi::test_led ==> Adjust the platform.json file
test_psu_fans.py::TestPsuFans::test_get_fans_target_speed ==> Adjust the platform.json file
test_psu_fans.py::TestPsuFans::test_set_fans_led ==> Adjust the platform.json file
test_sfp.py::TestSfpApi::test_reset ==> Add reset(...) in sfp.py
test_sfp.py::TestSfpApi::test_get_reset_status ==> Add get_reset_status(...) in sfp.py

AS7726-32X ==> Adjust the platform.json file

AS9736-64D ==> Adjust the platform.json file

#### How to verify it
Run pytest script again

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

