### PR TITLE
[cherry-pick] Change leaf value of used_cnt of sonic-events-swss:chk_crm_threshold

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/sonic-events-swss.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/sonic-events-swss.json
@@ -180,9 +180,9 @@
     "SONIC_EVENTS_SWSS_CHK_CRM_THRESHOLD_VALID": {
         "sonic-events-swss:sonic-events-swss": {
             "sonic-events-swss:chk_crm_threshold": {
-                "percent": 0,
-                "used_cnt": 0,
-                "free_cnt": 0,
+                "percent": 80,
+                "used_cnt": 6414,
+                "free_cnt": 65300,
                 "timestamp": "1985-04-12T23:20:50.52Z"
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-events-swss.yang
+++ b/src/sonic-yang-models/yang-models/sonic-events-swss.yang
@@ -102,11 +102,11 @@ module sonic-events-swss {
             }
 
             leaf used_cnt {
-                type uint8;
+                type uint32;
             }
 
             leaf free_cnt {
-                type uint64;
+                type uint32;
             }
 
             uses evtcmn:sonic-events-cmn;


### PR DESCRIPTION
The `used_cnt` type was originally `uint8`, which only goes up to 255, which is not sufficient.
And the community has a PR to solve this issue. Therefore cherry-pick commit f829807

For specific details, please refer to: https://github.com/sonic-net/sonic-buildimage/commit/f82980784de91fb9106be133282e894991f07147.