### PR TITLE
[Platform][AS4625-54P][AS5835-54X][AS9726-32D] Fix pytest test_psu.py::TestPsuApi failed.

### DIFF
--- a/device/accton/x86_64-accton_as4625_54p-r0/platform.json
+++ b/device/accton/x86_64-accton_as4625_54p-r0/platform.json
@@ -111,6 +111,9 @@
         "psus": [
             {
                 "name": "PSU-1",
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
                         "name": "PSU-1 FAN-1"
@@ -139,6 +142,9 @@
             },
             {
                 "name": "PSU-2",
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
                         "name": "PSU-2 FAN-1"

--- a/device/accton/x86_64-accton_as5835_54x-r0/platform.json
+++ b/device/accton/x86_64-accton_as5835_54x-r0/platform.json
@@ -203,6 +203,9 @@
         "psus": [
             {
                 "name": "PSU-1",
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
                         "name": "PSU-1 FAN-1"
@@ -223,6 +226,9 @@
             },
             {
                 "name": "PSU-2",
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
                         "name": "PSU-2 FAN-1"

--- a/device/accton/x86_64-accton_as9726_32d-r0/platform.json
+++ b/device/accton/x86_64-accton_as9726_32d-r0/platform.json
@@ -332,6 +332,9 @@
         "psus": [
             {
                 "name": "PSU-1",
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
                         "name": "PSU-1 FAN-1"
@@ -352,6 +355,9 @@
             },
             {
                 "name": "PSU-2",
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
                         "name": "PSU-2 FAN-1"

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/psu.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/sonic_platform/psu.py
@@ -128,3 +128,31 @@ class Psu(PddfPsu):
             return 0.0
 
         return super().get_power()
+
+    def get_temperature_high_threshold(self):
+        """
+        Retrieves the high threshold temperature of PSU
+        Returns:
+            A float number, the high threshold temperature of PSU in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        threshold = super().get_temperature_high_threshold()
+
+        for psu_thermal_idx in range(self.num_psu_thermals):
+            try:
+                tmp = self._thermal_list[psu_thermal_idx].get_high_threshold()
+                if threshold > tmp or threshold == 0.0:
+                    threshold = tmp
+            except Exception:
+                pass
+
+        return threshold
+
+    def get_revision(self):
+        """
+        Retrieves the hardware revision of the device
+
+        Returns:
+            string: Revision value of device
+        """
+        return 'N/A'


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- Test `platform_tests/api/test_psu.py::TestPsuApi` is failed.
  - For `AS4625-54P`, `AS5835-54X`, and `AS9726-32D`:
    - Test `test_led` is failed.

  - For `AS5835-54X`:
    - Test `test_get_revision` and `test_temperature` are failed.

#### How I did it
- For `AS4625-54P`, `AS5835-54X`, and `AS9726-32D`:
  - `test_led`:
    - Add `"controllable": false` for psus in platform.json to skip the test since PSU status LED is controlled by hardware.

- For `AS5835-54X`:
  - `test_get_revision`:
    - Implement API `get_revision()` by referring to other PDDF platforms.
      - PSU does not support PMBus **MFR_REVISION(9Bh)**, so just return 'N/A'.

  - `test_temperature`:
    - Implement API `get_temperature_high_threshold()` by referring to other PDDF platforms.

#### How to verify it
- Run pytest
  - `test_get_revision` and `test_temperature` are pass.
  - `test_led` is skipped.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->