### PR TITLE
[Platform][AS4625-54P][AS4630-54NPE][AS5835-54T/54X][AS9726-32D] Fix psu_fans pytest failed in test_set_fans_led and test_get_fans_target_speed

### DIFF
--- a/device/accton/x86_64-accton_as4625_54p-r0/platform.json
+++ b/device/accton/x86_64-accton_as4625_54p-r0/platform.json
@@ -113,7 +113,13 @@
                 "name": "PSU-1",
                 "fans": [
                     {
-                        "name": "PSU-1 FAN-1"
+                        "name": "PSU-1 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [
@@ -141,7 +147,13 @@
                 "name": "PSU-2",
                 "fans": [
                     {
-                        "name": "PSU-2 FAN-1"
+                        "name": "PSU-2 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [

--- a/device/accton/x86_64-accton_as4630_54npe-r0/platform.json
+++ b/device/accton/x86_64-accton_as4630_54npe-r0/platform.json
@@ -120,7 +120,13 @@
                 },
                 "fans": [
                     {
-                        "name": "PSU-1 FAN-1"
+                        "name": "PSU-1 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [
@@ -140,7 +146,13 @@
                 },
                 "fans": [
                     {
-                        "name": "PSU-2 FAN-1"
+                        "name": "PSU-2 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [

--- a/device/accton/x86_64-accton_as5835_54t-r0/platform.json
+++ b/device/accton/x86_64-accton_as5835_54t-r0/platform.json
@@ -282,7 +282,13 @@
                 },
                 "fans": [
                     {
-                        "name": "PSU-1 FAN-1"
+                        "name": "PSU-1 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [
@@ -305,7 +311,13 @@
                 },
                 "fans": [
                     {
-                        "name": "PSU-2 FAN-1"
+                        "name": "PSU-2 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [

--- a/device/accton/x86_64-accton_as5835_54x-r0/platform.json
+++ b/device/accton/x86_64-accton_as5835_54x-r0/platform.json
@@ -205,7 +205,13 @@
                 "name": "PSU-1",
                 "fans": [
                     {
-                        "name": "PSU-1 FAN-1"
+                        "name": "PSU-1 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [
@@ -225,7 +231,13 @@
                 "name": "PSU-2",
                 "fans": [
                     {
-                        "name": "PSU-2 FAN-1"
+                        "name": "PSU-2 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [

--- a/device/accton/x86_64-accton_as9726_32d-r0/platform.json
+++ b/device/accton/x86_64-accton_as9726_32d-r0/platform.json
@@ -334,7 +334,13 @@
                 "name": "PSU-1",
                 "fans": [
                     {
-                        "name": "PSU-1 FAN-1"
+                        "name": "PSU-1 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [
@@ -354,7 +360,13 @@
                 "name": "PSU-2",
                 "fans": [
                     {
-                        "name": "PSU-2 FAN-1"
+                        "name": "PSU-2 FAN-1",
+                        "speed": {
+                            "controllable": false
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ],
                 "thermals": [


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- The current supported PSUs do not support to control the fan of SPEED and LED.

#### How I did it
- Add `"controllable": false` for `speed` and `status_led` for all PSUs to skip these test cases.

#### How to verify it
- Pytest test_psu.py::TestPsuApi of test_set_fans_led and test_get_fans_target_speed can skip.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

