### PR TITLE
[Platform][AS9716-32D]: Add correct media_settings.json for HwSku Accton-AS9716-32D-100G

### DIFF
--- a/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D-100G/media_settings.json
+++ b/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D-100G/media_settings.json
@@ -1,0 +1,325 @@
+{
+    "PORT_MEDIA_SETTINGS": {
+        "0": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00187c08",
+                    "lane1": "0x00187c08",
+                    "lane2": "0x00187c08",
+                    "lane3": "0x00187c08"
+                }
+            }
+        },
+        "1": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00187808",
+                    "lane1": "0x00187c08",
+                    "lane2": "0x0014800c",
+                    "lane3": "0x00147c08"
+                }
+            }
+        },
+        "2": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00147c08",
+                    "lane1": "0x00147c08",
+                    "lane2": "0x00147c08",
+                    "lane3": "0x00147c08"
+                }
+            }
+        },
+        "3": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00187c08",
+                    "lane1": "0x00147c08",
+                    "lane2": "0x00147c08",
+                    "lane3": "0x00147c08"
+                }
+            }
+        },
+        "4": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00147c08",
+                    "lane1": "0x00147c08",
+                    "lane2": "0x00147c08",
+                    "lane3": "0x00147c08"
+                }
+            }
+        },
+        "5": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00147c08",
+                    "lane1": "0x001c7c08",
+                    "lane2": "0x00087c08",
+                    "lane3": "0x00147c08"
+                }
+            }
+        },
+        "6": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x000c8008",
+                    "lane1": "0x000c8008",
+                    "lane2": "0x000c8008",
+                    "lane3": "0x000c8008"
+                }
+            }
+        },
+        "7": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x000c7c08",
+                    "lane1": "0x00087c08",
+                    "lane2": "0x00087c08",
+                    "lane3": "0x000c7c08"
+                }
+            }
+        },
+        "8": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00187c08",
+                    "lane1": "0x00148010",
+                    "lane2": "0x00147c08",
+                    "lane3": "0x00107c08"
+                }
+            }
+        },
+        "9": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00147c0c",
+                    "lane1": "0x001c7408",
+                    "lane2": "0x00187408",
+                    "lane3": "0x0018780c"
+                }
+            }
+        },
+        "10": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x000c8008",
+                    "lane1": "0x00147408",
+                    "lane2": "0x00147c08",
+                    "lane3": "0x00108008"
+                }
+            }
+        },
+        "11": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00187c08",
+                    "lane1": "0x000c7c08",
+                    "lane2": "0x00107c08",
+                    "lane3": "0x00147408"
+                }
+            }
+        },
+        "12": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00088008",
+                    "lane1": "0x00088008",
+                    "lane2": "0x000c7c08",
+                    "lane3": "0x00087c08"
+                }
+            }
+        },
+        "13": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00087c08",
+                    "lane1": "0x00087c08",
+                    "lane2": "0x00087c08",
+                    "lane3": "0x00087c08"
+                }
+            }
+        },
+        "14": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00088008",
+                    "lane1": "0x00088008",
+                    "lane2": "0x00087c08",
+                    "lane3": "0x00087c08"
+                }
+            }
+        },
+        "15": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00087c08",
+                    "lane1": "0x00087c08",
+                    "lane2": "0x00087c08",
+                    "lane3": "0x00087c08"
+                }
+            }
+        },
+        "16": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00088008",
+                    "lane1": "0x00088008",
+                    "lane2": "0x00087c08",
+                    "lane3": "0x00087c08"
+                }
+            }
+        },
+        "17": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00087c08",
+                    "lane1": "0x000c7c08",
+                    "lane2": "0x00087c08",
+                    "lane3": "0x00087c08"
+                }
+            }
+        },
+        "18": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00088008",
+                    "lane1": "0x00088008",
+                    "lane2": "0x00087c08",
+                    "lane3": "0x00087c08"
+                }
+            }
+        },
+        "19": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00087c08",
+                    "lane1": "0x00087c08",
+                    "lane2": "0x00087c08",
+                    "lane3": "0x00047c08"
+                }
+            }
+        },
+        "20": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x000c8008",
+                    "lane1": "0x000c8008",
+                    "lane2": "0x00087c08",
+                    "lane3": "0x000c7c08"
+                }
+            }
+        },
+        "21": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00107c08",
+                    "lane1": "0x00147c08",
+                    "lane2": "0x000c7c08",
+                    "lane3": "0x000c7c08"
+                }
+            }
+        },
+        "22": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x000c8014",
+                    "lane1": "0x001c740c",
+                    "lane2": "0x00147808",
+                    "lane3": "0x001c8008"
+                }
+            }
+        },
+        "23": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x0024780c",
+                    "lane1": "0x00247410",
+                    "lane2": "0x0024780c",
+                    "lane3": "0x00187408"
+                }
+            }
+        },
+        "24": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00088008",
+                    "lane1": "0x000c8008",
+                    "lane2": "0x00087c08",
+                    "lane3": "0x000c7c08"
+                }
+            }
+        },
+        "25": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00087c08",
+                    "lane1": "0x000c7c08",
+                    "lane2": "0x000c7808",
+                    "lane3": "0x00107c08"
+                }
+            }
+        },
+        "26": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x000c8008",
+                    "lane1": "0x00107808",
+                    "lane2": "0x000c7c08",
+                    "lane3": "0x00108008"
+                }
+            }
+        },
+        "27": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00107c08",
+                    "lane1": "0x00147c08",
+                    "lane2": "0x00147c08",
+                    "lane3": "0x00107c08"
+                }
+            }
+        },
+        "28": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00188008",
+                    "lane1": "0x00108010",
+                    "lane2": "0x00187c04",
+                    "lane3": "0x00147c08"
+                }
+            }
+        },
+        "29": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00147c08",
+                    "lane1": "0x00147c08",
+                    "lane2": "0x00147c08",
+                    "lane3": "0x00147c08"
+                }
+            }
+        },
+        "30": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x000c8010",
+                    "lane1": "0x00187c08",
+                    "lane2": "0x00147c04",
+                    "lane3": "0x00147c08"
+                }
+            }
+        },
+        "31": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x00147c08",
+                    "lane1": "0x00187c08",
+                    "lane2": "0x00147c08",
+                    "lane3": "0x00187c08"
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Why I did it
- The syncd crashes with HwSku Accton-AS9716-32D-100G.
- And syslog has the error message: '`ERR syncd#syncd: [none] SAI_API_PORT:brcm_sai_create_port_serdes:9612 Port lane count 8 is different from supported lane count 4`'.

How I did it
- Add a correct media_settings.json file for HwSku Accton-AS9716-32D-100G based on community PR#460(repo. sonic-platform-daemons).
- For HwSku Accton-AS9716-32D, use the original media_settings.json file in platform folder.

How to verify it
- DUT can run syncd normally and syslog has not the error message.
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
