### PR TITLE
[Platform][AS5835-54T] Fix pytest test_psu.py::TestPsuApi failed in test_get_name and test_get_revision

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/psu.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/sonic_platform/psu.py
@@ -107,3 +107,15 @@ class Psu(PddfPsu):
             return 0.0
 
         return super().get_power()
+
+    def get_name(self):
+        return "PSU-{}".format(self.psu_index)
+
+    def get_revision(self):
+        """
+        Retrieves the hardware revision of the device
+
+        Returns:
+            string: Revision value of device
+        """
+        return 'N/A'


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- Test `platform_tests/api/test_psu.py::TestPsuApi` is failed as below tests.
  - `test_get_name`
    - No implement platform psu API: Psu.get_name() so that use the base class (PddfPsu) API PddfPsu.get_name().
  - `test_get_revision`
    - WARNING pmon#platform_api_server.py: API 'get_revision' not implemented

#### How I did it
- `test_get_name`:
  - Implement API get_name() by referring to other PDDF platforms such as AS5835-54X.
- `test_get_revision`:
  - Implement API get_revision() by referring to other PDDF platforms such as AS5835-54X.
    - PSU does not support PMBus MFR_REVISION(9Bh), so just return 'N/A'.

#### How to verify it
- Run pytest `test_get_name` and `test_get_revision` is pass.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

