### PR TITLE
[Platform][AS5835-54X] Fix sonic-mgmt pytest fail for chassis_fans, fan_drawer, and fan_drawer_fans

### DIFF
--- a/device/accton/x86_64-accton_as5835_54x-r0/platform.json
+++ b/device/accton/x86_64-accton_as5835_54x-r0/platform.json
@@ -28,34 +28,64 @@
         ],
         "fans": [
             {
-                "name": "FAN-1F"
+                "name": "FAN-1F",
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-1R"
+                "name": "FAN-1R",
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-2F"
+                "name": "FAN-2F",
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-2R"
+                "name": "FAN-2R",
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-3F"
+                "name": "FAN-3F",
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-3R"
+                "name": "FAN-3R",
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-4F"
+                "name": "FAN-4F",
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-4R"
+                "name": "FAN-4R",
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-5F"
+                "name": "FAN-5F",
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-5R"
+                "name": "FAN-5R",
+                "status_led": {
+                    "controllable": false
+                }
             }
         ],
         "fan_drawers":[
@@ -63,12 +93,21 @@
                 "name": "FanTray1",
                 "max_consumed_power": false,
                 "num_fans" : 2,
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
-                        "name": "FAN-1F"
+                        "name": "FAN-1F",
+                        "status_led": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-1R"
+                        "name": "FAN-1R",
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ]
             },
@@ -76,12 +115,21 @@
                 "name": "FanTray2",
                 "max_consumed_power": false,
                 "num_fans" : 2,
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
-                        "name": "FAN-2F"
+                        "name": "FAN-2F",
+                        "status_led": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-2R"
+                        "name": "FAN-2R",
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ]
             },
@@ -89,12 +137,21 @@
                 "name": "FanTray3",
                 "max_consumed_power": false,
                 "num_fans" : 2,
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
-                        "name": "FAN-3F"
+                        "name": "FAN-3F",
+                        "status_led": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-3R"
+                        "name": "FAN-3R",
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ]
             },
@@ -102,12 +159,21 @@
                 "name": "FanTray4",
                 "max_consumed_power": false,
                 "num_fans" : 2,
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
-                        "name": "FAN-4F"
+                        "name": "FAN-4F",
+                        "status_led": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-4R"
+                        "name": "FAN-4R",
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ]
             },
@@ -115,12 +181,21 @@
                 "name": "FanTray5",
                 "max_consumed_power": false,
                 "num_fans" : 2,
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
-                        "name": "FAN-5F"
+                        "name": "FAN-5F",
+                        "status_led": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-5R"
+                        "name": "FAN-5R",
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ]
             }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- Fix pytest fail:
  - platform_tests/api/test_chassis_fans.py::TestChassisFans::test_set_fans_led
  - platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_set_fan_drawers_led
  - platform_tests/api/test_fan_drawer_fans.py::TestFanDrawerFans::test_set_fans_led

#### How I did it
- Add `'controllable'=false` in platform.json to fix these failures because platform does not support.

#### How to verify it
- Run pytest cases is pass.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

