### PR TITLE
[Platform][AS4625-54P/T][AS5835-54X][AS9716-32D] Fix warning log about led_fw_path from syncd during boot-up

### DIFF
--- a/device/accton/x86_64-accton_as4625_54p-r0/Accton-AS4625-54P/hr4-as4625-48x1G+6x10G.config.bcm
+++ b/device/accton/x86_64-accton_as4625_54p-r0/Accton-AS4625-54P/hr4-as4625-48x1G+6x10G.config.bcm
@@ -33,6 +33,9 @@ ifp_inports_support_enable=1
 
 num_ipv6_lpm_128b_entries=512
 
+# Let Broadcom community sai to load custom_led.bin
+led_fw_path="/usr/share/sonic/platform/"
+
 
 dport_map_port_25=1
 dport_map_port_26=2

--- a/device/accton/x86_64-accton_as4625_54t-r0/Accton-AS4625-54T/hr4-as4625-48x1G+6x10G.config.bcm
+++ b/device/accton/x86_64-accton_as4625_54t-r0/Accton-AS4625-54T/hr4-as4625-48x1G+6x10G.config.bcm
@@ -33,6 +33,9 @@ ifp_inports_support_enable=1
 
 num_ipv6_lpm_128b_entries=512
 
+# Let Broadcom community sai to load custom_led.bin
+led_fw_path="/usr/share/sonic/platform/"
+
 
 dport_map_port_25=1
 dport_map_port_26=2

--- a/device/accton/x86_64-accton_as5835_54x-r0/Accton-AS5835-54X/mv2-as5835-48x10G+6x100G.config.bcm
+++ b/device/accton/x86_64-accton_as5835_54x-r0/Accton-AS5835-54X/mv2-as5835-48x10G+6x100G.config.bcm
@@ -51,6 +51,9 @@ use_all_splithorizon_groups=1
 host_as_route_disable=1
 sai_tunnel_support=1
 
+# Let Broadcom community sai to load custom_led.bin
+led_fw_path="/usr/share/sonic/platform/"
+
 #FC0
 dport_map_port_1=1
 dport_map_port_2=2

--- a/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D-100G/th3-as9716-32x100G.config.bcm
+++ b/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D-100G/th3-as9716-32x100G.config.bcm
@@ -45,6 +45,9 @@ bcm_tunnel_term_compatible_mode.0=1
 sai_tunnel_support=2
 sai_tunnel_global_sip_mask_enable=1
 
+# Let Broadcom community sai to load custom_led.bin
+led_fw_path="/usr/share/sonic/platform/"
+
 #firmware load method, use fast load
 load_firmware=0x2
 

--- a/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D/th3-as9716-32x400G.config.bcm
+++ b/device/accton/x86_64-accton_as9716_32d-r0/Accton-AS9716-32D/th3-as9716-32x400G.config.bcm
@@ -38,6 +38,9 @@ bcm_tunnel_term_compatible_mode.0=1
 sai_tunnel_support=2
 sai_tunnel_global_sip_mask_enable=1
 
+# Let Broadcom community sai to load custom_led.bin
+led_fw_path="/usr/share/sonic/platform/"
+
 #BC0#
 dport_map_port_1=81
 dport_map_port_2=82


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- The syslog records the warning message after boot-up by BRCM Community SAI.
  - `WARNING syncd#syncd: [none] SAI_API_SWITCH:platform_process_command:425 Platform command "if $?feature_cmicx && !$?trident3 && !$?helix5 "m0 load 0 0x3800 ${led_fw_path}custom_led.bin"" failed, rc = -1`

#### How I did it
- Add the led_fw_path with correct path to BCM config file.
  - Only below platforms found the log.
    - `AS4625-54P`
    - `AS4625-54T`
    - `AS5835-54X`
    - `AS9716-32D`

#### How to verify it
- The warning log is not present after boot-up.
  - `sudo rm /var/log/syslog*`
  - `sudo reboot`
  - `sudo cat /var/log/syslog | grep --color=auto led_fw_path`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

