### PR TITLE
JIRA-SONIC-11569: Remove default AN disabled configuration from mgmt …

### DIFF
--- a/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D-100G/hwsku.json
+++ b/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D-100G/hwsku.json
@@ -162,13 +162,11 @@
         },
 
         "Ethernet256": {
-            "default_brkout_mode": "1x10G[1G]",
-            "autoneg": "off"
+            "default_brkout_mode": "1x10G[1G]"
         },
 
         "Ethernet257": {
-            "default_brkout_mode": "1x10G[1G]",
-            "autoneg": "off"
+            "default_brkout_mode": "1x10G[1G]"
         }
     }
 }

--- a/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D/hwsku.json
+++ b/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D/hwsku.json
@@ -161,13 +161,11 @@
         },
 
         "Ethernet256": {
-            "default_brkout_mode": "1x10G[1G]",
-            "autoneg": "off"
+            "default_brkout_mode": "1x10G[1G]"
         },
 
         "Ethernet257": {
-            "default_brkout_mode": "1x10G[1G]",
-            "autoneg": "off"
+            "default_brkout_mode": "1x10G[1G]"
         }
     }
 }

--- a/device/accton/x86_64-accton_as9737_32db-r0/Accton-AS9737-32DB-100G/hwsku.json
+++ b/device/accton/x86_64-accton_as9737_32db-r0/Accton-AS9737-32DB-100G/hwsku.json
@@ -161,8 +161,7 @@
         },
 
         "Ethernet256": {
-            "default_brkout_mode": "1x10G[1G]",
-            "autoneg": "off"
+            "default_brkout_mode": "1x10G[1G]"
         }
     }
 }

--- a/device/accton/x86_64-accton_as9737_32db-r0/Accton-AS9737-32DB/hwsku.json
+++ b/device/accton/x86_64-accton_as9737_32db-r0/Accton-AS9737-32DB/hwsku.json
@@ -161,8 +161,7 @@
         },
 
         "Ethernet256": {
-            "default_brkout_mode": "1x10G[1G]",
-            "autoneg": "off"
+            "default_brkout_mode": "1x10G[1G]"
         }
     }
 }


### PR DESCRIPTION
…ports at AS9726/AS9737

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
AN feature is not supported on the mgmt ports.
#### How I did it
Remove the autoneg settings from mgmt port in hwsku.json.
#### How to verify it
Factory default rebooting, check the AN configuration of mgmt ports. The setting shall be N/A.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

