### PR TITLE
Remove default IPINIP configuration when SWSS docker init

### DIFF
--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -58,7 +58,9 @@ if [[ "$SYSTEM_WARM_START" == "true" ]] || [[ "$SWSS_WARM_START" == "true" ]]; t
   exit 0
 fi
 
-SWSSCONFIG_ARGS="ipinip.json ports.json switch.json vxlan.json"
+# Remove ipinip.json because it conflicts with DNAT feature in BRCM chip for UDP packets
+# SWSSCONFIG_ARGS="ipinip.json ports.json switch.json vxlan.json"
+SWSSCONFIG_ARGS="ports.json switch.json vxlan.json"
 
 for file in $SWSSCONFIG_ARGS; do
     swssconfig /etc/swss/config.d/$file


### PR DESCRIPTION
Remove ipinip.json because it conflicts with DNAT feature in BRCM chip for UDP packets