### PR TITLE
[Platform][AS9817-64D/64O][AIS800-64D/64O] Fix sonic-mgmt pytest test_fan_drawer.py::TestFanDrawerApi::test_get_maximum_consumed_power fail

### DIFF
--- a/device/accton/x86_64-accton_as9817_64d-r0/platform.json
+++ b/device/accton/x86_64-accton_as9817_64d-r0/platform.json
@@ -108,6 +108,7 @@
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -137,6 +138,7 @@
             },
             {
                 "name": "FanTray2",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -166,6 +168,7 @@
             },
             {
                 "name": "FanTray3",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -195,6 +198,7 @@
             },
             {
                 "name": "FanTray4",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },

--- a/device/accton/x86_64-accton_as9817_64d-r0/platform.json.ais800
+++ b/device/accton/x86_64-accton_as9817_64d-r0/platform.json.ais800
@@ -108,6 +108,7 @@
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -137,6 +138,7 @@
             },
             {
                 "name": "FanTray2",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -166,6 +168,7 @@
             },
             {
                 "name": "FanTray3",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -195,6 +198,7 @@
             },
             {
                 "name": "FanTray4",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },

--- a/device/accton/x86_64-accton_as9817_64d-r0/platform.json.as9817
+++ b/device/accton/x86_64-accton_as9817_64d-r0/platform.json.as9817
@@ -108,6 +108,7 @@
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -137,6 +138,7 @@
             },
             {
                 "name": "FanTray2",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -166,6 +168,7 @@
             },
             {
                 "name": "FanTray3",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -195,6 +198,7 @@
             },
             {
                 "name": "FanTray4",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },

--- a/device/accton/x86_64-accton_as9817_64o-r0/platform.json
+++ b/device/accton/x86_64-accton_as9817_64o-r0/platform.json
@@ -108,6 +108,7 @@
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -137,6 +138,7 @@
             },
             {
                 "name": "FanTray2",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -166,6 +168,7 @@
             },
             {
                 "name": "FanTray3",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -195,6 +198,7 @@
             },
             {
                 "name": "FanTray4",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },

--- a/device/accton/x86_64-accton_as9817_64o-r0/platform.json.ais800
+++ b/device/accton/x86_64-accton_as9817_64o-r0/platform.json.ais800
@@ -108,6 +108,7 @@
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -137,6 +138,7 @@
             },
             {
                 "name": "FanTray2",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -166,6 +168,7 @@
             },
             {
                 "name": "FanTray3",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -195,6 +198,7 @@
             },
             {
                 "name": "FanTray4",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },

--- a/device/accton/x86_64-accton_as9817_64o-r0/platform.json.as9817
+++ b/device/accton/x86_64-accton_as9817_64o-r0/platform.json.as9817
@@ -108,6 +108,7 @@
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -137,6 +138,7 @@
             },
             {
                 "name": "FanTray2",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -166,6 +168,7 @@
             },
             {
                 "name": "FanTray3",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -195,6 +198,7 @@
             },
             {
                 "name": "FanTray4",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- platform_tests/api/test_fan_drawer.py::TestFanDrawerApi::test_get_maximum_consumed_power
  - `Failed: Unable to retrieve module 0 slot id, Unable to retrieve module 1 slot id, Unable to retrieve module 2 slot id, Unable to retrieve module 3 slot id`

#### How I did it
- Add `{"max_consumed_power": false}` to skip test_get_maximum_consumed_power due to HW not support.

#### How to verify it
- Run pytest case is pass.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

