### PR TITLE
Change teamd log rule

### DIFF
--- a/files/image_config/rsyslog/rsyslog.d/00-sonic.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.d/00-sonic.conf.j2
@@ -33,7 +33,7 @@ if re_match($programname, "bgp[0-9]*#bgpd") then {
 
 ## Teamd rules
 
-if $programname contains "teamd_" then {
+if $programname contains "teamd#teamd_" then {
     /var/log/teamd.log
     stop
 }


### PR DESCRIPTION
If sonic-mgmt pytest case name contains "teamd_", the some messages executed by loganalyzer are add to teamd.log. These messages shall be added to syslog.log file.
To separate teamd container and sonic-mgmt, we change teamd log rule to check that program name contains "teamd#teamd_".


