### PR TITLE
Fix the Pytest issues in the 202311.X branch

### DIFF
--- a/device/accton/x86_64-accton_as4625_54p-r0/platform.json
+++ b/device/accton/x86_64-accton_as4625_54p-r0/platform.json
@@ -1,7 +1,11 @@
 {
     "chassis": {
-        "name": "4625-54P",
+        "name": "AS4625-54P",
         "thermal_manager": false,
+        "status_led": {
+            "controllable": true,
+            "colors": ["STATUS_LED_COLOR_GREEN", "STATUS_LED_COLOR_GREEN_BLINK", "STATUS_LED_COLOR_AMBER"]
+        },
         "components": [
             {
                 "name": "MB_CPLD"
@@ -45,6 +49,10 @@
         "fan_drawers":[
             {
                 "name": "FanTray-1",
+                "max_consumed_power": false,
+                "status_led": {
+                        "controllable": false
+                },
                 "num_fans" : 1,
                 "fans": [
                     {
@@ -61,6 +69,10 @@
             },
             {
                 "name": "FanTray-2",
+                "max_consumed_power": false,
+                "status_led": {
+                        "controllable": false
+                },
                 "num_fans" : 1,
                 "fans": [
                     {
@@ -77,6 +89,10 @@
             },
             {
                 "name": "FanTray-3",
+                "max_consumed_power": false,
+                "status_led": {
+                        "controllable": false
+                },
                 "num_fans" : 1,
                 "fans": [
                     {

--- a/device/accton/x86_64-accton_as4625_54t-r0/platform.json
+++ b/device/accton/x86_64-accton_as4625_54t-r0/platform.json
@@ -1,7 +1,11 @@
 {
     "chassis": {
-        "name": "4625-54T",
+        "name": "AS4625-54T",
         "thermal_manager": false,
+        "status_led": {
+            "controllable": true,
+            "colors": ["STATUS_LED_COLOR_GREEN", "STATUS_LED_COLOR_GREEN_BLINK", "STATUS_LED_COLOR_AMBER"]
+        },
         "components": [
             {
                 "name": "MB_CPLD"
@@ -45,6 +49,10 @@
         "fan_drawers":[
             {
                 "name": "FanTray-1",
+                "max_consumed_power": false,
+                "status_led": {
+                        "controllable": false
+                },
                 "num_fans" : 1,
                 "fans": [
                     {
@@ -61,6 +69,10 @@
             },
             {
                 "name": "FanTray-2",
+                "max_consumed_power": false,
+                "status_led": {
+                        "controllable": false
+                },
                 "num_fans" : 1,
                 "fans": [
                     {
@@ -77,6 +89,10 @@
             },
             {
                 "name": "FanTray-3",
+                "max_consumed_power": false,
+                "status_led": {
+                        "controllable": false
+                },
                 "num_fans" : 1,
                 "fans": [
                     {

--- a/device/accton/x86_64-accton_as4630_54npe-r0/platform.json
+++ b/device/accton/x86_64-accton_as4630_54npe-r0/platform.json
@@ -52,6 +52,7 @@
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -71,6 +72,7 @@
             },
             {
                 "name": "FanTray2",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -90,6 +92,7 @@
             },
             {
                 "name": "FanTray3",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },

--- a/device/accton/x86_64-accton_as4630_54pe-r0/platform.json
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/platform.json
@@ -49,6 +49,7 @@
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -68,6 +69,7 @@
             },
             {
                 "name": "FanTray2",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -87,6 +89,7 @@
             },
             {
                 "name": "FanTray3",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },

--- a/device/accton/x86_64-accton_as4630_54te-r0/platform.json
+++ b/device/accton/x86_64-accton_as4630_54te-r0/platform.json
@@ -52,6 +52,7 @@
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -71,6 +72,7 @@
             },
             {
                 "name": "FanTray2",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -90,6 +92,7 @@
             },
             {
                 "name": "FanTray3",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },

--- a/device/accton/x86_64-accton_as5835_54t-r0/platform.json
+++ b/device/accton/x86_64-accton_as5835_54t-r0/platform.json
@@ -125,6 +125,7 @@
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -154,6 +155,7 @@
             },
             {
                 "name": "FanTray2",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -183,6 +185,7 @@
             },
             {
                 "name": "FanTray3",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -212,6 +215,7 @@
             },
             {
                 "name": "FanTray4",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -241,6 +245,7 @@
             },
             {
                 "name": "FanTray5",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },

--- a/device/accton/x86_64-accton_as5835_54x-r0/platform.json
+++ b/device/accton/x86_64-accton_as5835_54x-r0/platform.json
@@ -61,6 +61,7 @@
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "max_consumed_power": false,
                 "num_fans" : 2,
                 "fans": [
                     {
@@ -73,6 +74,7 @@
             },
             {
                 "name": "FanTray2",
+                "max_consumed_power": false,
                 "num_fans" : 2,
                 "fans": [
                     {
@@ -85,6 +87,7 @@
             },
             {
                 "name": "FanTray3",
+                "max_consumed_power": false,
                 "num_fans" : 2,
                 "fans": [
                     {
@@ -97,6 +100,7 @@
             },
             {
                 "name": "FanTray4",
+                "max_consumed_power": false,
                 "num_fans" : 2,
                 "fans": [
                     {
@@ -109,6 +113,7 @@
             },
             {
                 "name": "FanTray5",
+                "max_consumed_power": false,
                 "num_fans" : 2,
                 "fans": [
                     {

--- a/device/accton/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json
@@ -4,7 +4,7 @@
         "num_psus":2,
         "num_fantrays":6,
         "num_fans_pertray":2,
-        "num_ports":58,
+        "num_ports":56,
         "num_temps": 5,
         "pddf_dev_types":
         {

--- a/device/accton/x86_64-accton_as7326_56x-r0/platform.json
+++ b/device/accton/x86_64-accton_as7326_56x-r0/platform.json
@@ -147,6 +147,7 @@
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -176,6 +177,7 @@
             },
             {
                 "name": "FanTray2",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -205,6 +207,7 @@
             },
             {
                 "name": "FanTray3",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -234,6 +237,7 @@
             },
             {
                 "name": "FanTray4",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -263,6 +267,7 @@
             },
             {
                 "name": "FanTray5",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -292,6 +297,7 @@
             },
             {
                 "name": "FanTray6",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },

--- a/device/accton/x86_64-accton_as7726_32x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/pddf/pddf-device.json
@@ -4,7 +4,7 @@
 		"num_psus":2,
 		"num_fantrays":6,
 		"num_fans_pertray":2,
-		"num_ports":34,
+		"num_ports":32,
 		"num_temps":10,
 		"pddf_dev_types":
 		{

--- a/device/accton/x86_64-accton_as7726_32x-r0/platform.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/platform.json
@@ -151,6 +151,7 @@
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -180,6 +181,7 @@
             },
             {
                 "name": "FanTray2",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -209,6 +211,7 @@
             },
             {
                 "name": "FanTray3",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -238,6 +241,7 @@
             },
             {
                 "name": "FanTray4",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -267,6 +271,7 @@
             },
             {
                 "name": "FanTray5",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -296,6 +301,7 @@
             },
             {
                 "name": "FanTray6",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },

--- a/device/accton/x86_64-accton_as9716_32d-r0/platform.json
+++ b/device/accton/x86_64-accton_as9716_32d-r0/platform.json
@@ -151,6 +151,7 @@
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -181,6 +182,7 @@
             },
             {
                 "name": "FanTray2",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -210,6 +212,7 @@
             },
             {
                 "name": "FanTray3",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -239,6 +242,7 @@
             },
             {
                 "name": "FanTray4",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -268,6 +272,7 @@
             },
             {
                 "name": "FanTray5",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -297,6 +302,7 @@
             },
             {
                 "name": "FanTray6",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },

--- a/device/accton/x86_64-accton_as9726_32d-r0/platform.json
+++ b/device/accton/x86_64-accton_as9726_32d-r0/platform.json
@@ -102,11 +102,12 @@
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "max_consumed_power": false,
                 "status_led": {
-		    "controllable": false
+                    "controllable": false
                 },
-		"num_fans" : 2,
-		"fans": [
+                "num_fans" : 2,
+                "fans": [
                     {
                         "name": "FAN-1F",
                         "status_led": {
@@ -123,10 +124,11 @@
             },
             {
                 "name": "FanTray2",
+                "max_consumed_power": false,
                 "status_led": {
-	             "controllable": false
+                    "controllable": false
                 },
-		"num_fans" : 2,
+                "num_fans" : 2,
                 "fans": [
                     {
                         "name": "FAN-2F",
@@ -144,6 +146,7 @@
             },
             {
                 "name": "FanTray3",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -165,6 +168,7 @@
             },
             {
                 "name": "FanTray4",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -186,8 +190,9 @@
             },
             {
                 "name": "FanTray5",
+                "max_consumed_power": false,
                 "status_led": {
-		    "controllable": false
+                    "controllable": false
                 },
                 "num_fans" : 2,
                 "fans": [
@@ -207,6 +212,7 @@
             },
             {
                 "name": "FanTray6",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },

--- a/device/accton/x86_64-accton_as9736_64d-r0/platform.json
+++ b/device/accton/x86_64-accton_as9736_64d-r0/platform.json
@@ -85,61 +85,89 @@
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "max_consumed_power": false,
                 "num_fans" : 2,
                 "status_led": {
                     "controllable": false
                 },
                 "fans": [
                     {
-                        "name": "FAN-1F"
+                        "name": "FAN-1F",
+                        "status_led": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-1R"
+                        "name": "FAN-1R",
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ]
             },
             {
                 "name": "FanTray2",
+                "max_consumed_power": false,
                 "num_fans" : 2,
                 "status_led": {
                     "controllable": false
                 },
                 "fans": [
                     {
-                        "name": "FAN-2F"
+                        "name": "FAN-2F",
+                        "status_led": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-2R"
+                        "name": "FAN-2R",
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ]
             },
             {
                 "name": "FanTray3",
+                "max_consumed_power": false,
                 "num_fans" : 2,
                 "status_led": {
                     "controllable": false
                 },
                 "fans": [
                     {
-                        "name": "FAN-3F"
+                        "name": "FAN-3F",
+                        "status_led": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-3R"
+                        "name": "FAN-3R",
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ]
             },
             {
                 "name": "FanTray4",
+                "max_consumed_power": false,
                 "num_fans" : 2,
                 "status_led": {
                     "controllable": false
                 },
                 "fans": [
                     {
-                        "name": "FAN-4F"
+                        "name": "FAN-4F",
+                        "status_led": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-4R"
+                        "name": "FAN-4R",
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ]
             }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- The below pytest cases are [**FAILED**] on some platforms.

**[AS4625-54T]**
```
test_chassis.py::TestChassisApi::test_get_name
test_chassis.py::TestChassisApi::test_status_led
test_fan_drawer.py::TestFanDrawerApi::test_set_fan_drawers_led
```

**[AS7326-56X]**
```
test_chassis.py::TestChassisApi::test_sfps
test_chassis_fans.py::TestChassisFans::test_set_fans_led
test_fan_drawer.py::TestFanDrawerApi::test_set_fan_drawers_led
test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_led
```

**[AS7726-32X]**
```
test_chassis.py::TestChassisApi::test_sfps
```

**[AS9736-64D]**
```
test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_led
```

**[AS4625-54P], [AS4625-54T], [AS4630-54PE], [AS4630-54TE], [AS4630-54NPE], [AS5835-54T], [AS5835-54X], [AS7326-56X], [AS7726-32X], [AS9716-32D], [AS9726-32D], [AS9736-64D]**
```
test_fan_drawer.py::TestFanDrawerApi::test_get_maximum_consumed_power
```

#### How I did it
1. Correct chassis `"name"` for test_get_name.
2. Add `"status_led"` settings for chassis for test_status_led.
3. Add `"status_led": {"controllable": false}` to skip test_set_fans_led/test_set_fan_drawers_led due to not support.
4. Correct `num_ports` for test_sfps.
5. Add `{"max_consumed_power": false}` to skip test_get_maximum_consumed_power due to not support.

#### How to verify it
- Run pytest cases are pass.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

