### PR TITLE
[Platform][AS9726-32D]: Add fan speed minimum value in platform.json

### DIFF
--- a/device/accton/x86_64-accton_as9726_32d-r0/platform.json
+++ b/device/accton/x86_64-accton_as9726_32d-r0/platform.json
@@ -4,7 +4,7 @@
         "status_led": {
             "controllable": false
         },
-	"thermal_manager":false,
+        "thermal_manager":false,
         "components": [
             {
                 "name": "CPLD1"
@@ -28,72 +28,120 @@
         "fans": [
             {
                 "name": "FAN-1F",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
                 "status_led": {
                     "controllable": false
-		}
+                }
             },
             {
                 "name": "FAN-1R",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
                 "status_led": {
                     "controllable": false
                 }
             },
             {
                 "name": "FAN-2F",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
                 "status_led": {
                     "controllable": false
                 }
             },
             {
                 "name": "FAN-2R",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
                 "status_led": {
                     "controllable": false
                 }
             },
             {
                 "name": "FAN-3F",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
                 "status_led": {
                     "controllable": false
                 }
             },
             {
                 "name": "FAN-3R",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
                 "status_led": {
                     "controllable": false
                 }
             },
             {
                 "name": "FAN-4F",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
                 "status_led": {
                     "controllable": false
                 }
             },
             {
                 "name": "FAN-4R",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
                 "status_led": {
                     "controllable": false
                 }
             },
             {
                 "name": "FAN-5F",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
                 "status_led": {
                     "controllable": false
                 }
             },
             {
                 "name": "FAN-5R",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
                 "status_led": {
                     "controllable": false
                 }
             },
             {
                 "name": "FAN-6F",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
                 "status_led": {
                     "controllable": false
                 }
             },
             {
                 "name": "FAN-6R",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
                 "status_led": {
                     "controllable": false
                 }
@@ -110,12 +158,20 @@
                 "fans": [
                     {
                         "name": "FAN-1F",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
                         "status_led": {
                             "controllable": false
                         }
                     },
                     {
                         "name": "FAN-1R",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
                         "status_led": {
                             "controllable": false
                         }
@@ -132,12 +188,20 @@
                 "fans": [
                     {
                         "name": "FAN-2F",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
                         "status_led": {
                             "controllable": false
                         }
                     },
                     {
                         "name": "FAN-2R",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
                         "status_led": {
                             "controllable": false
                         }
@@ -154,12 +218,20 @@
                 "fans": [
                     {
                         "name": "FAN-3F",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
                         "status_led": {
                             "controllable": false
                         }
                     },
                     {
                         "name": "FAN-3R",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
                         "status_led": {
                             "controllable": false
                         }
@@ -176,12 +248,20 @@
                 "fans": [
                     {
                         "name": "FAN-4F",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
                         "status_led": {
                             "controllable": false
                         }
                     },
                     {
                         "name": "FAN-4R",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
                         "status_led": {
                             "controllable": false
                         }
@@ -198,12 +278,20 @@
                 "fans": [
                     {
                         "name": "FAN-5F",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
                         "status_led": {
                             "controllable": false
                         }
                     },
                     {
                         "name": "FAN-5R",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
                         "status_led": {
                             "controllable": false
                         }
@@ -220,12 +308,20 @@
                 "fans": [
                     {
                         "name": "FAN-6F",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
                         "status_led": {
                             "controllable": false
                         }
                     },
                     {
                         "name": "FAN-6R",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
                         "status_led": {
                             "controllable": false
                         }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- Sonic-mgmt pytest use fixed speed to test in test items `chassis_fans` and `fan_drawer_fans`.
  - test_get_fans_target_speed
    - speed_target_val = 25

#### How I did it
- Add fan speed minimum value by HW spec. to let sonic-mgmt to use a random speed but not fixed speed to test.

#### How to verify it
- Re-run pytest cases and see the test speed is random.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

