### PR TITLE
[Platform][AS9726-32D] Sync codes to fix DUT is hanging after kernel panic reboot during pytest test_memory_exhaustion.py

### DIFF
--- a/device/accton/x86_64-accton_as9726_32d-r0/platform_reboot
+++ b/device/accton/x86_64-accton_as9726_32d-r0/platform_reboot
@@ -3,6 +3,14 @@
 echo "Do sync"
 sync
 
+platform_specific_op_sysfs="/sys/bus/i2c/devices/1-0065/reset_mac_before_reboot"
+do_cpld_cold_reset=true
+if [ -f "$platform_specific_op_sysfs" ]; then
+    if [ 1 == $(<$platform_specific_op_sysfs) ]; then
+        do_cpld_cold_reset=false
+    fi
+fi
+
 echo "Stop pmon.service"
 systemctl stop pmon.service
 
@@ -15,6 +23,7 @@ systemctl stop as9726-32d-platform-monitor-psu.service
 echo "Stop as9726-32d-platform-monitor.service"
 systemctl stop as9726-32d-platform-monitor.service
 
-echo "Cold Reset via CPLD Offset 0x4 Bit 3"
-i2cset -y -f 1 0x65 0x4 0x15
-
+if [ "$do_cpld_cold_reset" = true ]; then
+    echo "Cold Reset via CPLD Offset 0x4 Bit 3"
+    i2cset -y -f 1 0x65 0x4 0x15
+fi

--- a/platform/broadcom/sonic-platform-modules-accton/as9726-32d/utils/accton_as9726_32d_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9726-32d/utils/accton_as9726_32d_util.py
@@ -54,6 +54,8 @@ DEVICE_NO = {
     'psu': 2,
     'sfp': 34}
 
+BASE_CPLD_PATH = "/sys/bus/i2c/devices/1-0065/"
+
 fan_prefix = '/sys/devices/platform/as9726_32d_'
 hwmon_types = {'fan1': ['fan'],
                'fan2': ['fan'],
@@ -462,6 +464,11 @@ def do_install():
 #                return status
 
     do_sonic_platform_install()
+
+    status, output = log_os_system("echo 1 > "  + BASE_CPLD_PATH + "reset_mac_before_reboot", 1)
+    if status:
+        if FORCE == 0:
+            return status
 
     return
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- Pytest platform_tests/test_memory_exhaustion.py will make DUT console freeze sometimes.

#### How I did it
- Sync related bugfix codes from legacy branch to solve this issue.

#### How to verify it
- Re-run the test case 50 times and all pass.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

