### PR TITLE
[ARP/ND] Enlarge gc thresholds in Linux kernel

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -450,6 +450,7 @@ sudo cp files/dhcp/dhclient.conf.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
 j2 files/dhcp/dhclient.conf.j2 | sudo tee $FILESYSTEM_ROOT/etc/dhcp/dhclient.conf
 sudo cp files/dhcp/ifupdown2_policy.json $FILESYSTEM_ROOT/etc/network/ifupdown2/policy.d
 sudo cp files/dhcp/90-dhcp6-systcl.conf.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
+sudo cp files/neighbor/91-gc-thresh-sysctl.conf.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
 
 # Copy DNS configuration files and templates
 sudo cp $IMAGE_CONFIGS/resolv-config/resolv-config.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM

--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -49,6 +49,7 @@ CFGGEN_PARAMS=" \
     -d -j /tmp/ztp_input.json \
     -t /usr/share/sonic/templates/interfaces.j2,/etc/network/interfaces \
     -t /usr/share/sonic/templates/90-dhcp6-systcl.conf.j2,/etc/sysctl.d/90-dhcp6-systcl.conf \
+    -t /usr/share/sonic/templates/91-gc-thresh-sysctl.conf.j2,/etc/sysctl.d/91-gc-thresh-sysctl.conf \
     -t /usr/share/sonic/templates/dhclient.conf.j2,/etc/dhcp/dhclient.conf \
 "
 sonic-cfggen $CFGGEN_PARAMS
@@ -64,6 +65,7 @@ done
 
 # Read sysctl conf files again
 sysctl -p /etc/sysctl.d/90-dhcp6-systcl.conf
+sysctl -p /etc/sysctl.d/91-gc-thresh-sysctl.conf
 
 systemctl restart networking
 

--- a/files/neighbor/91-gc-thresh-sysctl.conf.j2
+++ b/files/neighbor/91-gc-thresh-sysctl.conf.j2
@@ -1,0 +1,22 @@
+{% if DEVICE_METADATA.get('localhost', {}).get('hwsku', '') in ["Accton-AS9726-32D", "Accton-AS9726-32D-100G"] %}
+net.ipv4.neigh.default.gc_thresh1=294912
+net.ipv6.neigh.default.gc_thresh1=147456
+net.ipv4.neigh.default.gc_thresh2=294912
+net.ipv6.neigh.default.gc_thresh2=147456
+net.ipv4.neigh.default.gc_thresh3=294912
+net.ipv6.neigh.default.gc_thresh3=147456
+{% elif DEVICE_METADATA.get('localhost', {}).get('hwsku', '') in ["Accton-AS4625-54P", "Accton-AS4625-54T"] %}
+net.ipv4.neigh.default.gc_thresh1=32768
+net.ipv6.neigh.default.gc_thresh1=16384
+net.ipv4.neigh.default.gc_thresh2=32768
+net.ipv6.neigh.default.gc_thresh2=16384
+net.ipv4.neigh.default.gc_thresh3=32768
+net.ipv6.neigh.default.gc_thresh3=16384
+{% else %}
+net.ipv4.neigh.default.gc_thresh1=16384
+net.ipv6.neigh.default.gc_thresh1=8192
+net.ipv4.neigh.default.gc_thresh2=16384
+net.ipv6.neigh.default.gc_thresh2=8192
+net.ipv4.neigh.default.gc_thresh3=16384
+net.ipv6.neigh.default.gc_thresh3=8192
+{% endif %}


### PR DESCRIPTION
Enlarge gc_thresh1/2/3 in Linux kernel according to chip capacity

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

