### PR TITLE
[Platform][AS5835-54T][AS5835-54X][AS7326-56X]: Add platform component API: install_firmware

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/component.py
@@ -7,7 +7,10 @@
 
 try:
     import subprocess
+    import os
+    import json
     from sonic_platform_base.component_base import ComponentBase
+    from sonic_py_common.general import getstatusoutput_noshell
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -112,7 +115,36 @@ class Component(ComponentBase):
         Returns:
             A boolean, True if install successfully, False if not
         """
-        raise NotImplementedError
+        ret, output = getstatusoutput_noshell(["tar", "-C", "/tmp", "-xzf", image_path ] )
+        if ret != 0:
+            print("Installation failed because of wrong image package")
+            return False
+
+        if  False == os.path.exists("/tmp/install.json"):
+            print("Installation failed without jsonfile")
+            return False
+
+        input_file = open ('/tmp/install.json')
+        json_array = json.load(input_file)
+        ret = 1
+        for item in json_array:
+            if item.get('id') == None or item.get('path') == None:
+                continue
+            if self.name == item['id'] and item['path'] and item.get('cpu'):
+                print( "Find", item['id'], item['path'], item['cpu'] )
+                ret, output = getstatusoutput_noshell(["/tmp/run_install.sh", item['id'], item['path'], item['cpu'] ])
+                if ret == 0:
+                    break
+            elif self.name == item['id'] and item['path']:
+                print( "Find", item['id'], item['path'] )
+                ret, output = getstatusoutput_noshell(["/tmp/run_install.sh", item['id'], item['path'] ])
+                if ret == 0:
+                    break
+
+        if ret == 0:
+            return True
+        else:
+            return False
 
     def get_presence(self):
         """


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- For legacy branch, AS5835-54T/54X and AS7326-56X support the component API: install_firmware.

#### How I did it
- Sync from legacy branch.

#### How to verify it
- Run sonic-mgmt pytest platform_tests/api/test_component.py -k 'TestComponentApi and test_install_firmware' is pass.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

