### PR TITLE
flashrom build fix: incorrect tag name (#21473)

### DIFF
--- a/src/flashrom/Makefile
+++ b/src/flashrom/Makefile
@@ -12,7 +12,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	pushd ./flashrom-$(FLASHROM_VERSION_FULL)
 
 	# Check out tag: tags/0.9.7
-	git checkout -b flashrom-src tags/$(FLASHROM_VERSION_FULL)
+	git checkout -b flashrom-src v$(FLASHROM_VERSION_FULL)
 
 	# Apply patch series
 	stg init


### PR DESCRIPTION
flashrom recently started failing to build with the below error:
```
Cloning into 'flashrom-0.9.7'...
/sonic/src/flashrom/flashrom-0.9.7 /sonic/src/flashrom
fatal: 'tags/0.9.7' is not a commit and a branch 'flashrom-src' cannot be created from it
```
Nothing in sonic-buildimage has changed in relation to this so presumably flashrom upstream renamed their tags.

This commit just fixes the formatting of the tag name to use the new format.

Signed-off-by: Brad House (@bradh352)

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

