### PR TITLE
[Sync PR]: Support to fetch pmon_daemon_control.json file from both platform and HWSKU folders (#18441)

### DIFF
--- a/dockers/docker-platform-monitor/docker_init.j2
+++ b/dockers/docker-platform-monitor/docker_init.j2
@@ -8,7 +8,6 @@ FANCONTROL_CONF_FILE="/usr/share/sonic/platform/fancontrol"
 
 SUPERVISOR_CONF_TEMPLATE="/usr/share/sonic/templates/docker-pmon.supervisord.conf.j2"
 SUPERVISOR_CONF_FILE="/etc/supervisor/conf.d/supervisord.conf"
-PMON_DAEMON_CONTROL_FILE="/usr/share/sonic/platform/pmon_daemon_control.json"
 MODULAR_CHASSISDB_CONF_FILE="/usr/share/sonic/platform/chassisdb.conf"
 
 HAVE_SENSORS_CONF=0
@@ -16,6 +15,13 @@ HAVE_FANCONTROL_CONF=0
 IS_MODULAR_CHASSIS=0
 # Default use python2 version
 SONIC_PLATFORM_API_PYTHON_VERSION=2
+
+if [ -e /usr/share/sonic/hwsku/pmon_daemon_control.json ];
+then
+    PMON_DAEMON_CONTROL_FILE="/usr/share/sonic/hwsku/pmon_daemon_control.json"
+else
+    PMON_DAEMON_CONTROL_FILE="/usr/share/sonic/platform/pmon_daemon_control.json"
+fi
 
 declare -r EXIT_SUCCESS="0"
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Sync PR#18441 due to sonic-platform-daemons PR#460.
- Support to get `pmon_daemon_control.json` file from both the platform folder and the SKU folder.
- It will search the HWSKU folder first and then fall back to the platform folder.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
