### PR TITLE
JIRA-SONIC-9824: Add retry for pulling k8s when building the SONiC image

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -798,8 +798,33 @@ sudo LANG=C DOCKER_HOST="$DOCKER_HOST" chroot $FILESYSTEM_ROOT /usr/local/bin/ge
 {% if include_kubernetes == "y" %}
 ## Pull in kubernetes docker images
 echo "pulling universal k8s images ..."
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT docker $SONIC_NATIVE_DOCKERD_FOR_DOCKERFS pull k8s.gcr.io/pause:${K8s_GCR_IO_PAUSE_VERSION}
-echo "docker images pull complete"
+
+MAX_ATTEMPTS=5
+RETRY_INTERVAL=10
+attempt=1
+
+# skip Exit immediately due to error retry
+set +e
+while [ $attempt -le $MAX_ATTEMPTS ]; do
+    output=$(sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT docker $SONIC_NATIVE_DOCKERD_FOR_DOCKERFS pull k8s.gcr.io/pause:${K8s_GCR_IO_PAUSE_VERSION} 2>&1)
+    exit_status=$?
+    if [ $exit_status -eq 0 ]; then
+        echo "docker images pull complete"
+        break
+    else
+        echo "Failed to pull Docker image. Error message:"
+        echo "$output"
+        echo "Retrying in $RETRY_INTERVAL seconds..."
+        sleep $RETRY_INTERVAL
+    fi
+
+    attempt=$(( $attempt + 1 ))
+done
+set -e
+if [ $attempt -gt $MAX_ATTEMPTS ]; then
+    echo "Failed to pull Docker image after $MAX_ATTEMPTS attempts."
+    exit 1
+fi
 {% endif %}
 
 {% if include_kubernetes_master == "y" %}


### PR DESCRIPTION
Pulling universal k8s images is not stable. It sometimes fails. Add retry to fix build image failure.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

