### PR TITLE
[Submodule] update URL and branch for submodules sonic-host-services to ec-github 202411.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -117,8 +117,8 @@
 	branch = 202411
 [submodule "src/sonic-host-services"]
 	path = src/sonic-host-services
-	url = https://github.com/sonic-net/sonic-host-services
-	branch = 202411
+	url = https://github.com/edge-core/sonic-host-services.git
+	branch = 202411.0
 [submodule "src/sonic-gnmi"]
 	path = src/sonic-gnmi
 	url = https://github.com/sonic-net/sonic-gnmi.git


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Create 202411.0 branch for host-services to maintain submodule.

#### How I did it
Update file .gitmodules to download 202411.0 branch codebase for required repositories.

#### How to verify it
Exec 'git submodule update --init src/sonic-host-services' and check if download the correct codes.
