### PR TITLE
Fix the type of used_cnt in sonic-events-swss.yang

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-events-swss.yang
+++ b/src/sonic-yang-models/yang-models/sonic-events-swss.yang
@@ -102,7 +102,7 @@ module sonic-events-swss {
             }
 
             leaf used_cnt {
-                type uint8;
+                type uint64;
             }
 
             leaf free_cnt {


### PR DESCRIPTION
#### Why I did it
The `used_cnt` type was originally uint8, which only goes up to 255, which is not sufficient. 

#### How I did it
Therefore, it has been changed to uint64, the same type as `free_cnt`.



