### PR TITLE
Migrate ebtables toc nfttables

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -409,8 +409,9 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     auditd                  \
     linux-perf              \
     resolvconf              \
-	lsof                    \
-	sysstat
+    lsof                    \
+    sysstat                 \
+    nftables
 
 # default rsyslog version is 8.2110.0 which has a bug on log rate limit,
 # use backport version
@@ -689,8 +690,8 @@ if [ "${enable_organization_extensions}" = "y" ]; then
    fi
 fi
 
-## Setup ebtable rules (rule file in text format)
-sudo cp files/image_config/ebtables/ebtables.filter.cfg ${FILESYSTEM_ROOT}/etc
+## Setup nftables rules
+sudo cp files/image_config/nftables/nftables.conf ${FILESYSTEM_ROOT}/etc
 
 ## Debug Image specific changes
 ## Update motd for debug image

--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -21,7 +21,10 @@ RUN apt-get update &&       \
         pciutils            \
         # Needed for installing netifaces Python package
         build-essential     \
-        python3-dev
+        python3-dev         \
+        iptables=1.8.7-1 \
+        libnftables1=0.9.8-3.1+deb11u2 \
+        nftables=0.9.8-3.1+deb11u2
 
 {% if ( CONFIGURED_ARCH == "armhf" or CONFIGURED_ARCH == "arm64" ) %}
 # Fix for gcc/python/iputils-ping not found in arm docker

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -208,9 +208,9 @@ function postStartAction()
            fi
        fi
     fi
-    # Setup ebtables configuration
+    # Setup nftables configuration
 {%- if sonic_asic_platform != "vs" %}
-    ebtables_config
+    nft -f /etc/nftables.conf
 {%- endif %}
     # chassisdb starts before database starts, bypass the PING check since other
     # databases are not availbale until database container is ready.

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -789,6 +789,9 @@ if [ "${PIPESTATUS[0]}" != "0" ]; then
     exit 1
 fi
 
+# Copy nftables.conf.j2 for SONiC Package Manager
+sudo cp $BUILD_TEMPLATES/nftables.conf.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/nftables.conf.j2
+
 # Copy docker_image_ctl.j2 for SONiC Package Manager
 sudo cp $BUILD_TEMPLATES/docker_image_ctl.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/docker_image_ctl.j2
 

--- a/files/image_config/nftables/nftables.conf.j2
+++ b/files/image_config/nftables/nftables.conf.j2
@@ -1,0 +1,48 @@
+#!/usr/sbin/nft -f
+
+flush ruleset
+
+table bridge filter {
+        chain INPUT {
+                type filter hook input priority filter; policy accept;
+        }
+
+        chain FORWARD {
+                type filter hook forward priority filter; policy accept;
+                iifname "PortChannel*" counter packets 0 bytes 0 jump MCLAG_PORT_ISOLATION
+                iifname "Ethernet*" counter packets 0 bytes 0 jump MCLAG_PORT_ISOLATION
+                iifname "VTTNL*" counter packets 0 bytes 0 jump MCLAG_PORT_ISOLATION
+                ether type ip6 icmpv6 type 135-136 icmpv6 code 0  counter packets 0 bytes 0 jump ND_LIST
+                ether type vlan vlan type ip6 icmpv6 type 135-136 icmpv6 code 0 counter packets 0 bytes 0 jump ND_LIST
+                ether type vlan vlan type 0x0806  counter packets 0 bytes 0 jump VLAN_ARP_LIST
+                ether type arp counter packets 0 bytes 0 jump ARP_LIST
+                ether type ip ip daddr 255.255.255.255 udp sport 68 udp dport 67  counter packets 0 bytes 0 jump VLAN_UNTAG_PORT_LIST
+{%- if sonic_asic_platform != "vs" %}
+                ether daddr 01:80:c2:00:00:00 counter packets 0 bytes 0 drop
+                ether type arp counter packets 0 bytes 0 drop
+                ether type vlan vlan type 0x0806  counter packets 0 bytes 0 drop
+                ether type ip6 icmpv6 type 135-136 icmpv6 code 0  counter packets 0 bytes 0 drop
+                ether type vlan vlan type ip6 icmpv6 type 135-136 icmpv6 code 0 counter packets 0 bytes 0 drop
+                ether type vlan vlan type 0x8100  counter packets 0 bytes 0 drop
+{%- endif %}
+        }
+
+        chain OUTPUT {
+                type filter hook output priority filter; policy accept;
+        }
+
+        chain MCLAG_PORT_ISOLATION {
+        }
+
+        chain ND_LIST {
+        }
+
+        chain VLAN_ARP_LIST {
+        }
+
+        chain ARP_LIST {
+        }
+
+        chain VLAN_UNTAG_PORT_LIST {
+        }
+}

--- a/slave.mk
+++ b/slave.mk
@@ -1450,6 +1450,8 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 	export include_mux="$(INCLUDE_MUX)"
 	export include_bootchart="$(INCLUDE_BOOTCHART)"
 	export enable_bootchart="$(ENABLE_BOOTCHART)"
+	mkdir -p files/image_config/nftables
+	j2 files/build_templates/nftables.conf.j2 > files/image_config/nftables/nftables.conf
 	$(foreach docker, $($*_DOCKERS),\
 		export docker_image="$(docker)"
 		export docker_image_name="$(basename $(docker))"


### PR DESCRIPTION
Migrate ebtables toc nfttables

#### Why I did it
- Install nftables and move the default conifuration in ebtables.filter.cfg to nftables.conf.
- Upgrade nftables package to proper version.
- Introduce new chains for ND suppression
- Add condition for VS platform

#### How I did it
N/A

#### How to verify it
N/A

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

