### PR TITLE
[Platform][4630-54TE] Add media_settings.json for ecSAI

### DIFF
--- a/device/accton/x86_64-accton_as4630_54te-r0/media_settings_ec.json
+++ b/device/accton/x86_64-accton_as4630_54te-r0/media_settings_ec.json
@@ -1,0 +1,52 @@
+{
+    "PORT_MEDIA_SETTINGS": {
+        "49": {
+            "Default": {
+                "preemphasis": {
+                    "lane0":"0x124106"
+                }
+            }
+        },
+        "50": {
+            "Default": {
+                "preemphasis": {
+                    "lane0":"0x124106"
+                }
+            }
+        },
+        "51": {
+            "Default": {
+                "preemphasis": {
+                    "lane0":"0x124106"
+                }
+            }
+        },
+        "52": {
+            "Default": {
+                "preemphasis": {
+                    "lane0":"0x124106"
+                }
+            }
+        },
+        "53": {
+            "Default": {
+                "preemphasis": {
+                    "lane0":"0x124106",
+                    "lane1":"0x124106",
+                    "lane2":"0x124106",
+                    "lane3":"0x124106"
+                }
+            }
+        },
+        "54": {
+            "Default": {
+                "preemphasis": {
+                    "lane0":"0x124106",
+                    "lane1":"0x124106",
+                    "lane2":"0x124106",
+                    "lane3":"0x124106"
+                }
+            }
+        }
+    }
+}

--- a/update_ecSAI_dep_files.sh
+++ b/update_ecSAI_dep_files.sh
@@ -41,6 +41,9 @@ cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as4630_54pe-r0/Ac
          $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as4630_54pe-r0/Accton-AS4630-54PE/hx5-as4630-48x1G+4x25G+2x100G.bcm
 cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as4630_54te-r0/Accton-AS4630-54TE/hx5-as4630-48x1G+4x25G+2x100G_ec.bcm \
          $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as4630_54te-r0/Accton-AS4630-54TE/hx5-as4630-48x1G+4x25G+2x100G.bcm
+cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as4630_54te-r0/media_settings_ec.json \
+         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as4630_54te-r0/media_settings.json
+
 
 ##update files for as5835
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add media_settings.json for 4630-54te platform

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

