### PR TITLE
[Platform][AS7326-56X]: Fix status led test failed for FAN and PSU.

### DIFF
--- a/device/accton/x86_64-accton_as7326_56x-r0/platform.json
+++ b/device/accton/x86_64-accton_as7326_56x-r0/platform.json
@@ -28,6 +28,9 @@
                 "speed": {
                     "controllable": true,
                     "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
                 }
             },
             {
@@ -35,6 +38,9 @@
                 "speed": {
                     "controllable": true,
                     "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
                 }
             },
             {
@@ -42,6 +48,9 @@
                 "speed": {
                     "controllable": true,
                     "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
                 }
             },
             {
@@ -49,6 +58,9 @@
                 "speed": {
                     "controllable": true,
                     "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
                 }
             },
             {
@@ -56,6 +68,9 @@
                 "speed": {
                     "controllable": true,
                     "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
                 }
             },
             {
@@ -63,6 +78,9 @@
                 "speed": {
                     "controllable": true,
                     "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
                 }
             },
             {
@@ -70,6 +88,9 @@
                 "speed": {
                     "controllable": true,
                     "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
                 }
             },
             {
@@ -77,6 +98,9 @@
                 "speed": {
                     "controllable": true,
                     "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
                 }
             },
             {
@@ -84,6 +108,9 @@
                 "speed": {
                     "controllable": true,
                     "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
                 }
             },
             {
@@ -91,6 +118,9 @@
                 "speed": {
                     "controllable": true,
                     "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
                 }
             },
             {
@@ -98,6 +128,9 @@
                 "speed": {
                     "controllable": true,
                     "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
                 }
             },
             {
@@ -105,12 +138,18 @@
                 "speed": {
                     "controllable": true,
                     "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
                 }
             }
         ],
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "status_led": {
+                    "controllable": false
+                },
                 "num_fans" : 2,
                 "fans": [
                     {
@@ -118,6 +157,9 @@
                         "speed": {
                             "controllable": true,
                             "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
                         }
                     },
                     {
@@ -125,12 +167,18 @@
                         "speed": {
                             "controllable": true,
                             "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
                         }
                     }
                 ]
             },
             {
                 "name": "FanTray2",
+                "status_led": {
+                    "controllable": false
+                },
                 "num_fans" : 2,
                 "fans": [
                     {
@@ -138,6 +186,9 @@
                         "speed": {
                             "controllable": true,
                             "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
                         }
                     },
                     {
@@ -145,12 +196,18 @@
                         "speed": {
                             "controllable": true,
                             "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
                         }
                     }
                 ]
             },
             {
                 "name": "FanTray3",
+                "status_led": {
+                    "controllable": false
+                },
                 "num_fans" : 2,
                 "fans": [
                     {
@@ -158,6 +215,9 @@
                         "speed": {
                             "controllable": true,
                             "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
                         }
                     },
                     {
@@ -165,12 +225,18 @@
                         "speed": {
                             "controllable": true,
                             "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
                         }
                     }
                 ]
             },
             {
                 "name": "FanTray4",
+                "status_led": {
+                    "controllable": false
+                },
                 "num_fans" : 2,
                 "fans": [
                     {
@@ -178,6 +244,9 @@
                         "speed": {
                             "controllable": true,
                             "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
                         }
                     },
                     {
@@ -185,12 +254,18 @@
                         "speed": {
                             "controllable": true,
                             "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
                         }
                     }
                 ]
             },
             {
                 "name": "FanTray5",
+                "status_led": {
+                    "controllable": false
+                },
                 "num_fans" : 2,
                 "fans": [
                     {
@@ -198,6 +273,9 @@
                         "speed": {
                             "controllable": true,
                             "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
                         }
                     },
                     {
@@ -205,12 +283,18 @@
                         "speed": {
                             "controllable": true,
                             "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
                         }
                     }
                 ]
             },
             {
                 "name": "FanTray6",
+                "status_led": {
+                    "controllable": false
+                },
                 "num_fans" : 2,
                 "fans": [
                     {
@@ -218,6 +302,9 @@
                         "speed": {
                             "controllable": true,
                             "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
                         }
                     },
                     {
@@ -225,6 +312,9 @@
                         "speed": {
                             "controllable": true,
                             "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
                         }
                     }
                 ]


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
 sonic-mgmt pytest failed on
  - platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_led
  - platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_set_fan_drawers_led
  - platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_led
  - platform_tests/api/test_psu.py::TestPsuApi::test_led

#### How I did it
Correct settings for platform.json because the status LEDs for PSU and FAN are uncontrollable.
#### How to verify it
Re-run the pytest and the result is pass.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

