### PR TITLE
[AS4630-54NPE/PE/TE] Support 2nd source PSU

### DIFF
--- a/device/accton/x86_64-accton_as4630_54pe-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/pddf/pddf-device.json
@@ -56,6 +56,10 @@
             "pddf_fan_driver_module",
             "pddf_fan_module",
             "pddf_led_module"
+        ],
+        "custom_kos":
+        [
+            "pddf_custom_psu"
         ]
     },
 
@@ -369,7 +373,7 @@
             "attr_list":
             [
                 { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x22", "attr_mask":"0x20", "attr_cmpval":"0x0", "attr_len":"1"},
-                { "attr_name":"psu_model_name", "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x20", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"12" },
+                { "attr_name":"psu_model_name", "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x20", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"13" },
                 { "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x22", "attr_mask":"0x40", "attr_cmpval":"0x40", "attr_len":"1"},
                 { "attr_name":"psu_serial_num", "attr_devaddr":"0x50", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"19" }
             ]
@@ -424,7 +428,7 @@
             "attr_list":
             [
                 { "attr_name":"psu_present", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x22", "attr_mask":"0x2", "attr_cmpval":"0x0", "attr_len":"1"},
-                { "attr_name":"psu_model_name", "attr_devaddr":"0x51", "attr_devtype":"eeprom", "attr_offset":"0x20", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"12" },
+                { "attr_name":"psu_model_name", "attr_devaddr":"0x51", "attr_devtype":"eeprom", "attr_offset":"0x20", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"13" },
                 { "attr_name":"psu_power_good", "attr_devaddr":"0x60", "attr_devtype":"cpld", "attr_offset":"0x22", "attr_mask":"0x4", "attr_cmpval":"0x4", "attr_len":"1"},
                 { "attr_name":"psu_serial_num", "attr_devaddr":"0x51", "attr_devtype":"eeprom", "attr_offset":"0x35", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"19" }
             ]

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54npe/modules/x86-64-accton-as4630-54npe-psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54npe/modules/x86-64-accton-as4630-54npe-psu.c
@@ -38,7 +38,12 @@
 
 #define MAX_MODEL_NAME          20
 #define MAX_SERIAL_NUMBER       19
+#define FAN_DIR_LEN 4
 
+const char FAN_DIR_F2B[] = "F2B";
+const char FAN_DIR_B2F[] = "B2F";
+
+static int models_min_offset = 0;
 static ssize_t show_status(struct device *dev, struct device_attribute *da, char *buf);
 static ssize_t show_string(struct device *dev, struct device_attribute *da, char *buf);
 static int as4630_54npe_psu_read_block(struct i2c_client *client, u8 command, u8 *data,int data_len);
@@ -59,6 +64,7 @@ struct as4630_54npe_psu_data {
     u8  status;          /* Status(present/power_good) register read from CPLD */
     char model_name[MAX_MODEL_NAME]; /* Model name, read from eeprom */
     char serial_number[MAX_SERIAL_NUMBER];
+    char fan_dir[FAN_DIR_LEN];
 };
 
 static struct as4630_54npe_psu_data *as4630_54npe_psu_update_device(struct device *dev);
@@ -67,7 +73,39 @@ enum as4630_54npe_psu_sysfs_attributes {
     PSU_PRESENT,
     PSU_MODEL_NAME,
     PSU_POWER_GOOD,
-    PSU_SERIAL_NUMBER
+    PSU_SERIAL_NUMBER,
+    PSU_FAN_DIR
+};
+
+enum psu_type {
+    PSU_YPEB1200,          /* F2B */
+    PSU_YPEB1200AM,        /* F2B */
+    PSU_UP1K21R_1085G,     /* F2B */
+    UNKNOWN_PSU
+};
+
+struct model_name_info {
+    enum psu_type type;
+    u8 offset;
+    u8 length;
+    char* model_name;
+};
+
+struct model_name_info models[] = {
+{PSU_YPEB1200,      0x20, 11, "YPEB1200"},
+{PSU_YPEB1200AM,    0x20, 11, "YPEB1200AM"}, /* Replace YPEB1200-AM to YPEB1200AM */
+{PSU_UP1K21R_1085G, 0x20, 13, "UP1K21R-1085G"},
+};
+
+struct serial_number_info {
+    u8 offset;
+    u8 length;
+};
+
+struct serial_number_info serials[] = {
+    [PSU_YPEB1200]   = {0x35, 17},
+    [PSU_YPEB1200AM] = {0x35, 18},
+    [PSU_UP1K21R_1085G] =  {0x3B, 9},
 };
 
 /* sysfs attributes for hwmon
@@ -76,13 +114,14 @@ static SENSOR_DEVICE_ATTR(psu_present,    S_IRUGO, show_status,    NULL, PSU_PRE
 static SENSOR_DEVICE_ATTR(psu_model_name, S_IRUGO, show_string,    NULL, PSU_MODEL_NAME);
 static SENSOR_DEVICE_ATTR(psu_power_good, S_IRUGO, show_status,    NULL, PSU_POWER_GOOD);
 static SENSOR_DEVICE_ATTR(psu_serial_number, S_IRUGO, show_string, NULL, PSU_SERIAL_NUMBER);
-
+static SENSOR_DEVICE_ATTR(psu_fan_dir, S_IRUGO,    show_string,    NULL, PSU_FAN_DIR);
 
 static struct attribute *as4630_54npe_psu_attributes[] = {
     &sensor_dev_attr_psu_present.dev_attr.attr,
     &sensor_dev_attr_psu_model_name.dev_attr.attr,
     &sensor_dev_attr_psu_power_good.dev_attr.attr,
     &sensor_dev_attr_psu_serial_number.dev_attr.attr,
+    &sensor_dev_attr_psu_fan_dir.dev_attr.attr,
     NULL
 };
 
@@ -127,6 +166,9 @@ static ssize_t show_string(struct device *dev, struct device_attribute *da,
 	case PSU_SERIAL_NUMBER:
 		ptr = data->serial_number;
 		break;
+	case PSU_FAN_DIR:
+		ptr = data->fan_dir;
+		break;
 	default:
 		return -EINVAL;
 	}
@@ -137,6 +179,18 @@ static ssize_t show_string(struct device *dev, struct device_attribute *da,
 static const struct attribute_group as4630_54npe_psu_group = {
     .attrs = as4630_54npe_psu_attributes,
 };
+
+static int find_models_min_offset(void) {
+    int i, min_offset = models[0].offset;
+
+    for(i = 1; i < (sizeof(models) / sizeof(models[0])); i++) {
+        if(models[i].offset < min_offset) {
+            min_offset = models[i].offset;
+        }
+    }
+
+    return min_offset;
+}
 
 static int as4630_54npe_psu_probe(struct i2c_client *client,
                                 const struct i2c_device_id *dev_id)
@@ -159,6 +213,7 @@ static int as4630_54npe_psu_probe(struct i2c_client *client,
     data->valid = 0;
     data->index = dev_id->driver_data;
     mutex_init(&data->update_lock);
+    models_min_offset = find_models_min_offset();
 
     dev_info(&client->dev, "chip found\n");
 
@@ -256,13 +311,14 @@ static struct as4630_54npe_psu_data *as4630_54npe_psu_update_device(struct devic
 {
     struct i2c_client *client = to_i2c_client(dev);
     struct as4630_54npe_psu_data *data = i2c_get_clientdata(client);
+    char temp_model_name[MAX_MODEL_NAME] = {0};
 
     mutex_lock(&data->update_lock);
 
     if (time_after(jiffies, data->last_updated + HZ + HZ / 2)
             || !data->valid) {
         int status;
-        int power_good = 0;
+        int i, power_good = 0;
 
         dev_dbg(&client->dev, "Starting as4630_54npe update\n");
 
@@ -282,54 +338,104 @@ static struct as4630_54npe_psu_data *as4630_54npe_psu_update_device(struct devic
         memset(data->model_name, 0, sizeof(data->model_name));
 #endif
 #ifdef __STDC_LIB_EXT1__
-	memset_s(data->serial_number, sizeof(data->serial_number), 0, sizeof(data->serial_number));
+        memset_s(data->serial_number, sizeof(data->serial_number), 0, sizeof(data->serial_number));
 #else
         memset(data->serial_number, 0, sizeof(data->serial_number));
+#endif
+#ifdef __STDC_LIB_EXT1__
+        memset_s(data->fan_dir, sizeof(data->fan_dir), 0, sizeof(data->fan_dir));
+#else
+        memset(data->fan_dir, 0, sizeof(data->fan_dir));
 #endif
         power_good = (data->status >> (data->index==0? 6:2)) & 0x1;
 
         if (power_good) {
-            status = as4630_54npe_psu_read_block(client, 0x20, data->model_name,
-                                               ARRAY_SIZE(data->model_name)-1);
+            enum psu_type type = UNKNOWN_PSU;
+
+            status = as4630_54npe_psu_read_block(client, models_min_offset,
+                                                 temp_model_name,
+                                                 ARRAY_SIZE(temp_model_name));
             if (status < 0) {
-                data->model_name[0] = '\0';
                 dev_dbg(&client->dev, "unable to read model name from (0x%x)\n", client->addr);
+                goto exit;
             }
-            else if(!strncmp(data->model_name, "YPEB1200", strlen("YPEB1200")))
-            {
+
+            for (i = 0; i < ARRAY_SIZE(models); i++) {
+                if ((models[i].length+1) > ARRAY_SIZE(data->model_name)) {
+                    dev_dbg(&client->dev,
+                            "invalid models[%d].length(%d), should not exceed the size of data->model_name(%ld)\n",
+                            i, models[i].length, ARRAY_SIZE(data->model_name));
+                    continue;
+                }
+
+                snprintf(data->model_name, models[i].length + 1, "%s",
+                         temp_model_name + (models[i].offset - models_min_offset));
+
+                if(!strncmp(data->model_name, "YPEB1200", strlen("YPEB1200")))
+                {
                     if (data->model_name[9]=='A' && data->model_name[10]=='M')
                     {
-                       data->model_name[8]='A';
-                       data->model_name[9]='M';
-                       data->model_name[strlen("YPEB1200AM")]='\0';
+                        data->model_name[8]='A';
+                        data->model_name[9]='M';
+                        data->model_name[strlen("YPEB1200AM")]='\0';
                     }
                     else
                         data->model_name[strlen("YPEB1200")]='\0';
-            }
-            else
-            {
-                data->model_name[ARRAY_SIZE(data->model_name)-1] = '\0';
-            }
-             /* Read from offset 0x35 ~ 0x46 (18 bytes) */
-            status = as4630_54npe_psu_read_block(client, 0x35,data->serial_number, MAX_SERIAL_NUMBER);
-            if (status < 0)
-            {
-                data->serial_number[0] = '\0';
-                dev_dbg(&client->dev, "unable to read model name from (0x%x) offset(0x35)\n", client->addr);
-            }
-            if (!strncmp(data->model_name, "YPEB1200AM", strlen("YPEB1200AM"))) /*for YPEB1200AM, SN length=18*/
-            {
-                data->serial_number[MAX_SERIAL_NUMBER-1]='\0';
-            }
-            else
-                data->serial_number[MAX_SERIAL_NUMBER-2]='\0';
+                }
 
+                /* Determine if the model name is known, if not, read next index */
+                if (strcmp(data->model_name, models[i].model_name) == 0) {
+                    type = models[i].type;
+                    break;
+                }
+
+                data->model_name[0] = '\0';
+            }
+
+            switch (type) {
+            case PSU_YPEB1200:
+            case PSU_YPEB1200AM:
+            case PSU_UP1K21R_1085G:
+                memcpy(data->fan_dir, FAN_DIR_F2B, sizeof(FAN_DIR_F2B));
+                break;
+            default:
+                dev_dbg(&client->dev, "Unknown PSU type for fan direction\n");
+                break;
+            }
+
+            if (type < ARRAY_SIZE(serials)) {
+                if ((serials[type].length+1) > ARRAY_SIZE(data->serial_number)) {
+                    dev_dbg(&client->dev,
+                            "invalid serials[%d].length(%d), should not exceed the size of data->serial_number(%ld)\n",
+                            type, serials[type].length, ARRAY_SIZE(data->serial_number));
+                    goto exit;
+                }
+
+                memset(data->serial_number, 0, sizeof(data->serial_number));
+                status = as4630_54npe_psu_read_block(client, serials[type].offset,
+                                                data->serial_number,
+                                                serials[type].length);
+                if (status < 0) {
+                    dev_dbg(&client->dev,
+                            "unable to read serial from (0x%x) offset(0x%02x)\n",
+                            client->addr, serials[type].length);
+                    goto exit;
+                }
+                else {
+                    data->serial_number[serials[type].length]= '\0';
+                }
+            }
+            else {
+                dev_dbg(&client->dev, "invalid PSU type(%d)\n", type);
+                goto exit;
+            }
         }
 
         data->last_updated = jiffies;
         data->valid = 1;
     }
 
+exit:
     mutex_unlock(&data->update_lock);
 
     return data;

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/modules/Makefile
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/modules/Makefile
@@ -1,7 +1,10 @@
 ifneq ($(KERNELRELEASE),)
 obj-m:= x86-64-accton-as4630-54pe-cpld.o x86-64-accton-as4630-54pe-psu.o  \
-	    x86-64-accton-as4630-54pe-leds.o ym2651y.o
+	    x86-64-accton-as4630-54pe-leds.o ym2651y.o pddf_custom_psu.o
 	    
+CFLAGS_pddf_custom_psu.o := -I$(M)/../../../../pddf/i2c/modules/include
+KBUILD_EXTRA_SYMBOLS := $(M)/../../../../pddf/i2c/Module.symvers.PDDF
+
 else
 ifeq (,$(KERNEL_SRC))
 $(error KERNEL_SRC is not defined)

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/modules/pddf_custom_psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/modules/pddf_custom_psu.c
@@ -1,0 +1,223 @@
+#include <linux/module.h>
+#include <linux/jiffies.h>
+#include <linux/i2c.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/err.h>
+#include <linux/delay.h>
+#include <linux/mutex.h>
+#include <linux/sysfs.h>
+#include <linux/slab.h>
+#include <linux/dmi.h>
+#include "pddf_client_defs.h"
+#include "pddf_psu_defs.h"
+#include "pddf_psu_driver.h"
+#include "pddf_psu_api.h"
+
+extern PSU_SYSFS_ATTR_DATA access_psu_v_out;
+int pddf_post_get_custom_psu_model_name(void *i2c_client, PSU_DATA_ATTR *adata, void *data);
+extern PSU_SYSFS_ATTR_DATA access_psu_model_name;
+int pddf_post_get_custom_psu_fan_dir(void *i2c_client, PSU_DATA_ATTR *adata, void *data);
+extern PSU_SYSFS_ATTR_DATA access_psu_fan_dir;
+int pddf_custom_psu_post_probe(struct i2c_client *client, const struct i2c_device_id *dev_id);
+int pddf_custom_psu_post_remove(struct i2c_client *client);
+extern struct pddf_ops_t pddf_psu_ops;
+
+const char FAN_DIR_F2B[] = "F2B\0";
+const char FAN_DIR_B2F[] = "B2F\0";
+
+static LIST_HEAD(psu_eeprom_client_list);
+static struct mutex     list_lock;
+
+struct psu_eeprom_client_node {
+    struct i2c_client *client;
+    struct list_head   list;
+};
+
+int pddf_post_get_custom_psu_model_name(void *i2c_client, PSU_DATA_ATTR *adata, void *data)
+{
+    struct psu_attr_info *sysfs_attr_info = (struct psu_attr_info *)data;
+    char *model_name = sysfs_attr_info->val.strval;
+
+    if(!strncmp(model_name, "YPEB1200", strlen("YPEB1200")))
+    {
+            if (model_name[9]=='A' && model_name[10]=='M')
+            {
+                model_name[8]='A';
+                model_name[9]='M';
+                model_name[strlen("YPEB1200AM")]='\0';
+            }
+            else
+                model_name[strlen("YPEB1200")]='\0';
+    }
+
+    return 0;
+}
+
+/*
+ * Get the PSU EEPROM I2C client with the same bus number.
+ */
+static struct i2c_client *find_psu_eeprom_client(struct i2c_client *pmbus_client)
+{
+    struct list_head *list_node = NULL;
+    struct psu_eeprom_client_node *psu_eeprom_node = NULL;
+    struct i2c_client *eeprom_client = NULL;
+
+    mutex_lock(&list_lock);
+    list_for_each(list_node, &psu_eeprom_client_list) {
+        psu_eeprom_node = list_entry(list_node, struct psu_eeprom_client_node, list);
+        /* Check if the bus adapter is the same or not. */
+        if (psu_eeprom_node->client->adapter == pmbus_client->adapter) {
+            eeprom_client = psu_eeprom_node->client;
+            break;
+        }
+    }
+    mutex_unlock(&list_lock);
+
+    return eeprom_client;
+}
+
+/*
+ * Compare the model name, then replace the content of psu_fan_dir.
+ */
+const char *fan_b2f_models[] = {
+    NULL
+};
+
+const char *fan_f2b_models[] = {
+    "YPEB1200",
+    "YPEB1200AM",
+    "UP1K21R-1085G",
+    NULL
+};
+
+int pddf_post_get_custom_psu_fan_dir(void *i2c_client, PSU_DATA_ATTR *adata, void *data)
+{
+    int i;
+    struct i2c_client *client = (struct i2c_client *)i2c_client;
+    struct psu_attr_info *psu_fan_dir_attr_info = (struct psu_attr_info *)data;
+    struct psu_data *psu_eeprom_client_data = NULL;
+    struct psu_attr_info *psu_eeprom_model_name = NULL;
+    struct i2c_client *psu_eeprom_client = NULL;
+
+    psu_eeprom_client = find_psu_eeprom_client(client);
+    if (!psu_eeprom_client) {
+        return 0;
+    }
+
+    /*
+     * Get the model name from the PSU EEPROM I2C client.
+     */
+    psu_eeprom_client_data = i2c_get_clientdata(psu_eeprom_client);
+    if (!psu_eeprom_client_data) {
+        return 0;
+    }
+    for (i = 0; i < psu_eeprom_client_data->num_attr; i++) {
+        if (strcmp(psu_eeprom_client_data->attr_info[i].name, "psu_model_name") == 0) {
+            psu_eeprom_model_name = &psu_eeprom_client_data->attr_info[i];
+            break;
+        }
+    }
+    if (!psu_eeprom_model_name) {
+        return 0;
+    }
+
+    /*
+     * Compare the model name, then replace the content of psu_fan_dir.
+     */
+    /* Check for B2F models */
+    for (i = 0; fan_b2f_models[i] != NULL; i++) {
+        if (strcmp(psu_eeprom_model_name->val.strval, fan_b2f_models[i]) == 0) {
+            strscpy(psu_fan_dir_attr_info->val.strval, 
+                    FAN_DIR_B2F, 
+                    sizeof(psu_fan_dir_attr_info->val.strval));
+            /* Match found in B2F models, exit early */
+            return 0;
+        }
+    }
+
+    /* If not found in B2F models, check F2B models */
+    for (i = 0; fan_f2b_models[i] != NULL; i++) {
+        if (strcmp(psu_eeprom_model_name->val.strval, fan_f2b_models[i]) == 0) {
+            strscpy(psu_fan_dir_attr_info->val.strval, 
+                    FAN_DIR_F2B, 
+                    sizeof(psu_fan_dir_attr_info->val.strval));
+            break;
+        }
+    }
+
+    return 0;
+}
+
+int pddf_custom_psu_post_probe(struct i2c_client *client, const struct i2c_device_id *dev_id)
+{
+    struct psu_eeprom_client_node *psu_eeprom_node;
+
+    if (strcmp(dev_id->name, "psu_eeprom") != 0) {
+        return 0;
+    }
+
+    psu_eeprom_node = kzalloc(sizeof(struct psu_eeprom_client_node), GFP_KERNEL);
+    if (!psu_eeprom_node) {
+        dev_dbg(&client->dev, "Can't allocate psu_eeprom_client_node (0x%x)\n", client->addr);
+        return -ENOMEM;
+    }
+
+    psu_eeprom_node->client = client;
+
+    mutex_lock(&list_lock);
+    list_add(&psu_eeprom_node->list, &psu_eeprom_client_list);
+    mutex_unlock(&list_lock);
+
+    return 0;
+}
+
+int pddf_custom_psu_post_remove(struct i2c_client *client)
+{
+    struct list_head    *list_node = NULL;
+    struct psu_eeprom_client_node *psu_eeprom_node = NULL;
+    int found = 0;
+
+    mutex_lock(&list_lock);
+
+    list_for_each(list_node, &psu_eeprom_client_list) {
+        psu_eeprom_node = list_entry(list_node, struct psu_eeprom_client_node, list);
+
+        if (psu_eeprom_node->client == client) {
+            list_del_init(&psu_eeprom_node->list);
+            found = 1;
+            break;
+        }
+    }
+
+    if (found) {
+        kfree(psu_eeprom_node);
+    }
+
+    mutex_unlock(&list_lock);
+
+    return 0;
+}
+
+static int __init pddf_custom_psu_init(void)
+{
+    mutex_init(&list_lock);
+    access_psu_model_name.post_get = pddf_post_get_custom_psu_model_name;
+    access_psu_fan_dir.post_get = pddf_post_get_custom_psu_fan_dir;
+    pddf_psu_ops.post_probe = pddf_custom_psu_post_probe;
+    pddf_psu_ops.post_remove = pddf_custom_psu_post_remove;
+    return 0;
+}
+
+static void __exit pddf_custom_psu_exit(void)
+{
+    return;
+}
+
+MODULE_AUTHOR("Broadcom");
+MODULE_DESCRIPTION("pddf custom psu api");
+MODULE_LICENSE("GPL");
+
+module_init(pddf_custom_psu_init);
+module_exit(pddf_custom_psu_exit);
+

--- a/platform/broadcom/sonic-platform-modules-accton/common/modules/ym2651y.c
+++ b/platform/broadcom/sonic-platform-modules-accton/common/modules/ym2651y.c
@@ -102,8 +102,8 @@ struct pmbus_register_value {
     u8   pmbus_revision; /* Register value */
     u8   mfr_serial[21]; /* Register value */
     u8   mfr_id[10];     /* Register value */
-    u8   mfr_model[16];  /* Register value */
-    u8   mfr_revsion[3]; /* Register value */
+    u8   mfr_model[18];  /* Register value */
+    u8   mfr_revsion[10]; /* Register value */
     u16  mfr_vin_min;    /* Register value */
     u16  mfr_vin_max;    /* Register value */
     u16  mfr_iin_max;    /* Register value */
@@ -212,8 +212,8 @@ static SENSOR_DEVICE_ATTR(psu_mfr_revision,    S_IRUGO, show_ascii, NULL, PSU_MF
 static SENSOR_DEVICE_ATTR(psu_mfr_serial,     S_IRUGO, show_ascii,  NULL, PSU_MFR_SERIAL);
 static SENSOR_DEVICE_ATTR(psu_mfr_vin_min,    S_IRUGO, show_linear, NULL, PSU_MFR_VIN_MIN);
 static SENSOR_DEVICE_ATTR(psu_mfr_vin_max,    S_IRUGO, show_linear, NULL, PSU_MFR_VIN_MAX);
-static SENSOR_DEVICE_ATTR(psu_mfr_vout_min,   S_IRUGO, show_linear, NULL, PSU_MFR_VOUT_MIN);
-static SENSOR_DEVICE_ATTR(psu_mfr_vout_max,   S_IRUGO, show_linear, NULL, PSU_MFR_VOUT_MAX);
+static SENSOR_DEVICE_ATTR(psu_mfr_vout_min,   S_IRUGO, show_vout, NULL, PSU_MFR_VOUT_MIN);
+static SENSOR_DEVICE_ATTR(psu_mfr_vout_max,   S_IRUGO, show_vout, NULL, PSU_MFR_VOUT_MAX);
 static SENSOR_DEVICE_ATTR(psu_mfr_iin_max,   S_IRUGO, show_linear, NULL, PSU_MFR_IIN_MAX);
 static SENSOR_DEVICE_ATTR(psu_mfr_iout_max,   S_IRUGO, show_linear, NULL, PSU_MFR_IOUT_MAX);
 static SENSOR_DEVICE_ATTR(psu_mfr_pin_max,   S_IRUGO, show_linear, NULL, PSU_MFR_PIN_MAX);
@@ -588,7 +588,9 @@ static ssize_t show_vout(struct device *dev, struct device_attribute *da,
     struct i2c_client *client = to_i2c_client(dev);
     struct ym2651y_data *data = i2c_get_clientdata(client);
 
-    if (data->chip == YM2401 || data->chip==YM1401A) {
+    if (data->chip == YM2401 || data->chip==YM1401A || 
+        (!strncmp("UPD1501SA-1190G", data->reg_val.mfr_model + 1, strlen("UPD1501SA-1190G"))) ||
+        (!strncmp("UPD1501SA-1290G", data->reg_val.mfr_model + 1, strlen("UPD1501SA-1290G")))) {
         return show_vout_by_mode(dev, da, buf);
     }
     else {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support 2nd source PSU
AS4630-54NPE/PE : UMEC 1085G
AS4630-54TE : UPD1501SA-1190G (F2B), UPD1501SA-1290G (B2F)

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

