### PR TITLE
JRTC-20911: Revise 'syncd.sh' to remove the command to start 'pmon.timer' which had been removed

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -90,20 +90,10 @@ function startplatform() {
 
 function waitplatform() {
 
-    BOOT_TYPE=`getBootType`
     if [[ x"$sonic_asic_platform" == x"mellanox" ]] || [[ x"$sonic_asic_platform" == x"broadcom" ]]; then
-        if [[ x"$BOOT_TYPE" = @(x"fast"|x"warm"|x"fastfast") ]]; then
-            PMON_TIMER_STATUS=$(systemctl is-active pmon.timer)
-            if [[ x"$PMON_TIMER_STATUS" = x"inactive" ]]; then
-                systemctl start pmon.timer
-            else
-                debug "PMON service is delayed by a timer for better fast/warm boot performance"
-            fi
-        else
-            debug "Starting pmon service..."
-            /bin/systemctl start pmon
-            debug "Started pmon service"
-        fi
+        debug "Starting pmon service..."
+        /bin/systemctl start pmon
+        debug "Started pmon service"
     fi
 }
 


### PR DESCRIPTION
JRTC-20911: Revise 'syncd.sh' to remove the command to start 'pmon.timer' which had been removed

pmon.timer had been removed in 'commit
2804998766ffebb35d4ca5e8d55c2d553bfce1e4'
Refer to the community PR on sonic-buildimage ([Mellanox] Remove pmon delay for certain platforms (#19190))
    https://github.com/sonic-net/sonic-buildimage/commit/6968aaa85d37b6d83549d0d4ea25c56d16f7207f
    https://github.com/sonic-net/sonic-buildimage/blob/6968aaa85d37b6d83549d0d4ea25c56d16f7207f/files/scripts/syncd.sh#L102

The line 'systemctl start pmon.timer' had been removed from the function 'waitplatform()' in 'files/scripts/syncd.sh'

NOTE: In commit 641434bac9d019c54a543290ffc2cd8bbd2237da, it turns off the delay of pmon upon system boot up.
