### PR TITLE
Set mem_cache_enable=1 for Accton TD3 platforms

### DIFF
--- a/device/accton/x86_64-accton_as5835_54t-r0/Accton-AS5835-54T/mv2-as5835t-48x10G+6x100G.config.bcm
+++ b/device/accton/x86_64-accton_as5835_54t-r0/Accton-AS5835-54T/mv2-as5835t-48x10G+6x100G.config.bcm
@@ -11,7 +11,7 @@ oversubscribe_mode=1
 pbmp_xport_xe=0x1FFFFFFFFFFFFFFFE
 
 parity_enable=0
-mem_cache_enable=0
+mem_cache_enable=1
 
 l2_mem_entries=32768
 l3_mem_entries=16384

--- a/device/accton/x86_64-accton_as5835_54x-r0/Accton-AS5835-54X/mv2-as5835-48x10G+6x100G.config.bcm
+++ b/device/accton/x86_64-accton_as5835_54x-r0/Accton-AS5835-54X/mv2-as5835-48x10G+6x100G.config.bcm
@@ -12,7 +12,7 @@ oversubscribe_mode=1
 pbmp_xport_xe=0x1FFFFFFFFFFFFFFFE
 
 parity_enable=0
-mem_cache_enable=0
+mem_cache_enable=1
 
 l2_mem_entries=32768
 l3_mem_entries=16384

--- a/device/accton/x86_64-accton_as7326_56x-r0/Accton-AS7326-56X/td3-as7326-48x25G+8x100G.config.bcm
+++ b/device/accton/x86_64-accton_as7326_56x-r0/Accton-AS7326-56X/td3-as7326-48x25G+8x100G.config.bcm
@@ -7,7 +7,7 @@ oversubscribe_mode=1
 pbmp_xport_xe=0x7F878787F878787FDFE1E1E1FE1E1E1FE
 
 parity_enable=0
-mem_cache_enable=0
+mem_cache_enable=1
 
 l2_mem_entries=32768
 l3_mem_entries=16384

--- a/device/accton/x86_64-accton_as7726_32x-r0/Accton-AS7726-32X/td3-as7726-32x100G.config.bcm
+++ b/device/accton/x86_64-accton_as7726_32x-r0/Accton-AS7726-32X/td3-as7726-32x100G.config.bcm
@@ -8,7 +8,7 @@ oversubscribe_mode=1
 pbmp_xport_xe=0x4888888888888888c2222222222222222
 
 parity_enable=0
-mem_cache_enable=0
+mem_cache_enable=1
 
 l2_mem_entries=32768
 l3_mem_entries=16384


### PR DESCRIPTION
#### Why I did it
When fdb move event occurs, the port number in delete notification is incorrect.

```
Aug  7 01:59:30.602557 as7726-32x-3 INFO syncd#syncd: [none] SAI_API_FDB:_brcm_sai_fdb_event_cb:260 fdbEvent: delete (0) for mac 00-11-22-33-44-55 vid:0x7064, port:0x0 lagid:0x244 flags:0x1304c0 flags2:0x0 lag:true station flags 0x0 prev count 3
Aug  7 01:59:30.602675 as7726-32x-3 INFO syncd#syncd: [none] SAI_API_FDB:_brcm_sai_fdb_event_cb:476 fdbEvent: FDB MOVE event: 0 for mac 00-11-22-33-44-55 port_tid:0x244 port_type:2 vid:0x64
Aug  7 01:59:30.602675 as7726-32x-3 INFO syncd#syncd: [none] SAI_API_FDB:_brcm_sai_fdb_table_delete:77 fdbEvent:FDB table del: MAC:00-11-22-33-44-55  vfi 0x7064
Aug  7 01:59:30.602675 as7726-32x-3 INFO syncd#syncd: [none] SAI_API_NEIGHBOR:brcm_sai_xgs_common_neighbor_mac_db_update:114 Mac entry not found - skip nbr processing. add 0, dir 3
Aug  7 01:59:30.602675 as7726-32x-3 INFO syncd#syncd: [none] SAI_API_DASH_ENI:_brcm_sai_l2_ecmp_nbr_mac_delete:259 FDB : MAC:00-11-22-33-44-55 vfi:0x7064, is_fdb_del 1, dir 6
Aug  7 01:59:30.602675 as7726-32x-3 INFO syncd#syncd: [none] SAI_API_DASH_ENI:_brcm_sai_l2_ecmp_nbr_mac_delete:278 l2ecmp macnbr entry not found
Aug  7 01:59:30.602729 as7726-32x-3 INFO syncd#syncd: [none] SAI_API_FDB:_brcm_sai_fdb_event_cb:260 fdbEvent: add (1) for mac 00-11-22-33-44-55 vid:0x7064, port:0xb0000002 lagid:0x0 flags:0x130440 flags2:0x0 lag:false station flags 0x0 prev count 2
Aug  7 01:59:30.602729 as7726-32x-3 INFO syncd#syncd: [none] SAI_API_FDB:_brcm_sai_fdb_event_cb:465 fdbEvent: FDB MOVE event: 1 for mac 00-11-22-33-44-55 port_tid:0x5 port_type:1 vid:0x64
Aug  7 01:59:30.602862 as7726-32x-3 INFO syncd#syncd: [none] SAI_API_FDB:_brcm_sai_fdb_table_add:55 fdbEvent:FDB table add: MAC:00-11-22-33-44-55  vfi 0x7064 port:0x1003a00000005 vlan:100 is_static 0 is_remote 0
Aug  7 01:59:30.602862 as7726-32x-3 INFO syncd#syncd: [none] SAI_API_NEIGHBOR:brcm_sai_xgs_common_neighbor_mac_db_update:114 Mac entry not found - skip nbr processing. add 0, dir 1
Aug  7 01:59:30.602862 as7726-32x-3 INFO syncd#syncd: [none] SAI_API_DASH_ENI:_brcm_sai_l2_ecmp_nbr_mac_delete:259 FDB : MAC:00-11-22-33-44-55 vfi:0x7064, is_fdb_del 1, dir 5
Aug  7 01:59:30.602862 as7726-32x-3 INFO syncd#syncd: [none] SAI_API_DASH_ENI:_brcm_sai_l2_ecmp_nbr_mac_delete:278 l2ecmp macnbr entry not found
Aug  7 01:59:30.602862 as7726-32x-3 INFO syncd#syncd: [none] SAI_API_NEIGHBOR:brcm_sai_xgs_common_neighbor_mac_db_update:114 Mac entry not found - skip nbr processing. add 1, dir 2
Aug  7 01:59:30.603153 as7726-32x-3 WARNING syncd#syncd: :- check_fdb_event_notification_data: RID 0x2003a00000244 on SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID is not present on local ASIC DB
Aug  7 01:59:30.603153 as7726-32x-3 ERR syncd#syncd: :- process_on_fdb_event: invalid OIDs in fdb notifications, NOT translating and NOT storing in ASIC DB
Aug  7 01:59:30.603153 as7726-32x-3 ERR syncd#syncd: :- process_on_fdb_event: FDB notification was not sent since it contain invalid OIDs, bug?
Aug  7 01:59:30.604447 as7726-32x-3 WARNING swss#orchagent: :- meta_sai_on_fdb_event_single: object key SAI_OBJECT_TYPE_FDB_ENTRY:{"bvid":"oid:0x260000000005e8","mac":"00:11:22:33:44:55","switch_id":"oid:0x21000000000000"} already exists, but received LEARNED event
```

#### How I did it
 set "mem_cache_enable=1" to get the port number for delete notification from cache if l2xmsg_mod is L2MODE_FIFO.

#### How to verify it
1. Create the VLAN 100 and untagged join Ethernet0 and Ethernet4
2. Inject a packet to Ethernet0
3. Inject same packet to Ethernet4
4. Verify if there is error message in the syslog
5. Verify the MAC address table are consistent between ASIC_DB and STATE_DB

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

