### PR TITLE
Set as9716 default medium to copper

### DIFF
--- a/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D-100G/th3-as9716-32x100G.config.bcm
+++ b/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D-100G/th3-as9716-32x100G.config.bcm
@@ -1300,6 +1300,8 @@ serdes_core_tx_polarity_flip_physical{254}=0xD6
 serdes_core_tx_polarity_flip_physical{255}=0xD6
 serdes_core_tx_polarity_flip_physical{256}=0xD6
 
+#Set default medium to copper
+serdes_lane_config_media_type=copper
 #dport_map_port_38=129
 #portmap_38=257:10
 #dport_map_port_118=130

--- a/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D/th3-as9716-32x400G.config.bcm
+++ b/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D/th3-as9716-32x400G.config.bcm
@@ -1286,6 +1286,8 @@ serdes_core_tx_polarity_flip_physical{254}=0xD6
 serdes_core_tx_polarity_flip_physical{255}=0xD6
 serdes_core_tx_polarity_flip_physical{256}=0xD6
 
+#Set default medium to copper
+serdes_lane_config_media_type=copper
 #dport_map_port_38=129
 #portmap_38=257:10
 #dport_map_port_118=130


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Set as9716 default medium to copper
#### How I did it
Add serdes_lane_config_media_type=copper in config.bcm
#### How to verify it
Check the interface type field in bcm shell. It change from KR to CR if no sfp present. 
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

