### PR TITLE
Remove the use of SYSLOG_IDENTIFIER in the SONiC platform API

### DIFF
--- a/device/accton/x86_64-accton_as9737_32db-r0/plugins/ssd_util.py
+++ b/device/accton/x86_64-accton_as9737_32db-r0/plugins/ssd_util.py
@@ -6,14 +6,9 @@
 try:
     from sonic_platform_base.sonic_ssd.ssd_generic import SsdUtil as MainSsdUtil
     from sonic_platform_base.sonic_ssd.ssd_generic import NOT_AVAILABLE
-    from sonic_py_common import logger
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
-SYSLOG_IDENTIFIER = "ssd_util.py"
-
-# Global logger instance
-log = logger.Logger(SYSLOG_IDENTIFIER)
 
 class SsdUtil(MainSsdUtil):
     """Platform-specific SsdUtil class"""

--- a/device/accton/x86_64-accton_as9817_32o-r0/sonic_platform/eeprom.py
+++ b/device/accton/x86_64-accton_as9817_32o-r0/sonic_platform/eeprom.py
@@ -8,16 +8,12 @@ try:
         from cStringIO import StringIO
 
     from sonic_platform_base.sonic_eeprom import eeprom_tlvinfo
-    from sonic_py_common import logger
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 CACHE_ROOT = '/var/cache/sonic/decode-syseeprom'
 CACHE_FILE = 'syseeprom_cache'
 NULL = 'N/A'
-
-SYSLOG_IDENTIFIER = "eeprom.py"
-log = logger.Logger(SYSLOG_IDENTIFIER)
 
 class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
 
@@ -148,5 +144,4 @@ class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
         try:
             return super().read_eeprom()
         except Exception as e:
-            log.log_warning(f"{str(e)}")
             return None

--- a/device/accton/x86_64-accton_as9817_32o-r0/sonic_platform/event.py
+++ b/device/accton/x86_64-accton_as9817_32o-r0/sonic_platform/event.py
@@ -23,6 +23,7 @@ class SfpEvent:
         self._sfp_list = sfp_list
         self._logger = Logger()
         self._sfp_change_event_data = {'present': 0}
+        self._sfp_change_event_data['present'] = self.get_presence_bitmap()
 
     def get_presence_bitmap(self):
         bitmap = 0

--- a/device/accton/x86_64-accton_as9817_32o-r0/sonic_platform/pcie.py
+++ b/device/accton/x86_64-accton_as9817_32o-r0/sonic_platform/pcie.py
@@ -6,12 +6,13 @@
 # Base PCIe class
 #############################################################################
 
-import syslog
-import os
 try:
     from sonic_platform_base.sonic_pcie.pcie_common import PcieUtil
+    from sonic_py_common import logger
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
+
+log = logger.Logger()
 
 class Pcie(PcieUtil):
     """Edgecore Platform-specific PCIe class"""
@@ -19,21 +20,6 @@ class Pcie(PcieUtil):
     def __init__(self, platform_path):
         PcieUtil.__init__(self, platform_path)
         self._conf_rev = self.__get_conf_rev()
-
-    def __log(self, level, message):
-        """
-        Logs a message with the specified level, adding filename and class name as prefix.
-
-        Logging behavior (e.g., log facility, identifier, destination, format) depends on the 
-        system's syslog configuration and the environment of the caller using this class.
-
-        Args:
-            level (int): syslog log level (e.g., syslog.LOG_WARNING, syslog.LOG_ERR)
-            message (str): The log message to record.
-        """
-        filename = os.path.basename(__file__)
-        class_name = self.__class__.__name__
-        syslog.syslog(level, f"{filename}:{class_name} {message}")
 
     def __get_conf_rev(self):
         """
@@ -52,13 +38,13 @@ class Pcie(PcieUtil):
 
             eeprom = Tlv()
             if eeprom is None:
-                self.__log(syslog.LOG_WARNING, "Initializing the EEPROM object has failed.")
+                log.log_warning("Initializing the EEPROM object has failed.")
                 return None
 
             # Try to get the TLV field for the label revision
             label_rev = eeprom._eeprom.get('0x27', None)
             if label_rev is None:
-                self.__log(syslog.LOG_WARNING, "Cannot retrieve Label Revision (0x27) from the system EEPROM.")
+                log.log_warning("Cannot retrieve Label Revision (0x27) from the system EEPROM.")
                 return None
 
             for rev in (label_rev, label_rev[:-1]):
@@ -67,7 +53,7 @@ class Pcie(PcieUtil):
                     return rev
 
         except Exception as e:
-            self.__log(syslog.LOG_WARNING, f"{str(e)}")
+            log.log_warning(f"{str(e)}")
             pass
 
         return None

--- a/device/accton/x86_64-accton_as9817_64d-r0/plugins/ssd_util.py
+++ b/device/accton/x86_64-accton_as9817_64d-r0/plugins/ssd_util.py
@@ -6,14 +6,9 @@
 try:
     from sonic_platform_base.sonic_ssd.ssd_generic import SsdUtil as MainSsdUtil
     from sonic_platform_base.sonic_ssd.ssd_generic import NOT_AVAILABLE
-    from sonic_py_common import logger
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
-SYSLOG_IDENTIFIER = "ssd_util.py"
-
-# Global logger instance
-log = logger.Logger(SYSLOG_IDENTIFIER)
 
 class SsdUtil(MainSsdUtil):
     """Platform-specific SsdUtil class"""

--- a/device/accton/x86_64-accton_as9817_64o-r0/plugins/ssd_util.py
+++ b/device/accton/x86_64-accton_as9817_64o-r0/plugins/ssd_util.py
@@ -6,14 +6,9 @@
 try:
     from sonic_platform_base.sonic_ssd.ssd_generic import SsdUtil as MainSsdUtil
     from sonic_platform_base.sonic_ssd.ssd_generic import NOT_AVAILABLE
-    from sonic_py_common import logger
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
-SYSLOG_IDENTIFIER = "ssd_util.py"
-
-# Global logger instance
-log = logger.Logger(SYSLOG_IDENTIFIER)
 
 class SsdUtil(MainSsdUtil):
     """Platform-specific SsdUtil class"""


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Since using logger.Logger(SYSLOG_IDENTIFIER) affects the caller's syslog identifier, it needs to be removed.

#### How I did it
To replace logger.Logger(SYSLOG_IDENTIFIER) with logger.Logger() 

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

