### PR TITLE
[AS9716-32D] Change the order of matching for the revision of pcie.yaml

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/pcie.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/pcie.py
@@ -46,7 +46,7 @@ class Pcie(PcieUtil):
 
                 label_rev = results[2].decode('ascii')
 
-                for rev in (label_rev[:-1], label_rev):
+                for rev in (label_rev, label_rev[:-1]):
                     pcie_yaml_file = os.path.join(self.config_path, f"pcie_{rev}.yaml")
                     if os.path.exists(pcie_yaml_file):
                         return rev


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The pcie_R01B.yaml should be matched first, followed by pcie_R01.yaml.

#### How I did it
Change the order of matching for the revision of pcie.yaml

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

