### PR TITLE
[Platform][AS4625-54T][AS9736-64D][AS9737-32DB][AS4630-54NPE] Update driver for kernel 6.1

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as4625-54t/modules/x86-64-accton-as4625-54t-psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as4625-54t/modules/x86-64-accton-as4625-54t-psu.c
@@ -203,8 +203,8 @@ static int as4625_54t_psu_probe(struct i2c_client *client,
 		goto exit_free;
 	}
 
-	data->hwmon_dev = hwmon_device_register_with_info(&client->dev,
-											DRVNAME, NULL, NULL, NULL);
+	data->hwmon_dev = hwmon_device_register_with_groups(&client->dev,
+											DRVNAME, NULL, NULL);
 	if (IS_ERR(data->hwmon_dev)) {
 		status = PTR_ERR(data->hwmon_dev);
 		goto exit_remove;
@@ -223,7 +223,7 @@ exit:
 	return status;
 }
 
-static int as4625_54t_psu_remove(struct i2c_client *client)
+static void as4625_54t_psu_remove(struct i2c_client *client)
 {
 	struct as4625_54t_psu_data *data = i2c_get_clientdata(client);
 
@@ -231,7 +231,6 @@ static int as4625_54t_psu_remove(struct i2c_client *client)
 	sysfs_remove_group(&client->dev.kobj, &as4625_54t_psu_group);
 	kfree(data);
 
-	return 0;
 }
 
 enum psu_index

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54npe/modules/x86-64-accton-as4630-54npe-cpld.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54npe/modules/x86-64-accton-as4630-54npe-cpld.c
@@ -770,7 +770,7 @@ exit:
 	return ret;
 }
 
-static int as4630_54npe_cpld_remove(struct i2c_client *client)
+static void as4630_54npe_cpld_remove(struct i2c_client *client)
 {
     struct as4630_54npe_cpld_data *data = i2c_get_clientdata(client);
     const struct attribute_group *group = NULL;
@@ -795,7 +795,6 @@ static int as4630_54npe_cpld_remove(struct i2c_client *client)
 
     kfree(data);
 
-    return 0;
 }
 
 static int as4630_54npe_cpld_read_internal(struct i2c_client *client, u8 reg)

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54npe/modules/x86-64-accton-as4630-54npe-psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54npe/modules/x86-64-accton-as4630-54npe-psu.c
@@ -188,7 +188,7 @@ exit:
     return status;
 }
 
-static int as4630_54npe_psu_remove(struct i2c_client *client)
+static void as4630_54npe_psu_remove(struct i2c_client *client)
 {
     struct as4630_54npe_psu_data *data = i2c_get_clientdata(client);
 
@@ -196,7 +196,6 @@ static int as4630_54npe_psu_remove(struct i2c_client *client)
     sysfs_remove_group(&client->dev.kobj, &as4630_54npe_psu_group);
     kfree(data);
 
-    return 0;
 }
 
 enum psu_index

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54npe/modules/ym2651y.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54npe/modules/ym2651y.c
@@ -489,7 +489,7 @@ exit:
     return status;
 }
 
-static int ym2651y_remove(struct i2c_client *client)
+static void ym2651y_remove(struct i2c_client *client)
 {
     struct ym2651y_data *data = i2c_get_clientdata(client);
 
@@ -497,7 +497,6 @@ static int ym2651y_remove(struct i2c_client *client)
     sysfs_remove_group(&client->dev.kobj, &ym2651y_group);
     kfree(data);
 
-    return 0;
 }
 
 static const struct i2c_device_id ym2651y_id[] = {

--- a/platform/broadcom/sonic-platform-modules-accton/as9736-64d/modules/accton_as9736_64d_cpld.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9736-64d/modules/accton_as9736_64d_cpld.c
@@ -786,7 +786,7 @@ exit:
     return ret;
 }
 
-static int as9736_64d_cpld_remove(struct i2c_client *client)
+static void as9736_64d_cpld_remove(struct i2c_client *client)
 {
     struct as9736_64d_cpld_data *data = i2c_get_clientdata(client);
     const struct attribute_group *group = NULL;
@@ -819,7 +819,6 @@ static int as9736_64d_cpld_remove(struct i2c_client *client)
 
     kfree(data);
 
-    return 0;
 }
 
 static int as9736_64d_cpld_read_internal(struct i2c_client *client, u8 reg)

--- a/platform/broadcom/sonic-platform-modules-accton/as9736-64d/modules/accton_as9736_64d_fan.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9736-64d/modules/accton_as9736_64d_fan.c
@@ -777,13 +777,12 @@ exit:
     return status;
 }
 
-static int as9736_64d_fan_remove(struct i2c_client *client)
+static void as9736_64d_fan_remove(struct i2c_client *client)
 {
     struct as9736_64d_fan_data *data = i2c_get_clientdata(client);
     hwmon_device_unregister(data->hwmon_dev);
     sysfs_remove_group(&client->dev.kobj, &as9736_64d_fan_group);
 
-    return 0;
 }
 
 /* Addresses to scan */

--- a/platform/broadcom/sonic-platform-modules-accton/as9736-64d/modules/accton_as9736_64d_psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9736-64d/modules/accton_as9736_64d_psu.c
@@ -183,7 +183,7 @@ exit:
     return status;
 }
 
-static int as9736_64d_psu_remove(struct i2c_client *client)
+static void as9736_64d_psu_remove(struct i2c_client *client)
 {
     struct as9736_64d_psu_data *data = i2c_get_clientdata(client);
 
@@ -191,7 +191,6 @@ static int as9736_64d_psu_remove(struct i2c_client *client)
     sysfs_remove_group(&client->dev.kobj, &as9736_64d_psu_group);
     kfree(data);
 
-    return 0;
 }
 
 enum psu_index

--- a/platform/broadcom/sonic-platform-modules-accton/as9736-64d/modules/accton_i2c_psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9736-64d/modules/accton_i2c_psu.c
@@ -459,7 +459,7 @@ exit:
     return status;
 }
 
-static int accton_i2c_psu_remove(struct i2c_client *client)
+static void accton_i2c_psu_remove(struct i2c_client *client)
 {
     struct accton_i2c_psu_data *data = i2c_get_clientdata(client);
 
@@ -467,7 +467,6 @@ static int accton_i2c_psu_remove(struct i2c_client *client)
     sysfs_remove_group(&client->dev.kobj, &accton_i2c_psu_group);
     kfree(data);
 
-    return 0;
 }
 /* Support psu moduel
  */

--- a/platform/broadcom/sonic-platform-modules-accton/as9737-32db/modules/accton_as9737_32db_cpld.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9737-32db/modules/accton_as9737_32db_cpld.c
@@ -645,7 +645,7 @@ exit:
     return ret;
 }
 
-static int as9737_32db_cpld_remove(struct i2c_client *client)
+static void as9737_32db_cpld_remove(struct i2c_client *client)
 {
     struct as9737_32db_cpld_data *data = i2c_get_clientdata(client);
     const struct attribute_group *group = NULL;
@@ -673,7 +673,6 @@ static int as9737_32db_cpld_remove(struct i2c_client *client)
 
     kfree(data);
 
-    return 0;
 }
 
 static int as9737_32db_cpld_read_internal(struct i2c_client *client, u8 reg)

--- a/platform/broadcom/sonic-platform-modules-accton/as9737-32db/modules/accton_as9737_32db_fan.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9737-32db/modules/accton_as9737_32db_fan.c
@@ -738,8 +738,8 @@ static int as9737_32db_fan_probe(struct platform_device *pdev)
     int status = 0;
     struct device *hwmon_dev;
 
-    hwmon_dev = hwmon_device_register_with_info(&pdev->dev, DRVNAME,
-                    NULL, NULL, as9737_32db_fan_groups);
+    hwmon_dev = hwmon_device_register_with_groups(&pdev->dev, DRVNAME,
+                    NULL, as9737_32db_fan_groups);
     if (IS_ERR(data->hwmon_dev)) {
         status = PTR_ERR(data->hwmon_dev);
         return status;

--- a/platform/broadcom/sonic-platform-modules-accton/as9737-32db/modules/accton_as9737_32db_mux.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9737-32db/modules/accton_as9737_32db_mux.c
@@ -172,11 +172,10 @@ exit_mux:
 	return ret;
 }
 
-static int as9737_32db_mux_remove(struct i2c_client *client)
+static void as9737_32db_mux_remove(struct i2c_client *client)
 {
 	struct i2c_mux_core *muxc = i2c_get_clientdata(client);
 	as9737_32db_mux_cleanup(muxc);
-	return 0;
 }
 
 static struct i2c_driver as9737_32db_mux_driver = {

--- a/platform/broadcom/sonic-platform-modules-accton/as9737-32db/modules/accton_as9737_32db_psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9737-32db/modules/accton_as9737_32db_psu.c
@@ -989,8 +989,8 @@ static int as9737_32db_psu_probe(struct platform_device *pdev)
     int status = 0;
     struct device *hwmon_dev = NULL;
 
-    hwmon_dev = hwmon_device_register_with_info(&pdev->dev, DRVNAME, 
-                    NULL, NULL, as9737_32db_psu_groups[pdev->id]);
+    hwmon_dev = hwmon_device_register_with_groups(&pdev->dev, DRVNAME,
+                    NULL, as9737_32db_psu_groups[pdev->id]);
     if (IS_ERR(hwmon_dev)) {
         status = PTR_ERR(hwmon_dev);
         return status;

--- a/platform/broadcom/sonic-platform-modules-accton/as9737-32db/modules/accton_as9737_32db_thermal.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9737-32db/modules/accton_as9737_32db_thermal.c
@@ -415,8 +415,8 @@ static int as9737_32db_thermal_probe(struct platform_device *pdev)
     int status = 0;
     struct device *hwmon_dev;
 
-    hwmon_dev = hwmon_device_register_with_info(&pdev->dev, DRVNAME, 
-                    NULL, NULL, as9737_32db_thermal_groups);
+    hwmon_dev = hwmon_device_register_with_groups(&pdev->dev, DRVNAME,
+                    NULL, as9737_32db_thermal_groups);
     if (IS_ERR(data->hwmon_dev)) {
         status = PTR_ERR(data->hwmon_dev);
         return status;


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The sonic-platform-modules-accton package builds were failing to build against the 6.1 kernel in bookworm branch.

#### How I did it
Update driver for kernel 6.1 on platform as4625-54t/as9736-64d/as9737-32db/as4630-54npe

#### How to verify it
Test below show commands are supported
- show platform syseeprom
- show platform fan
- show platform psustatus
- show platform temperature

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

