### PR TITLE
Enhance the sfp chagned event for as9817 and as9737

### DIFF
--- a/device/accton/x86_64-accton_as9737_32db-r0/sonic_platform/event.py
+++ b/device/accton/x86_64-accton_as9737_32db-r0/sonic_platform/event.py
@@ -23,6 +23,7 @@ class SfpEvent:
         self._sfp_list = sfp_list
         self._logger = Logger()
         self._sfp_change_event_data = {'present': 0}
+        self._sfp_change_event_data['present'] = self.get_presence_bitmap()
 
     def get_presence_bitmap(self):
         bitmap = 0

--- a/device/accton/x86_64-accton_as9817_64o-r0/sonic_platform/event.py
+++ b/device/accton/x86_64-accton_as9817_64o-r0/sonic_platform/event.py
@@ -23,6 +23,7 @@ class SfpEvent:
         self._sfp_list = sfp_list
         self._logger = Logger()
         self._sfp_change_event_data = {'present': 0}
+        self._sfp_change_event_data['present'] = self.get_presence_bitmap()
 
     def get_presence_bitmap(self):
         bitmap = 0


### PR DESCRIPTION
When xcvrd starts, it would update the current inserted sfp information. It doesn't need to send a change event for the already inserted transceiver. The duplicate event would cause the link to flap on warm restart. Modify code to send event only to detect sfp insertion.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

