### PR TITLE
[Submodule] update URL and branch for submodules sonic-host-services to ec-github 202311.X

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,8 +73,8 @@
 	branch = 202311
 [submodule "src/sonic-host-services"]
 	path = src/sonic-host-services
-	url = https://github.com/sonic-net/sonic-host-services
-	branch = 202311
+	url = https://github.com/edge-core/sonic-host-services.git
+	branch = 202311.X
 [submodule "src/sonic-gnmi"]
 	path = src/sonic-gnmi
 	url = https://github.com/sonic-net/sonic-gnmi.git


### PR DESCRIPTION
Why I did it
Create 202311.X branch for host-services to maintain submodule.

How I did it
Update file .gitmodules to download 202311.0 branch codebase for required repositories.

How to verify it
Exec 'git submodule update --init src/sonic-host-services' and check if download the correct codes.
