### PR TITLE
[Platform][AS9716-32D] Fix sonic-mgmt pytest test_chassis.py::testChassisApi::test_sfps fail

### DIFF
--- a/device/accton/x86_64-accton_as9716_32d-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as9716_32d-r0/pddf/pddf-device.json
@@ -4,7 +4,7 @@
         "num_psus":2,
         "num_fantrays":6,
         "num_fans_pertray":2,
-        "num_ports":34,
+        "num_ports": 32,
         "num_temps": 12,
         "pddf_dev_types":
         {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- platform_tests/api/test_chassis.py::TestChassisApi::test_sfps
  - Failed: Number of sfps (34) does not match expected number (32)
    - Wrong ‘num_ports’ value = 34 in pddf-device.json.

#### How I did it
- Change ‘num_ports’ value = 32 in pddf-device.json.

#### How to verify it
- Run pytest case is pass.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

