### PR TITLE
[AS5835-54T/X] Change the fan direction of the YM-1401A-CR/BR PSU.

### DIFF
--- a/device/accton/x86_64-accton_as5835_54x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as5835_54x-r0/pddf/pddf-device.json
@@ -165,7 +165,6 @@
             "attr_list": 
             [  
                 { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x1", "attr_cmpval":"0x0", "attr_len":"1"},
-                { "attr_name":"psu_model_name", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
                 { "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x2", "attr_cmpval":"0x2", "attr_len":"1"},
                 { "attr_name":"psu_mfr_id", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
                 { "attr_name":"psu_fan_dir", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
@@ -189,7 +188,8 @@
             "topo_info":{ "parent_bus":"0xb", "dev_addr":"0x50", "dev_type":"psu_eeprom"},
             "attr_list": 
             [  
-                { "attr_name":"psu_serial_num", "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"19" }
+                { "attr_name":"psu_serial_num", "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"19" },
+		{ "attr_name":"psu_model_name", "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x20", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"12" }
             ]
         }
     },
@@ -217,7 +217,6 @@
             "attr_list": 
             [  
                 { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x10", "attr_cmpval":"0x0", "attr_len":"1"},
-                { "attr_name":"psu_model_name", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x9a", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
                 { "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x2", "attr_mask":"0x20", "attr_cmpval":"0x20", "attr_len":"1"},
                 { "attr_name":"psu_mfr_id", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0X99", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"10" },
                 { "attr_name":"psu_fan_dir", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0xc3", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"5"},
@@ -241,7 +240,8 @@
             "topo_info":{ "parent_bus":"0xc", "dev_addr":"0x53", "dev_type":"psu_eeprom"},
             "attr_list": 
             [  
-                { "attr_name":"psu_serial_num", "attr_devaddr":"0x53", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"19" }
+                { "attr_name":"psu_serial_num", "attr_devaddr":"0x53", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"19" },
+		{ "attr_name":"psu_model_name", "attr_devaddr":"0x53", "attr_devtype":"eeprom", "attr_offset":"0x20", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"12" }
             ]
         }
     },

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/modules/pddf_custom_psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/modules/pddf_custom_psu.c
@@ -9,10 +9,31 @@
 #include <linux/sysfs.h>
 #include <linux/slab.h>
 #include <linux/dmi.h>
+#include "pddf_client_defs.h"
 #include "pddf_psu_defs.h"
+#include "pddf_psu_driver.h"
+#include "pddf_psu_api.h"
 
 ssize_t pddf_show_custom_psu_v_out(struct device *dev, struct device_attribute *da, char *buf);
 extern PSU_SYSFS_ATTR_DATA access_psu_v_out;
+int pddf_post_get_custom_psu_model_name(void *i2c_client, PSU_DATA_ATTR *adata, void *data);
+extern PSU_SYSFS_ATTR_DATA access_psu_model_name;
+int pddf_post_get_custom_psu_fan_dir(void *i2c_client, PSU_DATA_ATTR *adata, void *data);
+extern PSU_SYSFS_ATTR_DATA access_psu_fan_dir;
+int pddf_custom_psu_post_probe(struct i2c_client *client, const struct i2c_device_id *dev_id);
+int pddf_custom_psu_post_remove(struct i2c_client *client);
+extern struct pddf_ops_t pddf_psu_ops;
+
+const char FAN_DIR_F2B[] = "F2B\0";
+const char FAN_DIR_B2F[] = "B2F\0";
+
+static LIST_HEAD(psu_eeprom_client_list);
+static struct mutex     list_lock;
+
+struct psu_eeprom_client_node {
+	struct i2c_client *client;
+	struct list_head   list;
+};
 
 static int two_complement_to_int(u16 data, u8 valid_bit, int mask)
 {
@@ -94,12 +115,172 @@ ssize_t pddf_show_custom_psu_v_out(struct device *dev, struct device_attribute *
 		return sprintf(buf, "%d\n", (mantissa * multiplier) / (1 << -exponent));
 }
 
+int pddf_post_get_custom_psu_model_name(void *i2c_client, PSU_DATA_ATTR *adata, void *data)
+{
+    struct psu_attr_info *sysfs_attr_info = (struct psu_attr_info *)data;
 
+    if (strlen(sysfs_attr_info->val.strval) > 8) {
+        sysfs_attr_info->val.strval[8] = '-';
+    }
+
+    return 0;
+}
+
+/*
+ * Get the PSU EEPROM I2C client with the same bus number.
+ */
+static struct i2c_client *find_psu_eeprom_client(struct i2c_client *pmbus_client)
+{
+    struct list_head *list_node = NULL;
+    struct psu_eeprom_client_node *psu_eeprom_node = NULL;
+    struct i2c_client *eeprom_client = NULL;
+
+    mutex_lock(&list_lock);
+    list_for_each(list_node, &psu_eeprom_client_list) {
+        psu_eeprom_node = list_entry(list_node, struct psu_eeprom_client_node, list);
+        /* Check if the bus adapter is the same or not. */
+        if (psu_eeprom_node->client->adapter == pmbus_client->adapter) {
+            eeprom_client = psu_eeprom_node->client;
+            break;
+        }
+    }
+    mutex_unlock(&list_lock);
+
+    return eeprom_client;
+}
+
+/*
+ * Compare the model name, then replace the content of psu_fan_dir.
+ */
+const char *fan_b2f_models[] = {
+    "YM-2401H-DR",
+    "YM-1401A-CR",
+    NULL
+};
+
+const char *fan_f2b_models[] = {
+    "YM-2401H-CR",
+    "YM-1401A-BR",
+    NULL
+};
+
+int pddf_post_get_custom_psu_fan_dir(void *i2c_client, PSU_DATA_ATTR *adata, void *data)
+{
+    int i;
+    struct i2c_client *client = (struct i2c_client *)i2c_client;
+    struct psu_attr_info *psu_fan_dir_attr_info = (struct psu_attr_info *)data;
+    struct psu_data *psu_eeprom_client_data = NULL;
+    struct psu_attr_info *psu_eeprom_model_name = NULL;
+    struct i2c_client *psu_eeprom_client = NULL;
+
+    psu_eeprom_client = find_psu_eeprom_client(client);
+    if (!psu_eeprom_client) {
+        return 0;
+    }
+
+    /*
+     * Get the model name from the PSU EEPROM I2C client.
+     */
+    psu_eeprom_client_data = i2c_get_clientdata(psu_eeprom_client);
+    if (!psu_eeprom_client_data) {
+        return 0;
+    }
+    for (i = 0; i < psu_eeprom_client_data->num_attr; i++) {
+        if (strcmp(psu_eeprom_client_data->attr_info[i].name, "psu_model_name") == 0) {
+            psu_eeprom_model_name = &psu_eeprom_client_data->attr_info[i];
+            break;
+        }
+    }
+    if (!psu_eeprom_model_name) {
+        return 0;
+    }
+
+    /*
+     * Compare the model name, then replace the content of psu_fan_dir.
+     */
+    /* Check for B2F models */
+    for (i = 0; fan_b2f_models[i] != NULL; i++) {
+        if (strcmp(psu_eeprom_model_name->val.strval, fan_b2f_models[i]) == 0) {
+            strscpy(psu_fan_dir_attr_info->val.strval, 
+                    FAN_DIR_B2F, 
+                    sizeof(psu_fan_dir_attr_info->val.strval));
+	    /* Match found in B2F models, exit early */
+            return 0;
+        }
+    }
+
+    /* If not found in B2F models, check F2B models */
+    for (i = 0; fan_f2b_models[i] != NULL; i++) {
+        if (strcmp(psu_eeprom_model_name->val.strval, fan_f2b_models[i]) == 0) {
+            strscpy(psu_fan_dir_attr_info->val.strval, 
+                    FAN_DIR_F2B, 
+                    sizeof(psu_fan_dir_attr_info->val.strval));
+            break;
+        }
+    }
+
+    return 0;
+}
+
+int pddf_custom_psu_post_probe(struct i2c_client *client, const struct i2c_device_id *dev_id)
+{
+    struct psu_eeprom_client_node *psu_eeprom_node;
+
+    if (strcmp(dev_id->name, "psu_eeprom") != 0) {
+        return 0;
+    }
+
+    psu_eeprom_node = kzalloc(sizeof(struct psu_eeprom_client_node), GFP_KERNEL);
+    if (!psu_eeprom_node) {
+        dev_dbg(&client->dev, "Can't allocate psu_eeprom_client_node (0x%x)\n", client->addr);
+        return -ENOMEM;
+    }
+
+    psu_eeprom_node->client = client;
+
+    mutex_lock(&list_lock);
+    list_add(&psu_eeprom_node->list, &psu_eeprom_client_list);
+    mutex_unlock(&list_lock);
+
+    return 0;
+}
+
+int pddf_custom_psu_post_remove(struct i2c_client *client)
+{
+    struct list_head    *list_node = NULL;
+    struct psu_eeprom_client_node *psu_eeprom_node = NULL;
+    int found = 0;
+
+    mutex_lock(&list_lock);
+
+    list_for_each(list_node, &psu_eeprom_client_list) {
+        psu_eeprom_node = list_entry(list_node, struct psu_eeprom_client_node, list);
+
+        if (psu_eeprom_node->client == client) {
+            list_del_init(&psu_eeprom_node->list);
+            found = 1;
+            break;
+        }
+    }
+
+    if (found) {
+        kfree(psu_eeprom_node);
+    }
+
+    mutex_unlock(&list_lock);
+
+    return 0;
+}
 
 static int __init pddf_custom_psu_init(void)
 {
+    mutex_init(&list_lock);
     access_psu_v_out.show = pddf_show_custom_psu_v_out;
     access_psu_v_out.do_get = NULL;
+    access_psu_model_name.post_get = pddf_post_get_custom_psu_model_name;
+    access_psu_fan_dir.post_get = pddf_post_get_custom_psu_fan_dir;
+    pddf_psu_ops.post_probe = pddf_custom_psu_post_probe;
+    pddf_psu_ops.post_remove = pddf_custom_psu_post_remove;
     return 0;
 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

PSU-[1,2] FAN-1 direction exhaust is not aligned with FAN-1F direction intake

```
admin@sonic:~$ show platform fan
  Drawer    LED          FAN    Speed    Direction    Presence    Status          Timestamp
--------  -----  -----------  -------  -----------  ----------  --------  -----------------
FanTray1  green       FAN-1F      45%       intake     Present        OK  20240715 06:25:39
FanTray1  green       FAN-1R      45%       intake     Present        OK  20240715 06:25:39
FanTray2  green       FAN-2F      45%       intake     Present        OK  20240715 06:25:39
FanTray2  green       FAN-2R      45%       intake     Present        OK  20240715 06:25:39
FanTray3  green       FAN-3F      45%       intake     Present        OK  20240715 06:25:39
FanTray3  green       FAN-3R      46%       intake     Present        OK  20240715 06:25:39
FanTray4  green       FAN-4F      45%       intake     Present        OK  20240715 06:25:39
FanTray4  green       FAN-4R      45%       intake     Present        OK  20240715 06:25:40
FanTray5  green       FAN-5F      45%       intake     Present        OK  20240715 06:25:40
FanTray5  green       FAN-5R      45%       intake     Present        OK  20240715 06:25:40
     N/A    red  PSU-1 FAN-1      N/A          N/A     Present    Not OK  20240715 06:25:40
     N/A  green  PSU-2 FAN-1      13%      exhaust     Present        OK  20240715 06:25:40
admin@sonic:~$
```
#### How I did it
PSU model and FAN flow
- YM-1401ACR (AC, B2F)
- YM-1401ABR (AC, F2B)

So I changed the fan direction based on the PSU model name.

#### How to verify it

```
PSU    Model        Serial              HW Rev      Voltage (V)    Current (A)    Power (W)  Status    LED
-----  -----------  ------------------  --------  -------------  -------------  -----------  --------  -----
PSU 1  YM-1401A-CR  SA090W262231000700  N/A               11.82           3.09        39.00  OK        green
PSU 2  YM-1401A-CR  TA070W261952000333  N/A               11.92           3.97        39.00  OK        green
admin@sonic:~$ show platform fan
  Drawer    LED          FAN    Speed    Direction    Presence    Status          Timestamp
--------  -----  -----------  -------  -----------  ----------  --------  -----------------
FanTray1  green       FAN-1F      46%       intake     Present    Not OK  20240911 02:30:30
FanTray1  green       FAN-1R      45%       intake     Present    Not OK  20240911 02:30:30
FanTray2  green       FAN-2F      45%       intake     Present    Not OK  20240911 02:30:30
FanTray2  green       FAN-2R      45%       intake     Present    Not OK  20240911 02:30:30
FanTray3  green       FAN-3F      45%       intake     Present    Not OK  20240911 02:30:30
FanTray3  green       FAN-3R      46%       intake     Present    Not OK  20240911 02:30:30
FanTray4  green       FAN-4F      45%       intake     Present    Not OK  20240911 02:30:30
FanTray4  green       FAN-4R      46%       intake     Present    Not OK  20240911 02:30:30
FanTray5  green       FAN-5F      46%       intake     Present    Not OK  20240911 02:30:30
FanTray5  green       FAN-5R      46%       intake     Present    Not OK  20240911 02:30:30
     N/A  green  PSU-1 FAN-1      19%       intake     Present        OK  20240911 02:30:30
     N/A  green  PSU-2 FAN-1      13%       intake     Present        OK  20240911 02:30:30
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

