### PR TITLE
[AS9716-32D]Set psu fan speed not controllable

### DIFF
--- a/device/accton/x86_64-accton_as9716_32d-r0/platform.json
+++ b/device/accton/x86_64-accton_as9716_32d-r0/platform.json
@@ -341,6 +341,9 @@
                 "fans": [
                     {
                         "name": "PSU-1 FAN-1",
+			 "speed": {
+                            "controllable": false
+                        },
                         "status_led": {
                             "controllable": false
                         }
@@ -364,6 +367,9 @@
                 "fans": [
                     {
                         "name": "PSU-2 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
                         "status_led": {
                             "controllable": false
                         }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The PSU FAN speed is controlled by firmware.
#### How I did it
Set the controllable flag to False at AS9716-32D.
#### How to verify it
The psu fan speed related will be skipped in sonic-mgmt.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

