### PR TITLE
[Platform][AS9817-32D] Update config.yml for default port status

### DIFF
--- a/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D-100G/th5-as9817-32d-32x100G.config.yml
+++ b/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D-100G/th5-as9817-32d-32x100G.config.yml
@@ -651,7 +651,7 @@ device:
       ?
         PORT_ID: [[1, 2], [11, 12], [22, 23], [33, 34], [44, 45], [55, 56], [66, 67], [77, 78], [264, 265], [275, 276], [286, 287], [297, 298], [308, 309], [319, 320], [330, 331], [341, 342]]
       :
-        ENABLE: 1
+        ENABLE: 0
         SPEED: 100000
         NUM_LANES: 4
         FEC_MODE: PC_FEC_RS528
@@ -659,7 +659,7 @@ device:
       ?
         PORT_ID: [76, 274]
       :
-        ENABLE: 1
+        ENABLE: 0
         SPEED: 25000
         NUM_LANES: 1
         FEC_MODE: PC_FEC_NONE

--- a/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D-100G/th5-as9817-32d-32x100G_ec.config.yml
+++ b/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D-100G/th5-as9817-32d-32x100G_ec.config.yml
@@ -632,7 +632,7 @@ device:
       ?
         PORT_ID: [[1, 2], [11, 12], [22, 23], [33, 34], [44, 45], [55, 56], [66, 67], [77, 78], [264, 265], [275, 276], [286, 287], [297, 298], [308, 309], [319, 320], [330, 331], [341, 342]]
       :
-        ENABLE: 1
+        ENABLE: 0
         SPEED: 100000
         NUM_LANES: 4
         FEC_MODE: PC_FEC_RS528
@@ -640,7 +640,7 @@ device:
       ?
         PORT_ID: [76, 274]
       :
-        ENABLE: 1
+        ENABLE: 0
         SPEED: 25000
         NUM_LANES: 1
         FEC_MODE: PC_FEC_NONE

--- a/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D-400G/th5-as9817-32d-32x400G.config.yml
+++ b/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D-400G/th5-as9817-32d-32x400G.config.yml
@@ -651,7 +651,7 @@ device:
       ?
         PORT_ID: [[1, 2], [11, 12], [22, 23], [33, 34], [44, 45], [55, 56], [66, 67], [77, 78], [264, 265], [275, 276], [286, 287], [297, 298], [308, 309], [319, 320], [330, 331], [341, 342]]
       :
-        ENABLE: 1
+        ENABLE: 0
         SPEED: 400000
         NUM_LANES: 8
         FEC_MODE: PC_FEC_RS544_2XN
@@ -659,7 +659,7 @@ device:
       ?
         PORT_ID: [76, 274]
       :
-        ENABLE: 1
+        ENABLE: 0
         SPEED: 25000
         NUM_LANES: 1
         FEC_MODE: PC_FEC_NONE

--- a/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D-400G/th5-as9817-32d-32x400G_ec.config.yml
+++ b/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D-400G/th5-as9817-32d-32x400G_ec.config.yml
@@ -632,7 +632,7 @@ device:
       ?
         PORT_ID: [[1, 2], [11, 12], [22, 23], [33, 34], [44, 45], [55, 56], [66, 67], [77, 78], [264, 265], [275, 276], [286, 287], [297, 298], [308, 309], [319, 320], [330, 331], [341, 342]]
       :
-        ENABLE: 1
+        ENABLE: 0
         SPEED: 400000
         NUM_LANES: 8
         FEC_MODE: PC_FEC_RS544_2XN
@@ -640,7 +640,7 @@ device:
       ?
         PORT_ID: [76, 274]
       :
-        ENABLE: 1
+        ENABLE: 0
         SPEED: 25000
         NUM_LANES: 1
         FEC_MODE: PC_FEC_NONE

--- a/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D/th5-as9817-32d-32x800G.config.yml
+++ b/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D/th5-as9817-32d-32x800G.config.yml
@@ -651,7 +651,7 @@ device:
       ?
         PORT_ID: [[1, 2], [11, 12], [22, 23], [33, 34], [44, 45], [55, 56], [66, 67], [77, 78], [264, 265], [275, 276], [286, 287], [297, 298], [308, 309], [319, 320], [330, 331], [341, 342]]
       :
-        ENABLE: 1
+        ENABLE: 0
         SPEED: 800000
         NUM_LANES: 8
         FEC_MODE: PC_FEC_RS544_2XN
@@ -659,10 +659,10 @@ device:
       ?
         PORT_ID: [76, 274]
       :
-        ENABLE: 1
+        ENABLE: 0
         SPEED: 25000
         NUM_LANES: 1
-        FEC_MODE: PC_FEC_RS528
+        FEC_MODE: PC_FEC_NONE
         MAX_FRAME_SIZE: 9416
       ?
         PORT_ID: 0

--- a/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D/th5-as9817-32d-32x800G_ec.config.yml
+++ b/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D/th5-as9817-32d-32x800G_ec.config.yml
@@ -632,7 +632,7 @@ device:
       ?
         PORT_ID: [[1, 2], [11, 12], [22, 23], [33, 34], [44, 45], [55, 56], [66, 67], [77, 78], [264, 265], [275, 276], [286, 287], [297, 298], [308, 309], [319, 320], [330, 331], [341, 342]]
       :
-        ENABLE: 1
+        ENABLE: 0
         SPEED: 800000
         NUM_LANES: 8
         FEC_MODE: PC_FEC_RS544_2XN
@@ -640,10 +640,10 @@ device:
       ?
         PORT_ID: [76, 274]
       :
-        ENABLE: 1
+        ENABLE: 0
         SPEED: 25000
         NUM_LANES: 1
-        FEC_MODE: PC_FEC_RS528
+        FEC_MODE: PC_FEC_NONE
         MAX_FRAME_SIZE: 9416
       ?
         PORT_ID: 0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. Change the default port admin status as down
2. Change the default fec on Ethernet256 and Ethernet257 as none

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

