### PR TITLE
[Build] Deprecate the mirror packages.trafficmanager.net/debian (#17113)

### DIFF
--- a/scripts/build_mirror_config.sh
+++ b/scripts/build_mirror_config.sh
@@ -6,13 +6,13 @@ export ARCHITECTURE=$2
 export DISTRIBUTION=$3
 
 # The default mirror urls
-DEFAULT_MIRROR_URLS=http://debian-archive.trafficmanager.net/debian/,http://packages.trafficmanager.net/debian/debian/
-DEFAULT_MIRROR_SECURITY_URLS=http://debian-archive.trafficmanager.net/debian-security/,http://packages.trafficmanager.net/debian/debian-security/
+DEFAULT_MIRROR_URLS=http://debian-archive.trafficmanager.net/debian/
+DEFAULT_MIRROR_SECURITY_URLS=http://debian-archive.trafficmanager.net/debian-security/
 
 # The debian-archive.trafficmanager.net does not support armhf, use debian.org instead
 if [ "$ARCHITECTURE" == "armhf" ]; then
-    DEFAULT_MIRROR_URLS=http://deb.debian.org/debian/,http://packages.trafficmanager.net/debian/debian/
-    DEFAULT_MIRROR_SECURITY_URLS=http://deb.debian.org/debian-security/,http://packages.trafficmanager.net/debian/debian-security/
+    DEFAULT_MIRROR_URLS=http://deb.debian.org/debian/
+    DEFAULT_MIRROR_SECURITY_URLS=http://deb.debian.org/debian-security/
 fi
 
 if [ "$DISTRIBUTION" == "buster" ]; then


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- Fix build error:
  ```E: Failed to fetch http://packages.trafficmanager.net/debian/debian-security/dists/buster_updates/InRelease  400  The account being accessed does not support http. [IP: 13.107.246.73 80]```
  ```E: The repository 'http://packages.trafficmanager.net/debian/debian-security buster_updates InRelease' is not signed.```

#### How I did it
- Refer to PR#17113: deprecate the no use and out of service mirrors.
  -- http://packages.trafficmanager.net/debian/debian/
  -- http://packages.trafficmanager.net/debian/debian-security/

#### How to verify it
- Re-build pass.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

