### PR TITLE
[YANG] Add in_band_mgmt_enabled field in MGMT_VRF_CONFIG table

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-mgmt_vrf.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mgmt_vrf.yang
@@ -23,6 +23,11 @@ module sonic-mgmt_vrf {
                     default false;
                 }
 
+                leaf in_band_mgmt_enabled {
+                    type boolean;
+                    default false;
+                }
+
             } /* end of container vrf_global */
 
         } /* end of container MGMT_VRF_CONFIG */


### PR DESCRIPTION
Fix port breakout failed caused by missing in_band_mgmt_enabled field in MGMT_VRF_CONFIG table