### PR TITLE
[Platform][AS5835-54X] Fix PDDF service does not up in system bring up

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/modules/accton_psu_api.h
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/modules/accton_psu_api.h
@@ -1,0 +1,1 @@
+../../common/modules/accton_psu_api.h

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/modules/accton_psu_defs.h
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/modules/accton_psu_defs.h
@@ -1,0 +1,1 @@
+../../common/modules/accton_psu_defs.h

--- a/scripts/build_mirror_config.sh
+++ b/scripts/build_mirror_config.sh
@@ -6,13 +6,13 @@ export ARCHITECTURE=$2
 export DISTRIBUTION=$3
 
 # The default mirror urls
-DEFAULT_MIRROR_URLS=http://debian-archive.trafficmanager.net/debian/,http://packages.trafficmanager.net/debian/debian/
-DEFAULT_MIRROR_SECURITY_URLS=http://debian-archive.trafficmanager.net/debian-security/,http://packages.trafficmanager.net/debian/debian-security/
+DEFAULT_MIRROR_URLS=http://debian-archive.trafficmanager.net/debian/
+DEFAULT_MIRROR_SECURITY_URLS=http://debian-archive.trafficmanager.net/debian-security/
 
 # The debian-archive.trafficmanager.net does not support armhf, use debian.org instead
 if [ "$ARCHITECTURE" == "armhf" ]; then
-    DEFAULT_MIRROR_URLS=http://deb.debian.org/debian/,http://packages.trafficmanager.net/debian/debian/
-    DEFAULT_MIRROR_SECURITY_URLS=http://deb.debian.org/debian-security/,http://packages.trafficmanager.net/debian/debian-security/
+    DEFAULT_MIRROR_URLS=http://deb.debian.org/debian/
+    DEFAULT_MIRROR_SECURITY_URLS=http://deb.debian.org/debian-security/
 fi
 
 if [ "$DISTRIBUTION" == "buster" ]; then


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

1. [AS5835-54X] PDDF service does not up in system bring up.
  - The journalctl indicates the service **pddf-platform-init** has errors:
    - `pddf_util.py[277]: Failed :modprobe -f pddf_custom_psu`
    - `pddf_util.py[277]: driver_install() failed with error 1`
  - Manually to install the module `pddf_custom_psu` found an error as well.
    - sudo modprobe -f pddf_custom_psu
      - `modprobe: FATAL: Module pddf_custom_psu not found in directory /lib/modules/5.10.0-18-2-amd64`
- The root cause is missing kernel modules: `pddf_custom_psu.ko` and `ym2651y.ko` during the Debian build process caused by required library header not found. Thus, pddf_util.py executes driver_install() will find errors so that the required package `sonic_platform-1.0-py3-none-any.whl` is not installed.

2. Build docker slave-bullseye/buster fail.
  - `E: Failed to fetch http://packages.trafficmanager.net/debian/debian-security/dists/buster_updates/InRelease  400  The account being accessed does not support http. [IP: 13.107.246.73 80]`
  - `E: The repository 'http://packages.trafficmanager.net/debian/debian-security buster_updates InRelease' is not signed.`

#### How I did it

1. Add symbolic links to refer to correct header files for `ym2651y.c` during build platform Debian file(**sonic-platform-accton-as5835-54x_1.1_amd64.deb**).
2. Refer to PR#17113: deprecate the no use and out of service mirrors to fix build docker slave-bullseye/buster fail.
   - http://packages.trafficmanager.net/debian/debian/
   - http://packages.trafficmanager.net/debian/debian-security/

#### How to verify it
- Generate sonic-broadcom.bin normally and no build fail.
- No found driver install errors in journalctl log messages.
  - `sudo journalctl --no-pager -u pddf-platform-init`
- The below commands can display information normally and the output status is OK after system is ready.
  - `sudo show platform fan`
  - `sudo show platform psustatus`
  - `sudo show platform temperature`
  - `sudo show platform ssdhealth`
  - `sudo show platform syseeprom`
  - `sudo show system-health detail`
  - `sudo show system-health sysready-status detail`
  - `sudo pddf_psuutil status`
  - `sudo pddf_fanutil status`
  - `sudo pddf_thermalutil gettemp`
  - `sudo pddf_ledutil getstatusled DIAG_LED`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

