### PR TITLE
JIRA-SONIC-10075: [LED] Remove as5835_54x led_proc_init.soc on ec-SON…

### DIFF
--- a/update_ecSAI_dep_files.sh
+++ b/update_ecSAI_dep_files.sh
@@ -2,38 +2,7 @@
 
 export SONIC_BASE=$1
 
-set +e 
-## update files for as9736
-
-cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9736_64d-r0/platform_ec.json \
-         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9736_64d-r0/platform.json
-cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9736_64d-r0/Accton-AS9736-64D-100G/th4-as9736-64x100G_ec.config.yml \
-         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9736_64d-r0/Accton-AS9736-64D-100G/th4-as9736-64x100G.config.yml
-
-
-## update files for as9726
-
-cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D-100G/td4-as9726-32x100G_ec.config.yml \
-         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D-100G/td4-as9726-32x100G.config.yml
-cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D/td4-as9726-32x400G_ec.config.yml \
-         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D/td4-as9726-32x400G.config.yml
-
-## update files for as9817
-
-cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64d-r0/Accton-AS9817-64D-100G/th5-as9817-64d-64x100G_ec.config.yml \
-         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64d-r0/Accton-AS9817-64D-100G/th5-as9817-64d-64x100G.config.yml
-cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64d-r0/Accton-AS9817-64D-400G/th5-as9817-64d-64x400G_ec.config.yml \
-         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64d-r0/Accton-AS9817-64D-400G/th5-as9817-64d-64x400G.config.yml
-cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64d-r0/Accton-AS9817-64D/th5-as9817-64d-64x800G_ec.config.yml \
-         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64d-r0/Accton-AS9817-64D/th5-as9817-64d-64x800G.config.yml
-                  
-
-cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64o-r0/Accton-AS9817-64O-100G/th5-as9817-64o-64x100G_ec.config.yml \
-         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64o-r0/Accton-AS9817-64O-100G/th5-as9817-64o-64x100G.config.yml
-cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64o-r0/Accton-AS9817-64O-2x400G/th5-as9817-64o-128x400G_ec.config.yml \
-         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64o-r0/Accton-AS9817-64O-2x400G/th5-as9817-64o-128x400G.config.yml
-cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64o-r0/Accton-AS9817-64O/th5-as9817-64o-64x800G_ec.config.yml \
-         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64o-r0/Accton-AS9817-64O/th5-as9817-64o-64x800G.config.yml
+set +e
 
 ## update files for as4630
 
@@ -44,13 +13,13 @@ cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as4630_54te-r0/Ac
 cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as4630_54te-r0/media_settings_ec.json \
          $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as4630_54te-r0/media_settings.json
 
-
 ##update files for as5835
 
 cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as5835_54t-r0/Accton-AS5835-54T/mv2-as5835t-48x10G+6x100G_ec.config.bcm  \
          $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as5835_54t-r0/Accton-AS5835-54T/mv2-as5835t-48x10G+6x100G.config.bcm
 cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as5835_54x-r0/Accton-AS5835-54X/mv2-as5835-48x10G+6x100G_ec.config.bcm \
          $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as5835_54x-r0/Accton-AS5835-54X/mv2-as5835-48x10G+6x100G.config.bcm
+rm -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as5835_54x-r0/led_proc_init.soc
 
 ##update files for as7326 & as7726
 
@@ -68,6 +37,36 @@ cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9716_32d-r0/Acc
 cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9716_32d-r0/media_settings_ec.json \
          $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9716_32d-r0/media_settings.json
 rm -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D-100G/media_settings.json
+
+## update files for as9726
+
+cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D-100G/td4-as9726-32x100G_ec.config.yml \
+         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D-100G/td4-as9726-32x100G.config.yml
+cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D/td4-as9726-32x400G_ec.config.yml \
+         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D/td4-as9726-32x400G.config.yml
+
+## update files for as9736
+
+cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9736_64d-r0/platform_ec.json \
+         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9736_64d-r0/platform.json
+cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9736_64d-r0/Accton-AS9736-64D-100G/th4-as9736-64x100G_ec.config.yml \
+         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9736_64d-r0/Accton-AS9736-64D-100G/th4-as9736-64x100G.config.yml
+
+## update files for as9817
+
+cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64d-r0/Accton-AS9817-64D-100G/th5-as9817-64d-64x100G_ec.config.yml \
+         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64d-r0/Accton-AS9817-64D-100G/th5-as9817-64d-64x100G.config.yml
+cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64d-r0/Accton-AS9817-64D-400G/th5-as9817-64d-64x400G_ec.config.yml \
+         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64d-r0/Accton-AS9817-64D-400G/th5-as9817-64d-64x400G.config.yml
+cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64d-r0/Accton-AS9817-64D/th5-as9817-64d-64x800G_ec.config.yml \
+         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64d-r0/Accton-AS9817-64D/th5-as9817-64d-64x800G.config.yml
+
+cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64o-r0/Accton-AS9817-64O-100G/th5-as9817-64o-64x100G_ec.config.yml \
+         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64o-r0/Accton-AS9817-64O-100G/th5-as9817-64o-64x100G.config.yml
+cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64o-r0/Accton-AS9817-64O-2x400G/th5-as9817-64o-128x400G_ec.config.yml \
+         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64o-r0/Accton-AS9817-64O-2x400G/th5-as9817-64o-128x400G.config.yml
+cp -f $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64o-r0/Accton-AS9817-64O/th5-as9817-64o-64x800G_ec.config.yml \
+         $SONIC_BASE/sonic-buildimage/device/accton/x86_64-accton_as9817_64o-r0/Accton-AS9817-64O/th5-as9817-64o-64x800G.config.yml
 
 ## rebuild sonic-device-data
 rm -f $SONIC_BASE/sonic-buildimage/target/debs/bullseye/sonic-device-data_1.0-1_all.deb


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- as5835_54x front port LED firmware loading and control procedure by ec-SAI.
#### How I did it
- Remove led_proc_init.soc
#### How to verify it
- Checking SONiC-OS-202311.X.121-ecsai-20241010.115150
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

