### PR TITLE
[Platform][AS5835-54T][AS5835-54X][Thermal] Fix pytest test_thermal.py::TestThermalApi failed

### DIFF
--- a/device/accton/x86_64-accton_as5835_54t-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as5835_54t-r0/pddf/pddf-device.json
@@ -430,9 +430,9 @@
             "path_info": {"sysfs_base_path": "/sys/class/hwmon/hwmon1"},
             "attr_list":
             [
-                { "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp2_crit"},
-                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp2_max"},
-                { "attr_name": "temp1_input", "drv_attr_name":"temp2_input"}
+                { "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp4_crit"},
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp4_max"},
+                { "attr_name": "temp1_input", "drv_attr_name":"temp4_input"}
             ]
         }
     },
@@ -445,9 +445,9 @@
             "path_info": {"sysfs_base_path": "/sys/class/hwmon/hwmon1"},
             "attr_list":
             [
-                { "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp3_crit"},
-                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp3_max"},
-                { "attr_name": "temp1_input", "drv_attr_name":"temp3_input"}
+                { "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp8_crit"},
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp8_max"},
+                { "attr_name": "temp1_input", "drv_attr_name":"temp8_input"}
             ]
         }
     },
@@ -460,9 +460,9 @@
             "path_info": {"sysfs_base_path": "/sys/class/hwmon/hwmon1"},
             "attr_list":
             [
-                { "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp4_crit"},
-                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp4_max"},
-                { "attr_name": "temp1_input", "drv_attr_name":"temp4_input"}
+                { "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp10_crit"},
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp10_max"},
+                { "attr_name": "temp1_input", "drv_attr_name":"temp10_input"}
             ]
         }
     },
@@ -475,9 +475,9 @@
             "path_info": {"sysfs_base_path": "/sys/class/hwmon/hwmon1"},
             "attr_list":
             [
-                { "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp5_crit"},
-                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp5_max"},
-                { "attr_name": "temp1_input", "drv_attr_name":"temp5_input"}
+                { "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp14_crit"},
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp14_max"},
+                { "attr_name": "temp1_input", "drv_attr_name":"temp14_input"}
             ]
         }
     },

--- a/device/accton/x86_64-accton_as5835_54x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as5835_54x-r0/pddf/pddf-device.json
@@ -711,9 +711,9 @@
             "path_info": {"sysfs_base_path": "/sys/class/hwmon/hwmon1"},
             "attr_list":
             [
-                { "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp3_crit"},
-                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp3_max"},
-                { "attr_name": "temp1_input", "drv_attr_name":"temp3_input"}
+                { "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp6_crit"},
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp6_max"},
+                { "attr_name": "temp1_input", "drv_attr_name":"temp6_input"}
             ]
         }
     },
@@ -726,9 +726,9 @@
             "path_info": {"sysfs_base_path": "/sys/class/hwmon/hwmon1"},
             "attr_list":
             [
-                { "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp4_crit"},
-                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp4_max"},
-                { "attr_name": "temp1_input", "drv_attr_name":"temp4_input"}
+                { "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp12_crit"},
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp12_max"},
+                { "attr_name": "temp1_input", "drv_attr_name":"temp12_input"}
             ]
         }
     },
@@ -741,9 +741,9 @@
             "path_info": {"sysfs_base_path": "/sys/class/hwmon/hwmon1"},
             "attr_list":
             [
-                { "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp5_crit"},
-                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp5_max"},
-                { "attr_name": "temp1_input", "drv_attr_name":"temp5_input"}
+                { "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp16_crit"},
+                { "attr_name": "temp1_high_threshold", "drv_attr_name":"temp16_max"},
+                { "attr_name": "temp1_input", "drv_attr_name":"temp16_input"}
             ]
         }
     },


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- The linux kernel built-in kernel module: coretemp (/drivers/hwmon/coretemp.c) has been changed on **[Linux-6.1.94](https://web.git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-6.1.y&id=3fa78ee0e381d83d9413f05cc229c5ba399116b5)**.
  - The rule to generate sysfs attribute number **attr_no** is changed into `attr_no = cpu_core_id + 2`. 
  - However, the pddf-device.json still uses the old attribute number in name against Linux-5.10.179 so that the below tests in `platform_tests/api/test_thermal.py::TestThermalApi` are failed.
    - `test_get_status`
    - `test_get_temperature`
    - `test_get_minimum_recorded`
    - `test_get_maximum_recorded`

#### How I did it
- Correct drv_attr_name settings for TEMP6 ~ TEMP9 in pddf-device.json to get correct sysfs attributes.

#### How to verify it
- Re-run the pytest cases are all pass.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

