### PR TITLE
Support SFP Reset on AS5835-54X

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/sfp.py
@@ -25,6 +25,12 @@ class Sfp(PddfSfp):
         0xe1  # QSFP28 EDFA
     ]
 
+    UNRESETTABLE_TYPE_LIST = [
+        'SFP',
+        'SFP+',
+        'SFP28'
+    ]
+
     def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
         PddfSfp.__init__(self, index, pddf_data, pddf_plugin_data)
         self.index = index + 1
@@ -195,3 +201,25 @@ class Sfp(PddfSfp):
         except NotImplementedError:
             pass
         return self.__get_error_description()
+
+    def get_reset_status(self):
+        """
+        Retrieves the reset status of SFP
+
+        Returns:
+            A Boolean, True if reset enabled, False if disabled
+        """
+        if self.sfp_type in self.UNRESETTABLE_TYPE_LIST:
+            return False
+        return super().get_reset_status()
+
+    def reset(self):
+        """
+        Reset SFP and return all user module settings to their default srate.
+
+        Returns:
+            A boolean, True if successful, False if not
+        """
+        if self.sfp_type in self.UNRESETTABLE_TYPE_LIST:
+            return False
+        return super().reset()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
SFP reset function is not supported.
#### How I did it
Impl SFP reset function.
#### How to verify it
Run sonic-mgmt/tests/platform_tests/api/test_sfp.py ::TestSfpApi::test_rest passed.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

