### PR TITLE
Fix the NTP configuration in CONFIG_DB when loading from minigraph.

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -2077,7 +2077,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     results['SYSLOG_SERVER'] = dict((item, {}) for item in syslog_servers)
     results['DHCP_SERVER'] = dict((item, {}) for item in dhcp_servers)
     results['DHCP_RELAY'] = dhcp_relay_table
-    results['NTP_SERVER'] = dict((item, {}) for item in ntp_servers)
+    results['NTP_SERVER'] = dict((item, {'iburst': 'on'}) for item in ntp_servers)
     # Set default DNS nameserver from dns.j2
     results['DNS_NAMESERVER'] = {}
     if os.environ.get("CFGGEN_UNIT_TESTING", "0") == "2":

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -2077,7 +2077,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     results['SYSLOG_SERVER'] = dict((item, {}) for item in syslog_servers)
     results['DHCP_SERVER'] = dict((item, {}) for item in dhcp_servers)
     results['DHCP_RELAY'] = dhcp_relay_table
-    results['NTP_SERVER'] = dict((item, {'iburst': 'on'}) for item in ntp_servers)
+    results['NTP_SERVER'] = dict((item, {'association_type': 'server', 'resolve_as': item, 'iburst': 'on'}) for item in ntp_servers)
     # Set default DNS nameserver from dns.j2
     results['DNS_NAMESERVER'] = {}
     if os.environ.get("CFGGEN_UNIT_TESTING", "0") == "2":

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -696,7 +696,7 @@ class TestCfgGen(TestCase):
     def test_metadata_ntp(self):
         argument = ['-m', self.sample_graph_metadata, '-p', self.port_config, '-v', "NTP_SERVER"]
         output = self.run_script(argument)
-        self.assertEqual(utils.to_dict(output.strip()), utils.to_dict("{'10.0.10.1': {}, '10.0.10.2': {}}"))
+        self.assertEqual(utils.to_dict(output.strip()), utils.to_dict("{'10.0.10.1': {'iburst': 'on'}, '10.0.10.2': {'iburst': 'on'}}"))
 
     def test_dns_nameserver(self):
         argument = ['-m', self.sample_graph_metadata, '-p', self.port_config, '-v', "DNS_NAMESERVER"]

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -696,7 +696,7 @@ class TestCfgGen(TestCase):
     def test_metadata_ntp(self):
         argument = ['-m', self.sample_graph_metadata, '-p', self.port_config, '-v', "NTP_SERVER"]
         output = self.run_script(argument)
-        self.assertEqual(utils.to_dict(output.strip()), utils.to_dict("{'10.0.10.1': {'iburst': 'on'}, '10.0.10.2': {'iburst': 'on'}}"))
+        self.assertEqual(utils.to_dict(output.strip()), utils.to_dict("{'10.0.10.1': {'association_type': 'server', 'iburst': 'on', 'resolve_as': '10.0.10.1'}, '10.0.10.2': {'association_type': 'server', 'iburst': 'on', 'resolve_as': '10.0.10.2'}}"))
 
     def test_dns_nameserver(self):
         argument = ['-m', self.sample_graph_metadata, '-p', self.port_config, '-v', "DNS_NAMESERVER"]
@@ -1020,7 +1020,7 @@ class TestCfgGen(TestCase):
                 "'Vlan2000': {'dhcpv6_servers': ['fc02:2000::3', 'fc02:2000::4']}}"
             )
         )
-        
+
     def test_minigraph_packet_chassis_acl(self):
         argument = ['-m', self.packet_chassis_graph, '-p', self.packet_chassis_port_ini, '-v', "ACL_TABLE"]
         output = self.run_script(argument)

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -283,7 +283,7 @@ class TestCfgGenCaseInsensitive(TestCase):
     def test_metadata_ntp(self):
         argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', "NTP_SERVER"]
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "{'10.0.10.1': {}, '10.0.10.2': {}}")
+        self.assertEqual(output.strip(), "{'10.0.10.1': {'iburst': 'on'}, '10.0.10.2': {'iburst': 'on'}}")
 
     def test_minigraph_vnet(self):
         argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', "VNET"]

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -283,7 +283,7 @@ class TestCfgGenCaseInsensitive(TestCase):
     def test_metadata_ntp(self):
         argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', "NTP_SERVER"]
         output = self.run_script(argument)
-        self.assertEqual(output.strip(), "{'10.0.10.1': {'iburst': 'on'}, '10.0.10.2': {'iburst': 'on'}}")
+        self.assertEqual(output.strip(), "{'10.0.10.1': {'association_type': 'server', 'resolve_as': '10.0.10.1', 'iburst': 'on'}, '10.0.10.2': {'association_type': 'server', 'resolve_as': '10.0.10.2', 'iburst': 'on'}}")
 
     def test_minigraph_vnet(self):
         argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', "VNET"]

--- a/src/sonic-config-engine/tests/test_multinpu_cfggen.py
+++ b/src/sonic-config-engine/tests/test_multinpu_cfggen.py
@@ -142,7 +142,7 @@ class TestMultiNpuCfgGen(TestCase):
     def test_metadata_ntp(self):
         argument = ['-m', self.sample_graph, '-p', self.sample_port_config, '--var-json', "NTP_SERVER"]
         output = json.loads(self.run_script(argument))
-        self.assertDictEqual(output, {'17.39.1.130': {}, '17.39.1.129': {}})
+        self.assertDictEqual(output, {'17.39.1.130': {'iburst': 'on'}, '17.39.1.129': {'iburst': 'on'}})
         #NTP data is present only in the host config
         argument = ['-m', self.sample_graph, '--var-json', "NTP_SERVER"]
         for asic in range(NUM_ASIC):

--- a/src/sonic-config-engine/tests/test_multinpu_cfggen.py
+++ b/src/sonic-config-engine/tests/test_multinpu_cfggen.py
@@ -142,7 +142,7 @@ class TestMultiNpuCfgGen(TestCase):
     def test_metadata_ntp(self):
         argument = ['-m', self.sample_graph, '-p', self.sample_port_config, '--var-json', "NTP_SERVER"]
         output = json.loads(self.run_script(argument))
-        self.assertDictEqual(output, {'17.39.1.130': {'iburst': 'on'}, '17.39.1.129': {'iburst': 'on'}})
+        self.assertDictEqual(output, {'17.39.1.130': {'association_type': 'server', 'iburst': 'on', 'resolve_as': '17.39.1.130'}, '17.39.1.129': {'association_type': 'server', 'iburst': 'on', 'resolve_as': '17.39.1.129'}})
         #NTP data is present only in the host config
         argument = ['-m', self.sample_graph, '--var-json', "NTP_SERVER"]
         for asic in range(NUM_ASIC):


### PR DESCRIPTION
#### Why I did it
When the `association_type` and `resolve_as` fields are not set, the NTP server won't be configured in `/etc/ntp.conf`. Therefore, these fields need to be added during the conversion from minigraph to CONFIG_DB.

#### How I did it
Cherry-pick a community commit that adds the `iburst` field, and then add the two necessary fields, `association_type` and `resolve_as`, on top of that.

#### How to verify it
After manually adding the above configuration, it has been confirmed that the NTP server is successfully added to `/etc/ntp.conf`.
