### PR TITLE
[Platform][AS9716-32D]: Update preemphasis by OPTICAL-25000 settings for HwSku Accton-AS9716-32D-100G.

### DIFF
--- a/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D-100G/media_settings.json
+++ b/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D-100G/media_settings.json
@@ -1,322 +1,322 @@
 {
     "PORT_MEDIA_SETTINGS": {
-        "0": {
-            "Default": {
-                "preemphasis": {
-                    "lane0": "0x00187c08",
-                    "lane1": "0x00187c08",
-                    "lane2": "0x00187c08",
-                    "lane3": "0x00187c08"
-                }
-            }
-        },
         "1": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00187808",
-                    "lane1": "0x00187c08",
-                    "lane2": "0x0014800c",
-                    "lane3": "0x00147c08"
+                    "lane0": "0x1c5904",
+                    "lane1": "0x1c5904",
+                    "lane2": "0x1a5704",
+                    "lane3": "0x165304"
                 }
             }
         },
         "2": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00147c08",
-                    "lane1": "0x00147c08",
-                    "lane2": "0x00147c08",
-                    "lane3": "0x00147c08"
+                    "lane0": "0x1a5906",
+                    "lane1": "0x1a5b06",
+                    "lane2": "0x1a5706",
+                    "lane3": "0x1c5b06"
                 }
             }
         },
         "3": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00187c08",
-                    "lane1": "0x00147c08",
-                    "lane2": "0x00147c08",
-                    "lane3": "0x00147c08"
+                    "lane0": "0x165304",
+                    "lane1": "0x164f04",
+                    "lane2": "0x165504",
+                    "lane3": "0x185504"
                 }
             }
         },
         "4": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00147c08",
-                    "lane1": "0x00147c08",
-                    "lane2": "0x00147c08",
-                    "lane3": "0x00147c08"
+                    "lane0": "0x1c5b06",
+                    "lane1": "0x1a5706",
+                    "lane2": "0x1a5706",
+                    "lane3": "0x1a5906"
                 }
             }
         },
         "5": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00147c08",
-                    "lane1": "0x001c7c08",
-                    "lane2": "0x00087c08",
-                    "lane3": "0x00147c08"
+                    "lane0": "0x185504",
+                    "lane1": "0x185504",
+                    "lane2": "0x165104",
+                    "lane3": "0x165104"
                 }
             }
         },
         "6": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x000c8008",
-                    "lane1": "0x000c8008",
-                    "lane2": "0x000c8008",
-                    "lane3": "0x000c8008"
+                    "lane0": "0x144d04",
+                    "lane1": "0x1c5b06",
+                    "lane2": "0x124f06",
+                    "lane3": "0x1c5b06"
                 }
             }
         },
         "7": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x000c7c08",
-                    "lane1": "0x00087c08",
-                    "lane2": "0x00087c08",
-                    "lane3": "0x000c7c08"
+                    "lane0": "0x104904",
+                    "lane1": "0x104904",
+                    "lane2": "0x104904",
+                    "lane3": "0x104904"
                 }
             }
         },
         "8": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00187c08",
-                    "lane1": "0x00148010",
-                    "lane2": "0x00147c08",
-                    "lane3": "0x00107c08"
+                    "lane0": "0x104904",
+                    "lane1": "0x104904",
+                    "lane2": "0x104b04",
+                    "lane3": "0x104b04"
                 }
             }
         },
         "9": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00147c0c",
-                    "lane1": "0x001c7408",
-                    "lane2": "0x00187408",
-                    "lane3": "0x0018780c"
+                    "lane0": "0x185104",
+                    "lane1": "0x185504",
+                    "lane2": "0x164f04",
+                    "lane3": "0x144d04"
                 }
             }
         },
         "10": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x000c8008",
-                    "lane1": "0x00147408",
-                    "lane2": "0x00147c08",
-                    "lane3": "0x00108008"
+                    "lane0": "0x1a5906",
+                    "lane1": "0x1c5b06",
+                    "lane2": "0x1c5b06",
+                    "lane3": "0x1c5b06"
                 }
             }
         },
         "11": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00187c08",
-                    "lane1": "0x000c7c08",
-                    "lane2": "0x00107c08",
-                    "lane3": "0x00147408"
+                    "lane0": "0x144d04",
+                    "lane1": "0x165304",
+                    "lane2": "0x165104",
+                    "lane3": "0x164d04"
                 }
             }
         },
         "12": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00088008",
-                    "lane1": "0x00088008",
-                    "lane2": "0x000c7c08",
-                    "lane3": "0x00087c08"
+                    "lane0": "0x185104",
+                    "lane1": "0x165104",
+                    "lane2": "0x185304",
+                    "lane3": "0x185304"
                 }
             }
         },
         "13": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00087c08",
-                    "lane1": "0x00087c08",
-                    "lane2": "0x00087c08",
-                    "lane3": "0x00087c08"
+                    "lane0": "0x0c4104",
+                    "lane1": "0x0e4504",
+                    "lane2": "0x0e4304",
+                    "lane3": "0x0e4104"
                 }
             }
         },
         "14": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00088008",
-                    "lane1": "0x00088008",
-                    "lane2": "0x00087c08",
-                    "lane3": "0x00087c08"
+                    "lane0": "0x104504",
+                    "lane1": "0x0e4704",
+                    "lane2": "0x0e4504",
+                    "lane3": "0x0e4704"
                 }
             }
         },
         "15": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00087c08",
-                    "lane1": "0x00087c08",
-                    "lane2": "0x00087c08",
-                    "lane3": "0x00087c08"
+                    "lane0": "0x0c3f04",
+                    "lane1": "0x0e4704",
+                    "lane2": "0x0e4304",
+                    "lane3": "0x0e4304"
                 }
             }
         },
         "16": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00088008",
-                    "lane1": "0x00088008",
-                    "lane2": "0x00087c08",
-                    "lane3": "0x00087c08"
+                    "lane0": "0x104704",
+                    "lane1": "0x104704",
+                    "lane2": "0x104904",
+                    "lane3": "0x104904"
                 }
             }
         },
         "17": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00087c08",
-                    "lane1": "0x000c7c08",
-                    "lane2": "0x00087c08",
-                    "lane3": "0x00087c08"
+                    "lane0": "0x0e4304",
+                    "lane1": "0x0e4504",
+                    "lane2": "0x0e4304",
+                    "lane3": "0x0e4304"
                 }
             }
         },
         "18": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00088008",
-                    "lane1": "0x00088008",
-                    "lane2": "0x00087c08",
-                    "lane3": "0x00087c08"
+                    "lane0": "0x124b04",
+                    "lane1": "0x124b04",
+                    "lane2": "0x104704",
+                    "lane3": "0x104704"
                 }
             }
         },
         "19": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00087c08",
-                    "lane1": "0x00087c08",
-                    "lane2": "0x00087c08",
-                    "lane3": "0x00047c08"
+                    "lane0": "0x0e4304",
+                    "lane1": "0x0e4904",
+                    "lane2": "0x0e4504",
+                    "lane3": "0x0e4704"
                 }
             }
         },
         "20": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x000c8008",
-                    "lane1": "0x000c8008",
-                    "lane2": "0x00087c08",
-                    "lane3": "0x000c7c08"
+                    "lane0": "0x0e4304",
+                    "lane1": "0x0e4304",
+                    "lane2": "0x0e4504",
+                    "lane3": "0x0e4704"
                 }
             }
         },
         "21": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00107c08",
-                    "lane1": "0x00147c08",
-                    "lane2": "0x000c7c08",
-                    "lane3": "0x000c7c08"
+                    "lane0": "0x104b04",
+                    "lane1": "0x104b04",
+                    "lane2": "0x124b04",
+                    "lane3": "0x124b04"
                 }
             }
         },
         "22": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x000c8014",
-                    "lane1": "0x001c740c",
-                    "lane2": "0x00147808",
-                    "lane3": "0x001c8008"
+                    "lane0": "0x164f04",
+                    "lane1": "0x165104",
+                    "lane2": "0x144d04",
+                    "lane3": "0x144f04"
                 }
             }
         },
         "23": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x0024780c",
-                    "lane1": "0x00247410",
-                    "lane2": "0x0024780c",
-                    "lane3": "0x00187408"
+                    "lane0": "0x185104",
+                    "lane1": "0x1c5908",
+                    "lane2": "0x1a5308",
+                    "lane3": "0x1c5908"
                 }
             }
         },
         "24": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00088008",
-                    "lane1": "0x000c8008",
-                    "lane2": "0x00087c08",
-                    "lane3": "0x000c7c08"
+                    "lane0": "0x1c5b06",
+                    "lane1": "0x1c5b06",
+                    "lane2": "0x1c5b06",
+                    "lane3": "0x1c5b06"
                 }
             }
         },
         "25": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00087c08",
-                    "lane1": "0x000c7c08",
-                    "lane2": "0x000c7808",
-                    "lane3": "0x00107c08"
+                    "lane0": "0x104904",
+                    "lane1": "0x104904",
+                    "lane2": "0x104904",
+                    "lane3": "0x104b04"
                 }
             }
         },
         "26": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x000c8008",
-                    "lane1": "0x00107808",
-                    "lane2": "0x000c7c08",
-                    "lane3": "0x00108008"
+                    "lane0": "0x144d04",
+                    "lane1": "0x144d04",
+                    "lane2": "0x144d04",
+                    "lane3": "0x144f04"
                 }
             }
         },
         "27": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00107c08",
-                    "lane1": "0x00147c08",
-                    "lane2": "0x00147c08",
-                    "lane3": "0x00107c08"
+                    "lane0": "0x144d04",
+                    "lane1": "0x165104",
+                    "lane2": "0x144d04",
+                    "lane3": "0x185304"
                 }
             }
         },
         "28": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00188008",
-                    "lane1": "0x00108010",
-                    "lane2": "0x00187c04",
-                    "lane3": "0x00147c08"
+                    "lane0": "0x165104",
+                    "lane1": "0x165104",
+                    "lane2": "0x1a5304",
+                    "lane3": "0x144d04"
                 }
             }
         },
         "29": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00147c08",
-                    "lane1": "0x00147c08",
-                    "lane2": "0x00147c08",
-                    "lane3": "0x00147c08"
+                    "lane0": "0x1a5704",
+                    "lane1": "0x185304",
+                    "lane2": "0x1a5304",
+                    "lane3": "0x1c5504"
                 }
             }
         },
         "30": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x000c8010",
-                    "lane1": "0x00187c08",
-                    "lane2": "0x00147c04",
-                    "lane3": "0x00147c08"
+                    "lane0": "0x185706",
+                    "lane1": "0x1a5504",
+                    "lane2": "0x185506",
+                    "lane3": "0x1a5504"
                 }
             }
         },
         "31": {
             "Default": {
                 "preemphasis": {
-                    "lane0": "0x00147c08",
-                    "lane1": "0x00187c08",
-                    "lane2": "0x00147c08",
-                    "lane3": "0x00187c08"
+                    "lane0": "0x185304",
+                    "lane1": "0x1a5504",
+                    "lane2": "0x185306",
+                    "lane3": "0x1a5504"
+                }
+            }
+        },
+        "32": {
+            "Default": {
+                "preemphasis": {
+                    "lane0": "0x1c5704",
+                    "lane1": "0x1c5704",
+                    "lane2": "0x1b5704",
+                    "lane3": "0x1c5b06"
                 }
             }
         }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- Original pre-emphasis setting is for OPTICAL-50000, but not OPTICAL-25000.

#### How I did it
- Correct the pre-emphasis values for OPTICAL-25000.

#### How to verify it
- In testbed environment, ports can link-up normally.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

