### PR TITLE
[Platform][AS9726-32D]: Fix sonic-mgmt pytest test_chassis.py::TestChassisApi::test_get_system_eeprom_info fail.

### DIFF
--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/eeprom.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/eeprom.py
@@ -33,7 +33,7 @@ class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
         for line in lines:
             try:
                 match = re.search(
-                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)([\S]+)', line)
+                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)(.+)', line)
                 if match is not None:
                     idx = match.group(1)
                     value = match.group(3).rstrip('\0')


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- `Failed: System EEPROM info is incorrect - for '0x25', rcvd '09/15/2021', expected '09/15/2021 15:03:11' on 'as9726-32d-6'`
- EEPROM parser with wrong regular expression pattern so that extracting wrong string.
  - The regular expression `([\S]+)` is used to match one or more non-whitespace characters.
    - `09/15/2021` will match.
    - `15:03:11` will match.
    - So the string ‘`09/15/2021 15:03:11`’ will be divided into two parts ‘`09/15/2021`' and ‘`15:03:11`’ but not '`09/15/2021 15:03:11`’.

#### How I did it
- Use `(.+)` to match any string of characters that has at least one character in it, and it will keep matching until it encounters a newline or the end of the string.

#### How to verify it
- Re-run the test can pass.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

