### PR TITLE
[Platform][AS7712-32X] Sync community platform related PRs into 202411.0

### DIFF
--- a/device/accton/x86_64-accton_as7712_32x-r0/Accton-AS7712-32X/th-as7712-32x100G.config.bcm
+++ b/device/accton/x86_64-accton_as7712_32x-r0/Accton-AS7712-32X/th-as7712-32x100G.config.bcm
@@ -222,98 +222,98 @@ dport_map_port_16=128
 #FC0
 portmap_1=1:100
 portmap_2=2:25:i
-portmap_3=3:25:i
+portmap_3=3:25:50:i
 portmap_4=4:25:i
 
 #FC1
 portmap_5=5:100
 portmap_6=6:25:i
-portmap_7=7:25:i
+portmap_7=7:25:50:i
 portmap_8=8:25:i
 
 #FC2
 portmap_9=9:100
 portmap_10=10:25:i
-portmap_11=11:25:i
+portmap_11=11:25:50:i
 portmap_12=12:25:i
 
 #FC3
 portmap_13=13:100
 portmap_14=14:25:i
-portmap_15=15:25:i
+portmap_15=15:25:50:i
 portmap_16=16:25:i
 
 #FC4
 portmap_17=17:100
 portmap_18=18:25:i
-portmap_19=19:25:i
+portmap_19=19:25:50:i
 portmap_20=20:25:i
 
 #FC5
 portmap_21=21:100
 portmap_22=22:25:i
-portmap_23=23:25:i
+portmap_23=23:25:50:i
 portmap_24=24:25:i
 
 #FC6
 portmap_25=25:100
 portmap_26=26:25:i
-portmap_27=27:25:i
+portmap_27=27:25:50:i
 portmap_28=28:25:i
 
 #FC7
 portmap_29=29:100
 portmap_30=30:25:i
-portmap_31=31:25:i
+portmap_31=31:25:50:i
 portmap_32=32:25:i
 
 # Tile-1
 #FC8
 portmap_34=33:100
 portmap_35=34:25:i
-portmap_36=35:25:i
+portmap_36=35:25:50:i
 portmap_37=36:25:i
 
 #FC9
 portmap_38=37:100
 portmap_39=38:25:i
-portmap_40=39:25:i
+portmap_40=39:25:50:i
 portmap_41=40:25:i
 
 #FC10
 portmap_42=41:100
 portmap_43=42:25:i
-portmap_44=43:25:i
+portmap_44=43:25:50:i
 portmap_45=44:25:i
 
 #FC11
 portmap_46=45:100
 portmap_47=46:25:i
-portmap_48=47:25:i
+portmap_48=47:25:50:i
 portmap_49=48:25:i
 
 #FC12
 portmap_50=49:100
 portmap_51=50:25:i
-portmap_52=51:25:i
+portmap_52=51:25:50:i
 portmap_53=52:25:i
 
 #FC13
 portmap_54=53:100
 portmap_55=54:25:i
-portmap_56=55:25:i
+portmap_56=55:25:50:i
 portmap_57=56:25:i
 
 #FC14
 portmap_58=57:100
 portmap_59=58:25:i
-portmap_60=59:25:i
+portmap_60=59:25:50:i
 portmap_61=60:25:i
 
 #FC15
 portmap_62=61:100
 portmap_63=62:25:i
-portmap_64=63:25:i
+portmap_64=63:25:50:i
 portmap_65=64:25:i
 
 #TSC-E Management port 1
@@ -324,49 +324,49 @@ portmap_65=64:25:i
 #FC16
 portmap_68=65:100
 portmap_69=66:25:i
-portmap_70=67:25:i
+portmap_70=67:25:50:i
 portmap_71=68:25:i
 
 #FC17
 portmap_72=69:100
 portmap_73=70:25:i
-portmap_74=71:25:i
+portmap_74=71:25:50:i
 portmap_75=72:25:i
 
 #FC18
 portmap_76=73:100
 portmap_77=74:25:i
-portmap_78=75:25:i
+portmap_78=75:25:50:i
 portmap_79=76:25:i
 
 #FC19
 portmap_80=77:100
 portmap_81=78:25:i
-portmap_82=79:25:i
+portmap_82=79:25:50:i
 portmap_83=80:25:i
 
 #FC20
 portmap_84=81:100
 portmap_85=82:25:i
-portmap_86=83:25:i
+portmap_86=83:25:50:i
 portmap_87=84:25:i
 
 #FC21
 portmap_88=85:100
 portmap_89=86:25:i
-portmap_90=87:25:i
+portmap_90=87:25:50:i
 portmap_91=88:25:i
 
 #FC22
 portmap_92=89:100
 portmap_93=90:25:i
-portmap_94=91:25:i
+portmap_94=91:25:50:i
 portmap_95=92:25:i
 
 #FC23
 portmap_96=93:100
 portmap_97=94:25:i
-portmap_98=95:25:i
+portmap_98=95:25:50:i
 portmap_99=96:25:i
 
 #TSC-E Management port 2
@@ -377,49 +377,49 @@ portmap_99=96:25:i
 #FC24
 portmap_102=97:100
 portmap_103=98:25:i
-portmap_104=99:25:i
+portmap_104=99:25:50:i
 portmap_105=100:25:i
 
 #FC25
 portmap_106=101:100
 portmap_107=102:25:i
-portmap_108=103:25:i
+portmap_108=103:25:50:i
 portmap_109=104:25:i
 
 #FC26
 portmap_110=105:100
 portmap_111=106:25:i
-portmap_112=107:25:i
+portmap_112=107:25:50:i
 portmap_113=108:25:i
 
 #FC27
 portmap_114=109:100
 portmap_115=110:25:i
-portmap_116=111:25:i
+portmap_116=111:25:50:i
 portmap_117=112:25:i
 
 #FC28
 portmap_118=113:100
 portmap_119=114:25:i
-portmap_120=115:25:i
+portmap_120=115:25:50:i
 portmap_121=116:25:i
 
 #FC29
 portmap_122=117:100
 portmap_123=118:25:i
-portmap_124=119:25:i
+portmap_124=119:25:50:i
 portmap_125=120:25:i
 
 #FC30
 portmap_126=121:100
 portmap_127=122:25:i
-portmap_128=123:25:i
+portmap_128=123:25:50:i
 portmap_129=124:25:i
 
 #FC31
 portmap_130=125:100
 portmap_131=126:25:i
-portmap_132=127:25:i
+portmap_132=127:25:50:i
 portmap_133=128:25:i
 
 

--- a/device/accton/x86_64-accton_as7712_32x-r0/pcie.yaml
+++ b/device/accton/x86_64-accton_as7712_32x-r0/pcie.yaml
@@ -1,0 +1,95 @@
+- bus: '00'
+  dev: '00'
+  fn: '0'
+  id: 1f0c
+  name: 'Host bridge: Intel Corporation Atom processor C2000 SoC Transaction Router
+    (rev 02)'
+- bus: '00'
+  dev: '01'
+  fn: '0'
+  id: 1f10
+  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 1 (rev
+    02)'
+- bus: '00'
+  dev: '02'
+  fn: '0'
+  id: 1f11
+  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 2 (rev
+    02)'
+- bus: '00'
+  dev: '03'
+  fn: '0'
+  id: 1f12
+  name: 'PCI bridge: Intel Corporation Atom processor C2000 PCIe Root Port 3 (rev
+    02)'
+- bus: '00'
+  dev: 0e
+  fn: '0'
+  id: 1f14
+  name: 'Host bridge: Intel Corporation Atom processor C2000 RAS (rev 02)'
+- bus: '00'
+  dev: 0f
+  fn: '0'
+  id: 1f16
+  name: 'IOMMU: Intel Corporation Atom processor C2000 RCEC (rev 02)'
+- bus: '00'
+  dev: '13'
+  fn: '0'
+  id: 1f15
+  name: 'System peripheral: Intel Corporation Atom processor C2000 SMBus 2.0 (rev
+    02)'
+- bus: '00'
+  dev: '14'
+  fn: '0'
+  id: 1f41
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection I354 (rev 03)'
+- bus: '00'
+  dev: '14'
+  fn: '1'
+  id: 1f41
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection I354 (rev 03)'
+- bus: '00'
+  dev: '14'
+  fn: '2'
+  id: 1f41
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection I354 (rev 03)'
+- bus: '00'
+  dev: '16'
+  fn: '0'
+  id: 1f2c
+  name: 'USB controller: Intel Corporation Atom processor C2000 USB Enhanced Host
+    Controller (rev 02)'
+- bus: '00'
+  dev: '17'
+  fn: '0'
+  id: 1f22
+  name: 'SATA controller: Intel Corporation Atom processor C2000 AHCI SATA2 Controller
+    (rev 02)'
+- bus: '00'
+  dev: '18'
+  fn: '0'
+  id: 1f32
+  name: 'SATA controller: Intel Corporation Atom processor C2000 AHCI SATA3 Controller
+    (rev 02)'
+- bus: '00'
+  dev: 1f
+  fn: '0'
+  id: 1f38
+  name: 'ISA bridge: Intel Corporation Atom processor C2000 PCU (rev 02)'
+- bus: '00'
+  dev: 1f
+  fn: '3'
+  id: 1f3c
+  name: 'SMBus: Intel Corporation Atom processor C2000 PCU SMBus (rev 02)'
+- bus: '01'
+  dev: '00'
+  fn: '0'
+  id: b960
+  name: 'Ethernet controller: Broadcom Inc. and subsidiaries Broadcom BCM56960 Switch
+    ASIC (rev 11)'
+- bus: '01'
+  dev: '00'
+  fn: '1'
+  id: b960
+  name: 'Ethernet controller: Broadcom Inc. and subsidiaries Broadcom BCM56960 Switch
+    ASIC (rev 11)'

--- a/device/accton/x86_64-accton_as7712_32x-r0/pddf/pd-plugin.json
+++ b/device/accton/x86_64-accton_as7712_32x-r0/pddf/pd-plugin.json
@@ -21,11 +21,11 @@
         {
             "i2c":
             {
-                "valmap": { "F2B":"EXHAUST", "B2F":"INTAKE" }
+                "valmap": { "F2B":"exhaust", "B2F":"intake" }
             }
         },
 
-        "PSU_FAN_MAX_SPEED":"18000"
+        "PSU_FAN_MAX_SPEED":"26688"
     },
 
     "FAN":
@@ -34,7 +34,7 @@
         {
             "i2c":
             {
-                "valmap": {"1":"EXHAUST", "0":"INTAKE"}
+                "valmap": {"1":"exhaust", "0":"intake"}
             }
         },
 

--- a/device/accton/x86_64-accton_as7712_32x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7712_32x-r0/pddf/pddf-device.json
@@ -354,7 +354,11 @@
 				{ "attr_name":"psu_i_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x8c", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
 				{ "attr_name":"psu_p_out", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x96", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
 				{ "attr_name":"psu_fan1_speed_rpm", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x90", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
-				{ "attr_name":"psu_temp1_input", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x8d", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"}
+				{ "attr_name":"psu_temp1_input", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0x8d", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+				{ "attr_name":"psu_v_out_max", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0xa5", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+				{ "attr_name":"psu_v_out_min", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0xa4", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+				{ "attr_name":"psu_p_out_max", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0xa7", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+				{ "attr_name":"psu_temp1_high_threshold", "attr_devaddr":"0x5b", "attr_devtype":"pmbus", "attr_offset":"0xa8", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"}
 			]
 		}
 	},
@@ -391,7 +395,11 @@
 				{ "attr_name":"psu_i_out", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x8c", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
 				{ "attr_name":"psu_p_out", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x96", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
 				{ "attr_name":"psu_fan1_speed_rpm", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x90", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
-				{ "attr_name":"psu_temp1_input", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x8d", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"}
+				{ "attr_name":"psu_temp1_input", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0x8d", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+				{ "attr_name":"psu_v_out_max", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0xa5", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+				{ "attr_name":"psu_v_out_min", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0xa4", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+				{ "attr_name":"psu_p_out_max", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0xa7", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"},
+				{ "attr_name":"psu_temp1_high_threshold", "attr_devaddr":"0x58", "attr_devtype":"pmbus", "attr_offset":"0xa8", "attr_mask":"0x0", "attr_cmpval":"0xff", "attr_len":"2"}
 			]
 		}
 	},

--- a/device/accton/x86_64-accton_as7712_32x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7712_32x-r0/pddf/pddf-device.json
@@ -5,7 +5,7 @@
 		"num_fantrays":6,
 		"num_fans_pertray":2,
 		"num_ports":32,
-		"num_temps": 4,
+		"num_temps": 8,
 		"pddf_dev_types":
 		{
 			"description":"AS7712 - Below is the list of supported PDDF device types (chip names) for various components. If any component uses some other driver, we will create the client using 'echo <dev-address> <dev-type> > <path>/new_device' method",
@@ -210,7 +210,7 @@
 	"TEMP1" :
 	{
 		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP1", "device_parent":"MUX1"},
-		"dev_attr": { "display_name":"Temp_1"},
+		"dev_attr": { "display_name":"MB_RearLeft_temp(0x48)"},
 		"i2c":
 		{
 			"topo_info": { "parent_bus":"0x3", "dev_addr":"0x48", "dev_type":"lm75"},
@@ -226,7 +226,7 @@
 	"TEMP2" :
 	{
 		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP2", "device_parent":"MUX1"},
-		"dev_attr": { "display_name":"Temp_2"},
+		"dev_attr": { "display_name":"MB_FrontMiddle_temp(0x49)"},
 		"i2c":
 		{
 			"topo_info": { "parent_bus":"0x3", "dev_addr":"0x49", "dev_type":"lm75"},
@@ -242,7 +242,7 @@
 	"TEMP3" :
 	{
 		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP3", "device_parent":"MUX1"},
-		"dev_attr": { "display_name":"Temp_3"},
+		"dev_attr": { "display_name":"MB_MiddleLeft_temp(0x4A)"},
 		"i2c":
 		{
 			"topo_info": { "parent_bus":"0x3", "dev_addr":"0x4a", "dev_type":"lm75"},
@@ -258,7 +258,7 @@
 	"TEMP4" :
 	{
 		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP4", "device_parent":"MUX1"},
-		"dev_attr": { "display_name":"Temp_CPU"},
+		"dev_attr": { "display_name":"CB_temp(0x4B)"},
 		"i2c":
 		{
 			"topo_info": { "parent_bus":"0x3", "dev_addr":"0x4b", "dev_type":"lm75"},
@@ -270,7 +270,71 @@
 			]
 		}
 	},
+
+	"TEMP5" :
+	{
+		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP5"},
+		"dev_attr": { "display_name":"CPU_Core_0_temp"},
+		"i2c":
+		{
+			"path_info": {"sysfs_base_path": "/sys/class/hwmon/hwmon0"},
+			"attr_list":
+			[
+				{ "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp2_crit"},
+				{ "attr_name": "temp1_high_threshold", "drv_attr_name":"temp2_max"},
+				{ "attr_name": "temp1_input", "drv_attr_name":"temp2_input"}
+			]
+		}
+	},
 	
+	"TEMP6" :
+	{
+		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP6"},
+		"dev_attr": { "display_name":"CPU_Core_1_temp"},
+		"i2c":
+		{
+			"path_info": {"sysfs_base_path": "/sys/class/hwmon/hwmon0"},
+			"attr_list":
+			[
+				{ "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp3_crit"},
+				{ "attr_name": "temp1_high_threshold", "drv_attr_name":"temp3_max"},
+				{ "attr_name": "temp1_input", "drv_attr_name":"temp3_input"}
+			]
+		}
+	},
+
+	"TEMP7" :
+	{
+		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP7"},
+		"dev_attr": { "display_name":"CPU_Core_2_temp"},
+		"i2c":
+		{
+			"path_info": {"sysfs_base_path": "/sys/class/hwmon/hwmon0"},
+			"attr_list":
+			[
+				{ "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp4_crit"},
+				{ "attr_name": "temp1_high_threshold", "drv_attr_name":"temp4_max"},
+				{ "attr_name": "temp1_input", "drv_attr_name":"temp4_input"}
+			]
+		}
+	},
+
+	"TEMP8" :
+	{
+		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP8"},
+		"dev_attr": { "display_name":"CPU_Core_3_temp"},
+		"i2c":
+		{
+			"path_info": {"sysfs_base_path": "/sys/class/hwmon/hwmon0"},
+			"attr_list":
+			[
+				{ "attr_name": "temp1_high_crit_threshold", "drv_attr_name":"temp5_crit"},
+				{ "attr_name": "temp1_high_threshold", "drv_attr_name":"temp5_max"},
+				{ "attr_name": "temp1_input", "drv_attr_name":"temp5_input"}
+			]
+		}
+	},
+
 	"CPLD1":
 	{
 		"dev_info": { "device_type":"CPLD", "device_name":"CPLD1", "device_parent":"MUX1"},

--- a/device/accton/x86_64-accton_as7712_32x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7712_32x-r0/pddf/pddf-device.json
@@ -555,12 +555,12 @@
 	"LOC_LED":
 	{
 			"dev_info": { "device_type":"LED", "device_name":"LOC_LED"},
-                        "dev_attr": { "index":"0"},
+                        "dev_attr": { "index":"0", "flag":"rw"},
                         "i2c" : {
                         "attr_list":
                         [
-                                        {"attr_name":"STATUS_LED_COLOR_BLUE",  "bits" : "7", "descr" : "", "value" : "0x0", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"},
-                                        {"attr_name":"STATUS_LED_COLOR_OFF",  "bits" : "7", "descr" : "", "value" : "0x1", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"}
+                                        {"attr_name":"blue",  "bits" : "7", "descr" : "", "value" : "0x0", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"},
+                                        {"attr_name":"off",  "bits" : "7", "descr" : "", "value" : "0x1", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"}
                         ]
                         }
 	},
@@ -568,13 +568,13 @@
 	"DIAG_LED":
 	{
 			"dev_info": { "device_type":"LED", "device_name":"DIAG_LED"},
-                        "dev_attr": { "index":"0"},
+                        "dev_attr": { "index":"0", "flag":"rw"},
                         "i2c" : {
                         "attr_list":
                         [
-                                        {"attr_name":"STATUS_LED_COLOR_GREEN",  "bits" : "1:0", "descr" : "", "value" : "0x2", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"},
-                                        {"attr_name":"STATUS_LED_COLOR_RED",  "bits" : "1:0", "descr" : "", "value" : "0x1", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"},
-                                        {"attr_name":"STATUS_LED_COLOR_OFF",  "bits" : "1:0", "descr" : "", "value" : "0x3", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"}
+                                        {"attr_name":"green",  "bits" : "1:0", "descr" : "", "value" : "0x2", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"},
+                                        {"attr_name":"red",  "bits" : "1:0", "descr" : "", "value" : "0x1", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"},
+                                        {"attr_name":"off",  "bits" : "1:0", "descr" : "", "value" : "0x3", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x41"}
                         ]
                         }
 

--- a/device/accton/x86_64-accton_as7712_32x-r0/platform.json
+++ b/device/accton/x86_64-accton_as7712_32x-r0/platform.json
@@ -360,7 +360,7 @@
         ],
         "thermals": [
             {
-                "name": "Temp sensor 1",
+                "name": "MB_RearLeft_temp(0x48)",
                 "controllable": true,
                 "low-threshold": false,
                 "high-threshold": true,
@@ -368,7 +368,7 @@
                 "high-crit-threshold": false
             },
             {
-                "name": "Temp sensor 2",
+                "name": "MB_FrontMiddle_temp(0x49)",
                 "controllable": true,
                 "low-threshold": false,
                 "high-threshold": true,
@@ -376,7 +376,7 @@
                 "high-crit-threshold": false
             },
             {
-                "name": "Temp sensor 3",
+                "name": "MB_MiddleLeft_temp(0x4A)",
                 "controllable": true,
                 "low-threshold": false,
                 "high-threshold": true,
@@ -384,12 +384,44 @@
                 "high-crit-threshold": false
             },
             {
-                "name": "Temp sensor 4",
+                "name": "CB_temp(0x4B)",
                 "controllable": true,
                 "low-threshold": false,
                 "high-threshold": true,
                 "low-crit-threshold": false,
                 "high-crit-threshold": false
+            },
+            {
+                "name": "CPU_Core_0_temp",
+                "controllable": false,
+                "low-threshold": false,
+                "high-threshold": true,
+                "low-crit-threshold": false,
+                "high-crit-threshold": true
+            },
+            {
+                "name": "CPU_Core_1_temp",
+                "controllable": false,
+                "low-threshold": false,
+                "high-threshold": true,
+                "low-crit-threshold": false,
+                "high-crit-threshold": true
+            },
+            {
+                "name": "CPU_Core_2_temp",
+                "controllable": false,
+                "low-threshold": false,
+                "high-threshold": true,
+                "low-crit-threshold": false,
+                "high-crit-threshold": true
+            },
+            {
+                "name": "CPU_Core_3_temp",
+                "controllable": false,
+                "low-threshold": false,
+                "high-threshold": true,
+                "low-crit-threshold": false,
+                "high-crit-threshold": true
             }
         ],
         "sfps": [

--- a/device/accton/x86_64-accton_as7712_32x-r0/platform.json
+++ b/device/accton/x86_64-accton_as7712_32x-r0/platform.json
@@ -4,7 +4,7 @@
         "thermal_manager":false,
         "status_led": {
             "controllable": true,
-            "colors": ["STATUS_LED_COLOR_GREEN", "STATUS_LED_COLOR_RED", "STATUS_LED_COLOR_OFF"]
+            "colors": ["green", "red", "off"]
         },
         "components": [
             {

--- a/device/accton/x86_64-accton_as7712_32x-r0/platform.json
+++ b/device/accton/x86_64-accton_as7712_32x-r0/platform.json
@@ -145,6 +145,7 @@
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -174,6 +175,7 @@
             },
             {
                 "name": "FanTray2",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -203,6 +205,7 @@
             },
             {
                 "name": "FanTray3",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -232,6 +235,7 @@
             },
             {
                 "name": "FanTray4",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -261,6 +265,7 @@
             },
             {
                 "name": "FanTray5",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },
@@ -290,6 +295,7 @@
             },
             {
                 "name": "FanTray6",
+                "max_consumed_power": false,
                 "status_led": {
                     "controllable": false
                 },

--- a/device/accton/x86_64-accton_as7712_32x-r0/platform.json
+++ b/device/accton/x86_64-accton_as7712_32x-r0/platform.json
@@ -1,6 +1,11 @@
 {
     "chassis": {
         "name": "7712-32X",
+        "thermal_manager":false,
+        "status_led": {
+            "controllable": true,
+            "colors": ["STATUS_LED_COLOR_GREEN", "STATUS_LED_COLOR_RED", "STATUS_LED_COLOR_OFF"]
+        },
         "components": [
             {
                 "name": "CPLD1"
@@ -17,112 +22,298 @@
         ],
         "fans": [
             {
-                "name": "FAN-1F"
+                "name": "FAN-1F",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-1R"
+                "name": "FAN-1R",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-2F"
+                "name": "FAN-2F",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-2R"
+                "name": "FAN-2R",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-3F"
+                "name": "FAN-3F",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-3R"
+                "name": "FAN-3R",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-4F"
+                "name": "FAN-4F",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-4R"
+                "name": "FAN-4R",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-5F"
+                "name": "FAN-5F",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-5R"
+                "name": "FAN-5R",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-6F"
+                "name": "FAN-6F",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
+                }
             },
             {
-                "name": "FAN-6R"
+                "name": "FAN-6R",
+                "speed": {
+                    "controllable": true,
+                    "minimum": 32
+                },
+                "status_led": {
+                    "controllable": false
+                }
             }
         ],
         "fan_drawers":[
             {
                 "name": "FanTray1",
+                "status_led": {
+                    "controllable": false
+                },
                 "num_fans" : 2,
                 "fans": [
                     {
-                        "name": "FAN-1F"
+                        "name": "FAN-1F",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-1R"
+                        "name": "FAN-1R",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ]
             },
             {
                 "name": "FanTray2",
+                "status_led": {
+                    "controllable": false
+                },
                 "num_fans" : 2,
                 "fans": [
                     {
-                        "name": "FAN-2F"
+                        "name": "FAN-2F",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-2R"
+                        "name": "FAN-2R",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ]
             },
             {
                 "name": "FanTray3",
+                "status_led": {
+                    "controllable": false
+                },
                 "num_fans" : 2,
                 "fans": [
                     {
-                        "name": "FAN-3F"
+                        "name": "FAN-3F",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-3R"
+                        "name": "FAN-3R",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ]
             },
             {
                 "name": "FanTray4",
+                "status_led": {
+                    "controllable": false
+                },
                 "num_fans" : 2,
                 "fans": [
                     {
-                        "name": "FAN-4F"
+                        "name": "FAN-4F",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-4R"
+                        "name": "FAN-4R",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ]
             },
             {
                 "name": "FanTray5",
+                "status_led": {
+                    "controllable": false
+                },
                 "num_fans" : 2,
                 "fans": [
                     {
-                        "name": "FAN-5F"
+                        "name": "FAN-5F",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-5R"
+                        "name": "FAN-5R",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ]
             },
             {
                 "name": "FanTray6",
+                "status_led": {
+                    "controllable": false
+                },
                 "num_fans" : 2,
                 "fans": [
                     {
-                        "name": "FAN-6F"
+                        "name": "FAN-6F",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     },
                     {
-                        "name": "FAN-6R"
+                        "name": "FAN-6R",
+                        "speed": {
+                            "controllable": true,
+                            "minimum": 32
+                        },
+                        "status_led": {
+                            "controllable": false
+                        }
                     }
                 ]
             }
@@ -130,6 +321,9 @@
         "psus": [
             {
                 "name": "PSU-1",
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
                         "name": "PSU-1 FAN-1"
@@ -137,12 +331,18 @@
                 ],
                 "thermals": [
                     {
-                        "name": "PSU-1 temp sensor 1"
+                        "name": "PSU-1 temp sensor 1",
+                        "controllable": false,
+                        "low-crit-threshold": false,
+                        "high-crit-threshold": false
                     }
                 ]
             },
             {
                 "name": "PSU-2",
+                "status_led": {
+                    "controllable": false
+                },
                 "fans": [
                     {
                         "name": "PSU-2 FAN-1"
@@ -150,23 +350,46 @@
                 ],
                 "thermals": [
                     {
-                        "name": "PSU-2 temp sensor 1"
+                        "name": "PSU-2 temp sensor 1",
+                        "controllable": false,
+                        "low-crit-threshold": false,
+                        "high-crit-threshold": false
                     }
                 ]
             }
         ],
         "thermals": [
             {
-                "name": "Temp sensor 1"
+                "name": "Temp sensor 1",
+                "controllable": true,
+                "low-threshold": false,
+                "high-threshold": true,
+                "low-crit-threshold": false,
+                "high-crit-threshold": false
             },
             {
-                "name": "Temp sensor 2"
+                "name": "Temp sensor 2",
+                "controllable": true,
+                "low-threshold": false,
+                "high-threshold": true,
+                "low-crit-threshold": false,
+                "high-crit-threshold": false
             },
             {
-                "name": "Temp sensor 3"
+                "name": "Temp sensor 3",
+                "controllable": true,
+                "low-threshold": false,
+                "high-threshold": true,
+                "low-crit-threshold": false,
+                "high-crit-threshold": false
             },
             {
-                "name": "Temp sensor 4"
+                "name": "Temp sensor 4",
+                "controllable": true,
+                "low-threshold": false,
+                "high-threshold": true,
+                "low-crit-threshold": false,
+                "high-crit-threshold": false
             }
         ],
         "sfps": [

--- a/device/accton/x86_64-accton_as7712_32x-r0/platform_components.json
+++ b/device/accton/x86_64-accton_as7712_32x-r0/platform_components.json
@@ -1,0 +1,12 @@
+{
+    "chassis": {
+        "7712-32X-O-AC-F": {
+            "component": {
+                "CPLD1": { },
+                "CPLD2": { },
+                "CPLD3": { },
+                "BIOS": { }
+            }
+        }
+    }
+}

--- a/device/accton/x86_64-accton_as7712_32x-r0/pmon_daemon_control.json
+++ b/device/accton/x86_64-accton_as7712_32x-r0/pmon_daemon_control.json
@@ -1,5 +1,4 @@
 {
-    "skip_ledd": true,
-    "skip_pcied": true
+    "skip_ledd": true
 }
 

--- a/device/accton/x86_64-accton_as7712_32x-r0/sensors.conf
+++ b/device/accton/x86_64-accton_as7712_32x-r0/sensors.conf
@@ -38,13 +38,13 @@ chip "as7712_32x_fan-*"
 
 
 chip "lm75-i2c-*-48"
-    label temp1 "Main Board Temperature"
+    label temp1 "MB_RearLeft_temp(0x48)"
 
 chip "lm75-i2c-*-49"
-    label temp1 "Main Board Temperature"
+    label temp1 "MB_FrontMiddle_temp(0x49)"
 
 chip "lm75-i2c-*-4a"
-    label temp1 "Main Board Temperature"
+    label temp1 "MB_MiddleLeft_temp(0x4A)"
 
 chip "lm75-i2c-*-4b"
-    label temp1 "CPU Board Temperature"
+    label temp1 "CB_temp(0x4B)"

--- a/device/accton/x86_64-accton_as7712_32x-r0/system_health_monitoring_config.json
+++ b/device/accton/x86_64-accton_as7712_32x-r0/system_health_monitoring_config.json
@@ -1,0 +1,13 @@
+{
+    "services_to_ignore": [],
+    "devices_to_ignore": [
+        "asic"
+    ],
+    "user_defined_checkers": [],
+    "polling_interval": 60,
+    "led_color": {
+        "fault": "STATUS_LED_COLOR_RED",
+        "normal": "STATUS_LED_COLOR_GREEN",
+        "booting": "STATUS_LED_COLOR_GREEN"
+    }
+}

--- a/device/accton/x86_64-accton_as7712_32x-r0/system_health_monitoring_config.json
+++ b/device/accton/x86_64-accton_as7712_32x-r0/system_health_monitoring_config.json
@@ -6,8 +6,8 @@
     "user_defined_checkers": [],
     "polling_interval": 60,
     "led_color": {
-        "fault": "STATUS_LED_COLOR_RED",
-        "normal": "STATUS_LED_COLOR_GREEN",
-        "booting": "STATUS_LED_COLOR_GREEN"
+        "fault": "red",
+        "normal": "green",
+        "booting": "green"
     }
 }

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/modules/accton_as7712_32x_fan.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/modules/accton_as7712_32x_fan.c
@@ -55,6 +55,7 @@ static ssize_t get_sys_temp(struct device *dev, struct device_attribute *da, cha
  */
 static const u8 fan_reg[] = {
     0x0F,       /* fan 1-6 present status */
+    0x10,       /* fan 1-6 direction(0:B2F 1:F2B) */
     0x11,       /* fan PWM(for all fan) */
     0x12,       /* front fan 1 speed(rpm) */
     0x13,       /* front fan 2 speed(rpm) */
@@ -93,6 +94,7 @@ enum fan_id {
 
 enum sysfs_fan_attributes {
     FAN_PRESENT_REG,
+    FAN_DIRECTION_REG,
     FAN_DUTY_CYCLE_PERCENTAGE, /* Only one CPLD register to control duty cycle for all fans */
     FAN1_FRONT_SPEED_RPM,
     FAN2_FRONT_SPEED_RPM,
@@ -106,6 +108,12 @@ enum sysfs_fan_attributes {
     FAN4_REAR_SPEED_RPM,
     FAN5_REAR_SPEED_RPM,
     FAN6_REAR_SPEED_RPM,
+    FAN1_DIRECTION,
+    FAN2_DIRECTION,
+    FAN3_DIRECTION,
+    FAN4_DIRECTION,
+    FAN5_DIRECTION,
+    FAN6_DIRECTION,
     FAN1_PRESENT,
     FAN2_PRESENT,
     FAN3_PRESENT,
@@ -182,6 +190,13 @@ DECLARE_FAN_PRESENT_SENSOR_DEV_ATTR(3);
 DECLARE_FAN_PRESENT_SENSOR_DEV_ATTR(4);
 DECLARE_FAN_PRESENT_SENSOR_DEV_ATTR(5);
 DECLARE_FAN_PRESENT_SENSOR_DEV_ATTR(6);
+/* 6 fan direction attribute in this platform */
+DECLARE_FAN_DIRECTION_SENSOR_DEV_ATTR(1);
+DECLARE_FAN_DIRECTION_SENSOR_DEV_ATTR(2);
+DECLARE_FAN_DIRECTION_SENSOR_DEV_ATTR(3);
+DECLARE_FAN_DIRECTION_SENSOR_DEV_ATTR(4);
+DECLARE_FAN_DIRECTION_SENSOR_DEV_ATTR(5);
+DECLARE_FAN_DIRECTION_SENSOR_DEV_ATTR(6);
 /* 1 fan duty cycle attribute in this platform */
 DECLARE_FAN_DUTY_CYCLE_SENSOR_DEV_ATTR(1);
 /* System temperature for fancontrol */
@@ -207,6 +222,12 @@ static struct attribute *as7712_32x_fan_attributes[] = {
     DECLARE_FAN_PRESENT_ATTR(4),
     DECLARE_FAN_PRESENT_ATTR(5),
     DECLARE_FAN_PRESENT_ATTR(6),
+    DECLARE_FAN_DIRECTION_ATTR(1),
+    DECLARE_FAN_DIRECTION_ATTR(2),
+    DECLARE_FAN_DIRECTION_ATTR(3),
+    DECLARE_FAN_DIRECTION_ATTR(4),
+    DECLARE_FAN_DIRECTION_ATTR(5),
+    DECLARE_FAN_DIRECTION_ATTR(6),
     DECLARE_FAN_DUTY_CYCLE_ATTR(1),
     DECLARE_FAN_SYSTEM_TEMP_ATTR(),
     NULL
@@ -243,7 +264,14 @@ static u32 reg_val_to_speed_rpm(u8 reg_val)
 {
     return (u32)reg_val * FAN_REG_VAL_TO_SPEED_RPM_STEP;
 }
+static u8 reg_val_to_direction(u8 reg_val, enum fan_id id)
+{
+    u8 mask = (1 << id);
 
+    reg_val &= mask;
+
+    return reg_val ? 1 : 0;
+}
 static u8 reg_val_to_is_present(u8 reg_val, enum fan_id id)
 {
     u8 mask = (1 << id);
@@ -484,6 +512,16 @@ static ssize_t fan_show_value(struct device *dev, struct device_attribute *da,
         case FAN5_FAULT:
         case FAN6_FAULT:
             ret = sprintf(buf, "%d\n", is_fan_fault(data, attr->index - FAN1_FAULT));
+            break;
+        case FAN1_DIRECTION:
+        case FAN2_DIRECTION:
+        case FAN3_DIRECTION:
+        case FAN4_DIRECTION:
+        case FAN5_DIRECTION:
+        case FAN6_DIRECTION:
+            ret = sprintf(buf, "%d\n",
+                          reg_val_to_direction(data->reg_val[FAN_DIRECTION_REG],
+                          attr->index - FAN1_DIRECTION));
             break;
         default:
             break;

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/modules/accton_psu_api.h
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/modules/accton_psu_api.h
@@ -1,0 +1,1 @@
+../../common/modules/accton_psu_api.h

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/modules/accton_psu_defs.h
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/modules/accton_psu_defs.h
@@ -1,0 +1,1 @@
+../../common/modules/accton_psu_defs.h

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/modules/leds-accton_as7712_32x.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/modules/leds-accton_as7712_32x.c
@@ -505,7 +505,7 @@ static struct led_classdev accton_as7712_32x_leds[] = {
 		.brightness_set	 = accton_as7712_32x_led_diag_set,
 		.brightness_get	 = accton_as7712_32x_led_diag_get,
 		.flags			 = LED_CORE_SUSPENDRESUME,
-		.max_brightness	 = LED_MODE_RED,
+		.max_brightness	 = LED_MODE_GREEN,
 	},
 	[LED_TYPE_LOC] = {
 		.name			 = "accton_as7712_32x_led::loc",

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/chassis.py
@@ -10,20 +10,27 @@ try:
     import sys
     from sonic_platform_pddf_base.pddf_chassis import PddfChassis
     from .event import SfpEvent
+    from .helper import APIHelper
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 NUM_COMPONENT = 4
+HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
+PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
+REBOOT_CAUSE_FILE = "reboot-cause.txt"
 
 class Chassis(PddfChassis):
     """
     PDDF Platform-specific Chassis class
     """
 
+    SYSLED_DEV_NAME = "DIAG_LED"
+
     def __init__(self, pddf_data=None, pddf_plugin_data=None):
         PddfChassis.__init__(self, pddf_data, pddf_plugin_data)
         self.__initialize_components()
         self._sfpevent = SfpEvent(self.get_all_sfps())
+        self._api_helper = APIHelper()
        
     def __initialize_components(self):
         from sonic_platform.component import Component
@@ -57,3 +64,60 @@ class Chassis(PddfChassis):
             sys.stderr.write("SFP index {} out of range (1-{})\n".format(
                              index, len(self._sfp_list)))
         return sfp
+
+    def get_port_or_cage_type(self, port):
+        from sonic_platform_base.sfp_base import SfpBase
+        return SfpBase.SFP_PORT_TYPE_BIT_QSFP | SfpBase.SFP_PORT_TYPE_BIT_QSFP_PLUS | SfpBase.SFP_PORT_TYPE_BIT_QSFP28
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device. If the agent cannot determine the parent-relative position
+        for some reason, or if the associated value of entPhysicalContainedIn is '0', then the value '-1' is returned
+        Returns:
+            integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
+        """
+        return -1
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return False
+
+    def get_reboot_cause(self):
+        """
+        Retrieves the cause of the previous reboot
+        Returns:
+            A tuple (string, string) where the first element is a string
+            containing the cause of the previous reboot. This string must be
+            one of the predefined strings in this class. If the first string
+            is "REBOOT_CAUSE_HARDWARE_OTHER", the second string can be used
+            to pass a description of the reboot cause.
+        """
+
+        reboot_cause_path = (HOST_REBOOT_CAUSE_PATH + REBOOT_CAUSE_FILE)
+        sw_reboot_cause = self._api_helper.read_txt_file(
+            reboot_cause_path) or "Unknown"
+
+
+        return ('REBOOT_CAUSE_NON_HARDWARE', sw_reboot_cause)
+
+    def initizalize_system_led(self):
+        return
+
+    def get_status_led(self):
+        return self.get_system_led(self.SYSLED_DEV_NAME)
+
+    def set_status_led(self, color):
+        return self.set_system_led(self.SYSLED_DEV_NAME, color)
+
+    def get_revision(self):
+        """
+        Retrieves the hardware revision of the device
+
+        Returns:
+            string: Revision value of device
+        """
+        return self._eeprom.revision_str()

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/component.py
@@ -6,8 +6,10 @@
 #############################################################################
 
 try:
-    import subprocess
+    import os
+    import json
     from sonic_platform_base.component_base import ComponentBase
+    from sonic_py_common.general import getstatusoutput_noshell
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -35,22 +37,6 @@ class Component(ComponentBase):
         self.index = component_index
         self.name = self.get_name()
 
-    def __run_command(self, command):
-        # Run bash command and print output to stdout
-        try:
-            process = subprocess.Popen(
-                shlex.split(command), stdout=subprocess.PIPE)
-            while True:
-                output = process.stdout.readline()
-                if output == '' and process.poll() is not None:
-                    break
-            rc = process.poll()
-            if rc != 0:
-                return False
-        except Exception:
-            return False
-        return True
-
     def __get_bios_version(self):
         # Retrieves the BIOS firmware version
         try:
@@ -64,8 +50,8 @@ class Component(ComponentBase):
         # Retrieves the CPLD firmware version
         cpld_version = dict()
         for cpld_name in CPLD_ADDR_MAPPING:
-            cmd = "i2cget -f -y {0} {1} 0x1".format(CPLD_ADDR_MAPPING[cpld_name][0], CPLD_ADDR_MAPPING[cpld_name][1])
-            status, value = subprocess.getstatusoutput(cmd)
+            cmd = ["i2cget", "-f", "-y", CPLD_ADDR_MAPPING[cpld_name][0], CPLD_ADDR_MAPPING[cpld_name][1], "0x1"]
+            status, value = getstatusoutput_noshell(cmd)
             if not status:
                 cpld_version_raw = value.rstrip()
                 cpld_version[cpld_name] = "{}".format(int(cpld_version_raw,16))
@@ -112,4 +98,86 @@ class Component(ComponentBase):
         Returns:
             A boolean, True if install successfully, False if not
         """
-        raise NotImplementedError
+        ret, output = getstatusoutput_noshell(["tar", "-C", "/tmp", "-xzf", image_path ] )
+        if ret != 0 :
+            print("Installation failed because of wrong image package")
+            return False
+
+        if  False == os.path.exists("/tmp/install.json") :
+            print("Installation failed without jsonfile")
+            return False
+
+        input_file = open ('/tmp/install.json')
+        json_array = json.load(input_file)
+        ret = 1
+        for item in json_array:
+            if item.get('id')==None or item.get('path')==None:
+                continue
+            if self.name == item['id'] and item['path'] and item.get('cpu'):
+                print( "Find", item['id'], item['path'], item['cpu'] )
+                ret, output = getstatusoutput_noshell(["/tmp/run_install.sh", item['id'], item['path'], item['cpu'] ])
+                if ret==0:
+                    break
+            elif self.name == item['id'] and item['path']:
+                print( "Find", item['id'], item['path'] )
+                ret, output = getstatusoutput_noshell(["/tmp/run_install.sh", item['id'], item['path'] ])
+                if ret==0:
+                    break
+
+        if ret==0:
+            return True
+        else :
+            return False
+
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the device
+        Returns:
+            bool: True if device is present, False if not
+        """
+        return True
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the device
+        Returns:
+            string: Model/part number of device
+        """
+        return 'N/A'
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the device
+        Returns:
+            string: Serial number of device
+        """
+        return 'N/A'
+
+    def get_status(self):
+        """
+        Retrieves the operational status of the device
+        Returns:
+            A boolean value, True if device is operating properly, False if not
+        """
+        return True
+
+    def get_position_in_parent(self):
+        """
+        Retrieves 1-based relative physical position in parent device.
+        If the agent cannot determine the parent-relative position
+        for some reason, or if the associated value of
+        entPhysicalContainedIn is'0', then the value '-1' is returned
+        Returns:
+            integer: The 1-based relative physical position in parent device
+            or -1 if cannot determine the position
+        """
+        return -1
+
+    def is_replaceable(self):
+        """
+        Indicate whether this device is replaceable.
+        Returns:
+            bool: True if it is replaceable.
+        """
+        return False

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/event.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/event.py
@@ -1,10 +1,20 @@
 try:
     import time
     from sonic_py_common.logger import Logger
+    from .sfp import Sfp
 except ImportError as e:
     raise ImportError(repr(e) + " - required module not found")
 
 POLL_INTERVAL_IN_SEC = 1
+
+# SFP errors that will block eeprom accessing
+SFP_BLOCKING_ERRORS = [
+    Sfp.SFP_ERROR_BIT_I2C_STUCK,
+    Sfp.SFP_ERROR_BIT_BAD_EEPROM,
+    Sfp.SFP_ERROR_BIT_UNSUPPORTED_CABLE,
+    Sfp.SFP_ERROR_BIT_HIGH_TEMP,
+    Sfp.SFP_ERROR_BIT_BAD_CABLE
+]
 
 class SfpEvent:
     ''' Listen to insert/remove sfp events '''
@@ -46,15 +56,54 @@ class SfpEvent:
         if changed_ports != 0:
             for sfp in self._sfp_list:
                 i=sfp.get_position_in_parent() - 1
-                if (changed_ports & (1 << i)):
-                    if (bitmap & (1 << i)) == 0:
-                        port_dict[i+1] = '0'
-                    else:
-                        port_dict[i+1] = '1'
+                if (changed_ports & (1 << i)) == 0:
+                    continue
 
+                if (bitmap & (1 << i)) == 0:
+                    port_dict[i+1] = '0'
+                else:
+                    # sfp.refresh_optoe_dev_class()
+                    sfp_state_bits = self.get_sfp_state_bits(sfp, True)
+                    sfp_state_bits = self.check_sfp_blocking_errors(sfp_state_bits)
+
+                    port_dict[i+1] = str(sfp_state_bits)
 
             # Update the cache dict
             self._sfp_change_event_data['present'] = bitmap
             return True, change_dict
         else:
             return True, change_dict
+
+    def get_sfp_state_bits(self, sfp, present):
+        sfp_state_bits = 0
+
+        if present is True:
+            sfp_state_bits |= Sfp.SFP_STATUS_BIT_INSERTED
+        else:
+            return sfp_state_bits
+
+        status = sfp.validate_eeprom()
+        if status is None:
+            sfp_state_bits |= Sfp.SFP_ERROR_BIT_I2C_STUCK
+            return sfp_state_bits
+        elif status is not True:
+            sfp_state_bits |= Sfp.SFP_ERROR_BIT_BAD_EEPROM
+            return sfp_state_bits
+
+        status = sfp.validate_temperature()
+        if status is None:
+            sfp_state_bits |= Sfp.SFP_ERROR_BIT_I2C_STUCK
+            return sfp_state_bits
+        elif status is not True:
+            sfp_state_bits |= Sfp.SFP_ERROR_BIT_HIGH_TEMP
+            return sfp_state_bits
+
+        return sfp_state_bits
+
+    def check_sfp_blocking_errors(self, sfp_state_bits):
+        for i in SFP_BLOCKING_ERRORS:
+            if (i & sfp_state_bits) == 0:
+                continue
+            sfp_state_bits |= Sfp.SFP_ERROR_BIT_BLOCKING
+
+        return sfp_state_bits

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/fan.py
@@ -6,6 +6,9 @@ try:
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
+FAN_NAME_LIST = ["FAN-1F", "FAN-1R", "FAN-2F", "FAN-2R",
+                 "FAN-3F", "FAN-3R", "FAN-4F", "FAN-4R",
+                 "FAN-5F", "FAN-5R", "FAN-6F", "FAN-6R"]
 
 class Fan(PddfFan):
     """PDDF Platform-Specific Fan class"""
@@ -15,10 +18,56 @@ class Fan(PddfFan):
         PddfFan.__init__(self, tray_idx, fan_idx, pddf_data, pddf_plugin_data, is_psu_fan, psu_index)
 
     # Provide the functions/variables below for which implementation is to be overwritten e.g.
-    #def get_name(self):
-        ## Since AS7712 has two fans in a tray, modifying this function to return proper name
-        #if self.is_psu_fan:
-            #return "PSU_FAN{}".format(self.fan_index)
-        #else:
-            #return "Fantray{}_{}".format(self.fantray_index, {1:'Front', 2:'Rear'}.get(self.fan_index,'none'))
+    def get_name(self):
+        """
+        Retrieves the name of the device
+            Returns:
+            string: The name of the device
+        """
+        fan_name = FAN_NAME_LIST[(self.fantray_index-1)*2 + self.fan_index-1] \
+            if not self.is_psu_fan \
+            else "PSU-{} FAN-{}".format(self.fans_psu_index, self.fan_index)
 
+        return fan_name
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the device
+        Returns:
+            string: Model/part number of device
+        """
+        return 'N/A'
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the device
+        Returns:
+            string: Serial number of device
+        """
+        return 'N/A'
+
+    def get_target_speed(self):
+        """
+        Retrieves the target (expected) speed of the fan
+
+        Returns:
+            An integer, the percentage of full fan speed, in the range 0 (off)
+                 to 100 (full speed)
+        """
+        if self.is_psu_fan:
+            return super().get_speed()
+        else:
+            return super().get_target_speed()
+
+    def get_direction(self):
+        """
+        Retrieves the direction of fan
+        Returns:
+            A string, either FAN_DIRECTION_INTAKE or FAN_DIRECTION_EXHAUST
+            depending on fan direction
+        """
+        direction = super().get_direction()
+        if direction is not None and len(direction) > 0:
+            return direction
+
+        return 'N/A'

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/fan_drawer.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/fan_drawer.py
@@ -15,3 +15,26 @@ class FanDrawer(PddfFanDrawer):
         PddfFanDrawer.__init__(self, tray_idx, pddf_data, pddf_plugin_data)
 
     # Provide the functions/variables below for which implementation is to be overwritten
+    def get_name(self):
+        """
+        Retrieves the fan drawer name
+        Returns:
+            string: The name of the device
+        """
+        return "FanTray{}".format(self.fantray_index)
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the device
+        Returns:
+            string: Model/part number of device
+        """
+        return 'N/A'
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the device
+        Returns:
+            string: Serial number of device
+        """
+        return 'N/A'

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/helper.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/helper.py
@@ -1,0 +1,368 @@
+import os
+import struct
+import json
+import fcntl
+from mmap import *
+from sonic_py_common import device_info
+from sonic_py_common import logger
+from threading import Lock
+from typing import cast
+from sonic_py_common.general import getstatusoutput_noshell_pipe
+from sonic_py_common.general import getstatusoutput_noshell
+
+HOST_CHK_CMD = ["docker"]
+EMPTY_STRING = ""
+
+
+class APIHelper():
+
+    def __init__(self):
+        (self.platform, self.hwsku) = device_info.get_platform_and_hwsku()
+
+    def is_host(self):
+        try:
+            status, output = getstatusoutput_noshell(HOST_CHK_CMD)
+            return status == 0
+        except Exception:
+            return False
+
+    def pci_get_value(self, resource, offset):
+        status = True
+        result = ""
+        try:
+            fd = os.open(resource, os.O_RDWR)
+            mm = mmap(fd, 0)
+            mm.seek(int(offset))
+            read_data_stream = mm.read(4)
+            result = struct.unpack('I', read_data_stream)
+        except Exception:
+            status = False
+        return status, result
+
+    def run_interactive_command(self, cmd):
+        try:
+            os.system(cmd)
+        except Exception:
+            return False
+        return True
+
+    def read_txt_file(self, file_path):
+        try:
+            with open(file_path, 'r', errors='replace') as fd:
+                data = fd.read()
+                ret = data.strip()
+                if len(ret) > 0:
+                    return ret
+        except IOError:
+            pass
+        return None
+
+    def write_txt_file(self, file_path, value):
+        try:
+            with open(file_path, 'w') as fd:
+                fd.write(str(value))
+        except IOError:
+            return False
+        return True
+
+    def ipmi_raw(self, netfn, cmd):
+        status = True
+        result = ""
+        try:
+            err, raw_data = getstatusoutput_noshell_pipe(['ipmitool', 'raw', str(netfn), str(cmd)])
+            if err == [0]:
+                result = raw_data.strip()
+            else:
+                status = False
+        except Exception:
+            status = False
+        return status, result
+
+    def ipmi_fru_id(self, id, key=None):
+        status = True
+        result = ""
+        try:
+            if (key is None):
+                err, raw_data = getstatusoutput_noshell_pipe(['ipmitool', 'fru', 'print', str(id)])
+            else:
+                err, raw_data = getstatusoutput_noshell_pipe(['ipmitool', 'fru', 'print', str(id)], ['grep', str(key)])
+            if err == [0] or err == [0, 0]:
+                result = raw_data.strip()
+            else:
+                status = False
+        except Exception:
+            status = False
+        return status, result
+
+    def ipmi_set_ss_thres(self, id, threshold_key, value):
+        status = True
+        result = ""
+        try:
+            err, raw_data = getstatusoutput_noshell_pipe(['ipmitool', 'sensor', 'thresh', str(id), str(threshold_key), str(value)])
+            if err == [0]:
+                result = raw_data.strip()
+            else:
+                status = False
+        except Exception:
+            status = False
+        return status, result
+
+
+class FileLock:
+    """
+    Due to pmon docker not installing the py-filelock, this class 
+    implements a simple file lock feature.
+    Ref: https://github.com/tox-dev/py-filelock/blob/main/src/filelock/
+    """
+
+    def __init__(self, lock_file):
+        self._lock_file = lock_file
+        self._thread_lock = Lock()
+        self.is_locked = False
+
+    def acquire(self):
+        with self._thread_lock:
+            if self.is_locked:
+                return
+
+            fd = os.open(self._lock_file, flags=(os.O_RDWR | os.O_CREAT | os.O_TRUNC))
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            self._lock_file_fd = fd
+            self.is_locked = True
+
+    def release(self):
+        with self._thread_lock:
+            if self.is_locked:
+                fd = cast(int, self._lock_file_fd)
+                self._lock_file_fd = None
+                fcntl.flock(fd, fcntl.LOCK_UN)
+                os.close(fd)
+                self.is_locked = False
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc_val, traceback):
+        self.release()
+
+    def __del__(self):
+        self.release()
+
+
+DEVICE_THRESHOLD_JSON_PATH = "/tmp/device_threshold.json"
+
+class DeviceThreshold:
+    HIGH_THRESHOLD = 'high_threshold'
+    LOW_THRESHOLD = 'low_threshold'
+    HIGH_CRIT_THRESHOLD = 'high_critical_threshold'
+    LOW_CRIT_THRESHOLD = 'low_critical_threshold'
+    NOT_AVAILABLE = 'N/A'
+
+    def __init__(self, th_name = NOT_AVAILABLE):
+        self.flock = FileLock("{}.lock".format(DEVICE_THRESHOLD_JSON_PATH))
+        self.name = th_name
+        self.__log = logger.Logger(log_identifier="DeviceThreshold")
+
+        self.__db_data = {}
+        self.__db_mtime = 0
+
+    def __reload_db(self):
+        try:
+            db_data = {}
+            with self.flock:
+                with open(DEVICE_THRESHOLD_JSON_PATH, "r") as db_file:
+                    db_data = json.load(db_file)
+        except Exception as e:
+            self.__log.log_warning('{}'.format(str(e)))
+            return None
+
+        return db_data
+
+    def __get_data(self, field):
+        """
+        Retrieves data frome JSON file by field
+
+        Args :
+            field: String
+
+        Returns:
+            A string if getting is successfully, 'N/A' if not
+        """
+        if os.path.exists(DEVICE_THRESHOLD_JSON_PATH):
+            new_mtime = os.path.getmtime(DEVICE_THRESHOLD_JSON_PATH)
+            if new_mtime != self.__db_mtime:
+                new_data = self.__reload_db()
+                if new_data is not None:
+                    self.__db_data = new_data
+                    self.__db_mtime = new_mtime
+
+        if self.name not in self.__db_data.keys():
+            return self.NOT_AVAILABLE
+
+        if field not in self.__db_data[self.name].keys():
+            return self.NOT_AVAILABLE
+
+        return self.__db_data[self.name][field]
+
+    def __set_data(self, field, new_val):
+        """
+        Set data to JSON file by field
+
+        Args :
+            field: String
+            new_val: String
+
+        Returns:
+            A boolean, True if setting is set successfully, False if not
+        """
+        if self.name not in self.__db_data.keys():
+            self.__db_data[self.name] = {}
+
+        old_val = self.__db_data[self.name].get(field, None)
+        if old_val is not None and old_val == new_val:
+            return True
+
+        self.__db_data[self.name][field] = new_val
+
+        try:
+            with self.flock:
+                db_data = {}
+                mode = "r+" if os.path.exists(DEVICE_THRESHOLD_JSON_PATH) else "w+"
+                with open(DEVICE_THRESHOLD_JSON_PATH, mode) as db_file:
+                    if mode == "r+":
+                        db_data = json.load(db_file)
+
+                    if self.name not in db_data.keys():
+                        db_data[self.name] = {}
+
+                    db_data[self.name][field] = new_val
+
+                    if mode == "r+":
+                        db_file.seek(0)
+                        # erase old data
+                        db_file.truncate(0)
+                    # write all data
+                    json.dump(db_data, db_file, indent=4)
+                self.__db_mtime = os.path.getmtime(DEVICE_THRESHOLD_JSON_PATH)
+        except Exception as e:
+            self.__log.log_error('{}'.format(str(e)))
+            return False
+
+        return True
+
+    def get_high_threshold(self):
+        """
+        Retrieves the high threshold temperature from JSON file.
+
+        Returns:
+            string : the high threshold temperature of thermal,
+                     e.g. "30.125"
+        """
+        return self.__get_data(self.HIGH_THRESHOLD)
+
+    def set_high_threshold(self, temperature):
+        """
+        Sets the high threshold temperature of thermal
+        Args :
+            temperature: A string of temperature, e.g. "30.125"
+        Returns:
+            A boolean, True if threshold is set successfully, False if not
+        """
+        if isinstance(temperature, str) is not True:
+            raise TypeError('The parameter requires string type.')
+
+        try:
+            if temperature != self.NOT_AVAILABLE:
+                float(temperature)
+        except ValueError:
+            raise ValueError('The parameter requires a float string. ex:\"30.1\"')
+
+        return self.__set_data(self.HIGH_THRESHOLD, temperature)
+
+    def get_low_threshold(self):
+        """
+        Retrieves the low threshold temperature from JSON file.
+
+        Returns:
+            string : the low threshold temperature of thermal,
+                     e.g. "30.125"
+        """
+        return self.__get_data(self.LOW_THRESHOLD)
+
+    def set_low_threshold(self, temperature):
+        """
+        Sets the low threshold temperature of thermal
+        Args :
+            temperature: A string of temperature, e.g. "30.125"
+        Returns:
+            A boolean, True if threshold is set successfully, False if not
+        """
+        if isinstance(temperature, str) is not True:
+            raise TypeError('The parameter requires string type.')
+
+        try:
+            if temperature != self.NOT_AVAILABLE:
+                float(temperature)
+        except ValueError:
+            raise ValueError('The parameter requires a float string. ex:\"30.1\"')
+
+        return self.__set_data(self.LOW_THRESHOLD, temperature)
+
+    def get_high_critical_threshold(self):
+        """
+        Retrieves the high critical threshold temperature from JSON file.
+
+        Returns:
+            string : the high critical threshold temperature of thermal,
+                     e.g. "30.125"
+        """
+        return self.__get_data(self.HIGH_CRIT_THRESHOLD)
+
+    def set_high_critical_threshold(self, temperature):
+        """
+        Sets the high critical threshold temperature of thermal
+        Args :
+            temperature: A string of temperature, e.g. "30.125"
+        Returns:
+            A boolean, True if threshold is set successfully, False if not
+        """
+        if isinstance(temperature, str) is not True:
+            raise TypeError('The parameter requires string type.')
+
+        try:
+            if temperature != self.NOT_AVAILABLE:
+                float(temperature)
+        except ValueError:
+            raise ValueError('The parameter requires a float string. ex:\"30.1\"')
+
+        return self.__set_data(self.HIGH_CRIT_THRESHOLD, temperature)
+
+    def get_low_critical_threshold(self):
+        """
+        Retrieves the low critical threshold temperature from JSON file.
+
+        Returns:
+            string : the low critical threshold temperature of thermal,
+                     e.g. "30.125"
+        """
+        return self.__get_data(self.LOW_CRIT_THRESHOLD)
+
+    def set_low_critical_threshold(self, temperature):
+        """
+        Sets the low critical threshold temperature of thermal
+        Args :
+            temperature: A string of temperature, e.g. "30.125"
+        Returns:
+            A boolean, True if threshold is set successfully, False if not
+        """
+        if isinstance(temperature, str) is not True:
+            raise TypeError('The parameter requires string type.')
+
+        try:
+            if temperature != self.NOT_AVAILABLE:
+                float(temperature)
+        except ValueError:
+            raise ValueError('The parameter requires a float string. ex:\"30.1\"')
+
+        return self.__set_data(self.LOW_CRIT_THRESHOLD, temperature)

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/pcie.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/pcie.py
@@ -1,0 +1,19 @@
+#############################################################################
+# Edgecore
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the fan status which are available in the platform
+# Base PCIe class
+#############################################################################
+
+try:
+    from sonic_platform_base.sonic_pcie.pcie_common import PcieUtil
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Pcie(PcieUtil):
+    """Edgecore Platform-specific PCIe class"""
+
+    def __init__(self, platform_path):
+        PcieUtil.__init__(self, platform_path)

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/psu.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/psu.py
@@ -11,41 +11,38 @@ except ImportError as e:
 class Psu(PddfPsu):
     """PDDF Platform-Specific PSU class"""
     
-    PLATFORM_PSU_CAPACITY = 650
 
     def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
         PddfPsu.__init__(self, index, pddf_data, pddf_plugin_data)
         
     # Provide the functions/variables below for which implementation is to be overwritten
-    def get_capacity(self):
+    def get_name(self):
+        return "PSU-{}".format(self.psu_index)
+
+    def get_revision(self):
         """
-        Gets the capacity (maximum output power) of the PSU in watts
+        Retrieves the hardware revision of the device
 
         Returns:
-            An integer, the capacity of PSU
+            string: Revision value of device
         """
-        return (self.PLATFORM_PSU_CAPACITY)
+        return 'N/A'
 
-    def get_type(self):
+    def get_temperature_high_threshold(self):
         """
-        Gets the type of the PSU
-
+        Retrieves the high threshold temperature of PSU
         Returns:
-            A string, the type of PSU (AC/DC)
+            A float number, the high threshold temperature of PSU in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
-        ptype = "AC"
-        # Currently the platform supports only AC type of PSUs
-        try:
-            import sonic_platform.platform
-            ch=sonic_platform.platform.Platform().get_chassis()
-            e=ch.sys_eeprom.read_eeprom()
-            ret, prod_name = ch.sys_eeprom.get_tlv_field(e,0x21)
-            if ret:
-                prod_name = prod_name[2].decode('ascii')
-                #print "Product name is {}".format(prod_name)
-                if '48V' in prod_name:
-                    ptype = 'DC'
-        except Exception as e:
-            print("Error while trying to read syseeprom to get PSU type - {}".format(repr(e)))
+        threshold = super().get_temperature_high_threshold()
 
-        return ptype
+        for psu_thermal_idx in range(self.num_psu_thermals):
+            try:
+                tmp = self._thermal_list[psu_thermal_idx].get_high_threshold()
+                if threshold > tmp or threshold == 0.0:
+                    threshold = tmp
+            except Exception:
+                pass
+
+        return threshold

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/psu.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/psu.py
@@ -46,3 +46,68 @@ class Psu(PddfPsu):
                 pass
 
         return threshold
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the device
+
+        Returns:
+            string: Model/part number of device
+        """
+        model = super().get_model()
+        if model and model.strip() == "":
+            return None
+
+        return model
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the device
+
+        Returns:
+            string: Serial number of device
+        """
+        serial = super().get_serial()
+        if serial and serial.strip() == "":
+            return None
+
+        return serial
+
+    def get_voltage(self):
+        """
+        Retrieves current PSU voltage output
+
+        Returns:
+            A float number, the output voltage in volts,
+            e.g. 12.1
+        """
+        if self.get_status() is not True:
+            return 0.0
+
+        return super().get_voltage()
+
+    def get_current(self):
+        """
+        Retrieves present electric current supplied by PSU
+
+        Returns:
+            A float number, electric current in amperes,
+            e.g. 15.4
+        """
+        if self.get_status() is not True:
+            return 0.0
+
+        return super().get_current()
+
+    def get_power(self):
+        """
+        Retrieves current energy supplied by PSU
+
+        Returns:
+            A float number, the power in watts,
+            e.g. 302.6
+        """
+        if self.get_status() is not True:
+            return 0.0
+
+        return super().get_power()

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/sfp.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 
 try:
+    import natsort
     from sonic_platform_pddf_base.pddf_sfp import PddfSfp
+    from sonic_platform_base.sonic_sfp.sfputilhelper import SfpUtilHelper
+    from sonic_py_common import device_info
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
@@ -11,10 +14,184 @@ class Sfp(PddfSfp):
     PDDF Platform-Specific Sfp class
     """
 
+    SFP_TYPE_CODE_LIST = [
+        0x03,  # SFP/SFP+/SFP28
+        0x0b   # DWDM-SFP/SFP+
+    ]
+    QSFP_TYPE_CODE_LIST = [
+        0x0c, # QSFP
+        0x0d, # QSFP+ or later
+        0x11, # QSFP28 or later
+        0xe1  # QSFP28 EDFA
+    ]
+
     def __init__(self, index, pddf_data=None, pddf_plugin_data=None):
         PddfSfp.__init__(self, index, pddf_data, pddf_plugin_data)
+        self.index = index + 1
 
     # Provide the functions/variables below for which implementation is to be overwritten
     def get_position_in_parent(self):
         """Retrieves 1-based relative physical position in parent device."""
         return self.port_index
+
+    def __get_path_to_port_config_file(self):
+        platform, hwsku = device_info.get_platform_and_hwsku()
+        hwsku_path = "/".join(["/usr/share/sonic/platform",hwsku])
+        return "/".join([hwsku_path, "port_config.ini"])
+
+    def get_name(self):
+        """
+        Retrieves the name of the device
+            Returns:
+            string: The name of the device
+        """
+        sfputil_helper = SfpUtilHelper()
+        sfputil_helper.read_porttab_mappings(
+            self.__get_path_to_port_config_file())
+
+        logical_port_list = sfputil_helper.logical
+        logical_port_list = natsort.natsorted(logical_port_list)
+        name = logical_port_list[self.port_index-1] or "Unknown"
+
+        return name
+
+    def __validate_eeprom_sfp(self):
+        checksum_test = 0
+        eeprom_raw = self.read_eeprom(0, 96)
+        if eeprom_raw is None:
+            return None
+
+        for i in range(0, 63):
+            checksum_test = (checksum_test + eeprom_raw[i]) & 0xFF
+        else:
+            if checksum_test != eeprom_raw[63]:
+                return False
+
+        checksum_test = 0
+        for i in range(64, 95):
+            checksum_test = (checksum_test + eeprom_raw[i]) & 0xFF
+        else:
+            if checksum_test != eeprom_raw[95]:
+                return False
+
+        api = self.get_xcvr_api()
+        if api is None:
+            return False
+
+        if api.is_flat_memory():
+            return True
+
+        checksum_test = 0
+        eeprom_raw = self.read_eeprom(384, 96)
+        if eeprom_raw is None:
+            return None
+
+        for i in range(0, 95):
+            checksum_test = (checksum_test + eeprom_raw[i]) & 0xFF
+        else:
+            if checksum_test != eeprom_raw[95]:
+                return False
+
+        return True
+
+    def __validate_eeprom_qsfp(self):
+        checksum_test = 0
+        eeprom_raw = self.read_eeprom(128, 96)
+        if eeprom_raw is None:
+            return None
+
+        for i in range(0, 63):
+            checksum_test = (checksum_test + eeprom_raw[i]) & 0xFF
+        else:
+            if checksum_test != eeprom_raw[63]:
+                return False
+
+        checksum_test = 0
+        for i in range(64, 95):
+            checksum_test = (checksum_test + eeprom_raw[i]) & 0xFF
+        else:
+            if checksum_test != eeprom_raw[95]:
+                return False
+
+        api = self.get_xcvr_api()
+        if api is None:
+            return False
+
+        if api.is_flat_memory():
+            return True
+
+        return True
+
+    def validate_eeprom(self):
+        id_byte_raw = self.read_eeprom(0, 1)
+        if id_byte_raw is None:
+            return None
+
+        id = id_byte_raw[0]
+        if id in self.QSFP_TYPE_CODE_LIST:
+            return self.__validate_eeprom_qsfp()
+        elif id in self.SFP_TYPE_CODE_LIST:
+            return self.__validate_eeprom_sfp()
+        else:
+            return False
+
+    def validate_temperature(self):
+        temperature = self.get_temperature()
+        if temperature is None:
+            return None
+
+        threshold_dict = self.get_transceiver_threshold_info()
+        if threshold_dict is None:
+            return None
+
+        if isinstance(temperature, float) is not True:
+            return True
+
+        if isinstance(threshold_dict['temphighalarm'], float) is not True:
+            return True
+
+        return threshold_dict['temphighalarm'] > temperature
+
+    def __get_error_description(self):
+        if not self.get_presence():
+            return self.SFP_STATUS_UNPLUGGED
+
+        err_stat = self.SFP_STATUS_BIT_INSERTED
+
+        status = self.validate_eeprom()
+        if status is not True:
+            err_stat = (err_stat | self.SFP_ERROR_BIT_BAD_EEPROM)
+
+        status = self.validate_temperature()
+        if status is not True:
+            err_stat = (err_stat | self.SFP_ERROR_BIT_HIGH_TEMP)
+
+        if err_stat is self.SFP_STATUS_BIT_INSERTED:
+            return self.SFP_STATUS_OK
+        else:
+            err_desc = ''
+            cnt = 0
+            for key in self.SFP_ERROR_BIT_TO_DESCRIPTION_DICT:
+                if (err_stat & key) != 0:
+                    if cnt > 0:
+                        err_desc = err_desc + "|"
+                        cnt = cnt + 1
+                    err_desc = err_desc + self.SFP_ERROR_BIT_TO_DESCRIPTION_DICT[key]
+
+            return err_desc
+
+    def get_error_description(self):
+        """
+        Retrives the error descriptions of the SFP module
+        Returns:
+            String that represents the current error descriptions of vendor specific errors
+            In case there are multiple errors, they should be joined by '|',
+            like: "Bad EEPROM|Unsupported cable"
+        """
+        try:
+            ret = super().get_error_description()
+            if ret is not None:
+                return ret
+        except NotImplementedError:
+            pass
+        return self.__get_error_description()

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/thermal.py
@@ -3,15 +3,251 @@
 
 try:
     from sonic_platform_pddf_base.pddf_thermal import PddfThermal
+    from .helper import DeviceThreshold
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 
+NOT_AVAILABLE = DeviceThreshold.NOT_AVAILABLE
+HIGH_THRESHOLD = DeviceThreshold.HIGH_THRESHOLD
+LOW_THRESHOLD = DeviceThreshold.LOW_THRESHOLD
+HIGH_CRIT_THRESHOLD = DeviceThreshold.HIGH_CRIT_THRESHOLD
+LOW_CRIT_THRESHOLD = DeviceThreshold.LOW_CRIT_THRESHOLD
 
+DEFAULT_THRESHOLD = {
+    'Temp sensor 1' : {
+        HIGH_THRESHOLD : '80.0',
+        LOW_THRESHOLD : NOT_AVAILABLE,
+        HIGH_CRIT_THRESHOLD : NOT_AVAILABLE,
+        LOW_CRIT_THRESHOLD : NOT_AVAILABLE
+    },
+    'Temp sensor 2' : {
+        HIGH_THRESHOLD : '80.0',
+        LOW_THRESHOLD : NOT_AVAILABLE,
+        HIGH_CRIT_THRESHOLD : NOT_AVAILABLE,
+        LOW_CRIT_THRESHOLD : NOT_AVAILABLE
+    },
+    'Temp sensor 3' : {
+        HIGH_THRESHOLD : '80.0',
+        LOW_THRESHOLD : NOT_AVAILABLE,
+        HIGH_CRIT_THRESHOLD : NOT_AVAILABLE,
+        LOW_CRIT_THRESHOLD : NOT_AVAILABLE
+    },
+    'Temp sensor 4' : {
+        HIGH_THRESHOLD : '80.0',
+        LOW_THRESHOLD : NOT_AVAILABLE,
+        HIGH_CRIT_THRESHOLD : NOT_AVAILABLE,
+        LOW_CRIT_THRESHOLD : NOT_AVAILABLE
+    },
+    'PSU-1 temp sensor 1' : {
+        HIGH_THRESHOLD : '80.0',
+        LOW_THRESHOLD : NOT_AVAILABLE,
+        HIGH_CRIT_THRESHOLD : NOT_AVAILABLE,
+        LOW_CRIT_THRESHOLD : NOT_AVAILABLE
+    },
+    'PSU-2 temp sensor 1' : {
+        HIGH_THRESHOLD : '80.0',
+        LOW_THRESHOLD : NOT_AVAILABLE,
+        HIGH_CRIT_THRESHOLD : NOT_AVAILABLE,
+        LOW_CRIT_THRESHOLD : NOT_AVAILABLE
+    }
+}
 class Thermal(PddfThermal):
     """PDDF Platform-Specific Thermal class"""
 
     def __init__(self, index, pddf_data=None, pddf_plugin_data=None, is_psu_thermal=False, psu_index=0):
         PddfThermal.__init__(self, index, pddf_data, pddf_plugin_data, is_psu_thermal, psu_index)
 
+        # Threshold Configuration
+        self.__conf = DeviceThreshold(self.get_name())
+        # Default threshold.
+        self.__default_threshold = DEFAULT_THRESHOLD[self.get_name()]
+        self.min_temperature = None
+        self.max_temperature = None
+
     # Provide the functions/variables below for which implementation is to be overwritten
+    def get_name(self):
+        if self.is_psu_thermal:
+            return "PSU-{0} temp sensor 1".format(self.thermals_psu_index)
+        else:
+            return "Temp sensor {0}".format(self.thermal_index)
+
+    def get_status(self):
+        get_temp=self.get_temperature()
+
+        if get_temp is not None:
+            return True if get_temp else False
+
+    def get_temperature(self):
+        current = super().get_temperature()
+
+        if self.min_temperature is None or \
+            current < self.min_temperature:
+            self.min_temperature = current
+
+        if self.max_temperature is None or \
+           current > self.max_temperature:
+            self.max_temperature = current
+
+        return current
+
+    def set_high_threshold(self, temperature):
+        try:
+            value = float(temperature)
+        except Exception:
+            return False
+
+        # The new value can not be more than the default value.
+        default_value = self.__default_threshold[HIGH_THRESHOLD]
+        if default_value != NOT_AVAILABLE:
+            if value > float(default_value):
+                return False
+
+        try:
+            self.__conf.set_high_threshold(str(value))
+        except Exception:
+            return False
+
+        return True
+
+    def get_high_threshold(self):
+        value = self.__conf.get_high_threshold()
+        if value != NOT_AVAILABLE:
+            return float(value)
+
+        default_value = self.__default_threshold[HIGH_THRESHOLD]
+        if default_value != NOT_AVAILABLE:
+            return float(default_value)
+
+        raise NotImplementedError
+
+    def set_low_threshold(self, temperature):
+        try:
+            value = float(temperature)
+        except Exception:
+            return False
+
+        # The new value can not be less than the default value.
+        default_value = self.__default_threshold[LOW_THRESHOLD]
+        if default_value != NOT_AVAILABLE:
+            if value < float(default_value):
+                return False
+
+        try:
+            self.__conf.set_low_threshold(str(value))
+        except Exception:
+            return False
+
+        return True
+
+    def get_low_threshold(self):
+        value = self.__conf.get_low_threshold()
+        if value != NOT_AVAILABLE:
+            return float(value)
+
+        default_value = self.__default_threshold[LOW_THRESHOLD]
+        if default_value != NOT_AVAILABLE:
+            return float(default_value)
+
+        raise NotImplementedError
+
+    def set_high_critical_threshold(self, temperature):
+        try:
+            value = float(temperature)
+        except Exception:
+            return False
+
+        # The new value can not be more than the default value.
+        default_value = self.__default_threshold[HIGH_CRIT_THRESHOLD]
+        if default_value != NOT_AVAILABLE:
+            if value > float(default_value):
+                return False
+
+        try:
+            self.__conf.set_high_critical_threshold(str(value))
+        except Exception:
+            return False
+
+        return True
+
+    def get_high_critical_threshold(self):
+        value = self.__conf.get_high_critical_threshold()
+        if value != NOT_AVAILABLE:
+            return float(value)
+
+        default_value = self.__default_threshold[HIGH_CRIT_THRESHOLD]
+        if default_value != NOT_AVAILABLE:
+            return float(default_value)
+
+        raise NotImplementedError
+
+    def set_low_critical_threshold(self, temperature):
+        try:
+            value = float(temperature)
+        except Exception:
+            return False
+
+        # The new value can not be less than the default value.
+        default_value = self.__default_threshold[LOW_CRIT_THRESHOLD]
+        if default_value != NOT_AVAILABLE:
+            if value < float(default_value):
+                return False
+
+        try:
+            self.__conf.set_low_critical_threshold(str(value))
+        except Exception:
+            return False
+
+        return True
+
+    def get_low_critical_threshold(self):
+        value = self.__conf.get_low_critical_threshold()
+        if value != NOT_AVAILABLE:
+            return float(value)
+
+        default_value = self.__default_threshold[LOW_CRIT_THRESHOLD]
+        if default_value != NOT_AVAILABLE:
+            return float(default_value)
+
+        raise NotImplementedError
+
+    def get_model(self):
+        """
+        Retrieves the model number (or part number) of the device
+        Returns:
+            string: Model/part number of device
+        """
+
+        return "N/A"
+
+    def get_serial(self):
+        """
+        Retrieves the serial number of the device
+        Returns:
+            string: Serial number of device
+        """
+        return "N/A"
+
+    def get_minimum_recorded(self):
+        """
+        Retrieves the minimum recorded temperature of thermal
+        Returns:
+            A float number, the minimum recorded temperature of thermal in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        if self.min_temperature is None:
+            self.get_temperature()
+
+        return self.min_temperature
+
+    def get_maximum_recorded(self):
+        """
+        Retrieves the maximum recorded temperature of thermal
+        Returns:
+            A float number, the maximum recorded temperature of thermal in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        if self.min_temperature is None:
+            self.get_temperature()
+
+        return self.max_temperature

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/thermal.py
@@ -247,7 +247,7 @@ class Thermal(PddfThermal):
             A float number, the maximum recorded temperature of thermal in Celsius
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
-        if self.min_temperature is None:
+        if self.max_temperature is None:
             self.get_temperature()
 
         return self.max_temperature

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/thermal.py
@@ -15,28 +15,52 @@ HIGH_CRIT_THRESHOLD = DeviceThreshold.HIGH_CRIT_THRESHOLD
 LOW_CRIT_THRESHOLD = DeviceThreshold.LOW_CRIT_THRESHOLD
 
 DEFAULT_THRESHOLD = {
-    'Temp sensor 1' : {
+    'MB_RearLeft_temp(0x48)' : {
         HIGH_THRESHOLD : '80.0',
         LOW_THRESHOLD : NOT_AVAILABLE,
         HIGH_CRIT_THRESHOLD : NOT_AVAILABLE,
         LOW_CRIT_THRESHOLD : NOT_AVAILABLE
     },
-    'Temp sensor 2' : {
+    'MB_FrontMiddle_temp(0x49)' : {
         HIGH_THRESHOLD : '80.0',
         LOW_THRESHOLD : NOT_AVAILABLE,
         HIGH_CRIT_THRESHOLD : NOT_AVAILABLE,
         LOW_CRIT_THRESHOLD : NOT_AVAILABLE
     },
-    'Temp sensor 3' : {
+    'MB_MiddleLeft_temp(0x4A)' : {
         HIGH_THRESHOLD : '80.0',
         LOW_THRESHOLD : NOT_AVAILABLE,
         HIGH_CRIT_THRESHOLD : NOT_AVAILABLE,
         LOW_CRIT_THRESHOLD : NOT_AVAILABLE
     },
-    'Temp sensor 4' : {
+    'CB_temp(0x4B)' : {
         HIGH_THRESHOLD : '80.0',
         LOW_THRESHOLD : NOT_AVAILABLE,
         HIGH_CRIT_THRESHOLD : NOT_AVAILABLE,
+        LOW_CRIT_THRESHOLD : NOT_AVAILABLE
+    },
+    'CPU_Core_0_temp' : {
+        HIGH_THRESHOLD : '98.0',
+        LOW_THRESHOLD : NOT_AVAILABLE,
+        HIGH_CRIT_THRESHOLD : '98.0',
+        LOW_CRIT_THRESHOLD : NOT_AVAILABLE
+    },
+    'CPU_Core_1_temp' : {
+        HIGH_THRESHOLD : '98.0',
+        LOW_THRESHOLD : NOT_AVAILABLE,
+        HIGH_CRIT_THRESHOLD : '98.0',
+        LOW_CRIT_THRESHOLD : NOT_AVAILABLE
+    },
+    'CPU_Core_2_temp' : {
+        HIGH_THRESHOLD : '98.0',
+        LOW_THRESHOLD : NOT_AVAILABLE,
+        HIGH_CRIT_THRESHOLD : '98.0',
+        LOW_CRIT_THRESHOLD : NOT_AVAILABLE
+    },
+    'CPU_Core_3_temp' : {
+        HIGH_THRESHOLD : '98.0',
+        LOW_THRESHOLD : NOT_AVAILABLE,
+        HIGH_CRIT_THRESHOLD : '98.0',
         LOW_CRIT_THRESHOLD : NOT_AVAILABLE
     },
     'PSU-1 temp sensor 1' : {
@@ -70,6 +94,11 @@ class Thermal(PddfThermal):
         if self.is_psu_thermal:
             return "PSU-{0} temp sensor 1".format(self.thermals_psu_index)
         else:
+            if 'dev_attr' in self.thermal_obj.keys():
+                if 'display_name' in self.thermal_obj['dev_attr']:
+                    return str(self.thermal_obj['dev_attr']['display_name'])
+
+            # In case of errors
             return "Temp sensor {0}".format(self.thermal_index)
 
     def get_status(self):
@@ -119,7 +148,7 @@ class Thermal(PddfThermal):
         if default_value != NOT_AVAILABLE:
             return float(default_value)
 
-        raise NotImplementedError
+        return super().get_high_threshold()
 
     def set_low_threshold(self, temperature):
         try:
@@ -179,7 +208,7 @@ class Thermal(PddfThermal):
         if default_value != NOT_AVAILABLE:
             return float(default_value)
 
-        raise NotImplementedError
+        return super().get_high_critical_threshold()
 
     def set_low_critical_threshold(self, temperature):
         try:

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/utils/accton_as7712_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/utils/accton_as7712_util.py
@@ -134,7 +134,6 @@ def main():
         elif opt in ('-f', '--force'):
             FORCE = 1
         else:
-            print("TEST")
             logging.info('no option')
     for arg in args:
         if arg == 'install':
@@ -178,7 +177,7 @@ def driver_check():
 
 kos = [
 'modprobe i2c_dev',
-'modprobe i2c_mux_pca954x force_deselect_on_exit=1',
+'modprobe i2c_mux_pca954x',
 'modprobe accton_i2c_cpld'  ,
 'modprobe ym2651y'                  ,
 'modprobe accton_as7712_32x_fan'     ,
@@ -259,6 +258,13 @@ def device_install():
                 print(output)
                 if FORCE == 0:                
                     return status  
+    # set all pca954x idle_disconnect
+    cmd = 'echo -2 | tee /sys/bus/i2c/drivers/pca954x/*-00*/idle_state'
+    status, output = log_os_system(cmd, 1)
+    if status:
+        print(output)
+        if FORCE == 0:
+            return status
     for i in range(0,len(sfp_map)):
         status, output =log_os_system("echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-"+str(sfp_map[i])+"/new_device", 1)
         if status:

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/utils/accton_as7712_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/utils/accton_as7712_util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (C) 2016 Accton Networks, Inc.
 #
@@ -17,180 +17,29 @@
 
 """
 Usage: %(scriptName)s [options] command object
-
 options:
     -h | --help     : this help message
     -d | --debug    : run with debug mode
-    -f | --force    : ignore error during installation or clean 
+    -f | --force    : ignore error during installation or clean
 command:
     install     : install drivers and generate related sysfs nodes
     clean       : uninstall drivers and remove related sysfs nodes
-    show        : show all systen status
-    sff         : dump SFP eeprom
-    set         : change board setting with fan|led|sfp    
 """
-
 import subprocess
 import getopt
 import sys
 import logging
-import re
 import time
-
-
-
 
 PROJECT_NAME = 'as7712_32x'
 version = '0.1.0'
 verbose = False
 DEBUG = False
 args = []
-ALL_DEVICE = {}               
-DEVICE_NO = {'led':5, 'fan':6,'thermal':4, 'psu':2, 'sfp':32}
-FORCE = 0
-#logging.basicConfig(filename= PROJECT_NAME+'.log', filemode='w',level=logging.DEBUG)
-#logging.basicConfig(level=logging.INFO)
-
-
-if DEBUG == True:
-    print(sys.argv[0])
-    print('ARGV      :', sys.argv[1:])   
-
-
-def main():
-    global DEBUG
-    global args
-    global FORCE
-        
-    if len(sys.argv)<2:
-        show_help()
-         
-    options, args = getopt.getopt(sys.argv[1:], 'hdf', ['help',
-                                                       'debug',
-                                                       'force',
-                                                          ])
-    if DEBUG == True:                                                           
-        print(options)
-        print(args)
-        print(len(sys.argv))
-            
-    for opt, arg in options:
-        if opt in ('-h', '--help'):
-            show_help()
-        elif opt in ('-d', '--debug'):            
-            DEBUG = True
-            logging.basicConfig(level=logging.INFO)
-        elif opt in ('-f', '--force'): 
-            FORCE = 1
-        else:
-            logging.info('no option')                          
-    for arg in args:            
-        if arg == 'install':
-           do_install()
-        elif arg == 'clean':
-           do_uninstall()
-        elif arg == 'show':
-           device_traversal()
-        elif arg == 'sff':
-            if len(args)!=2:
-                show_eeprom_help()
-            elif int(args[1]) ==0 or int(args[1]) > DEVICE_NO['sfp']:              
-                show_eeprom_help()
-            else:
-                show_eeprom(args[1])  
-            return                              
-        elif arg == 'set':
-            if len(args)<3:
-                show_set_help()
-            else:
-                set_device(args[1:])                
-            return                
-        else:
-            show_help()
-            
-            
-    return 0              
-        
-def show_help():
-    print(__doc__ % {'scriptName' : sys.argv[0].split("/")[-1]})
-    sys.exit(0)
-
-def  show_set_help():
-    cmd =  sys.argv[0].split("/")[-1]+ " "  + args[0]
-    print(cmd +" [led|sfp|fan]")
-    print("    use \""+ cmd + " led 0-4 \"  to set led color")
-    print("    use \""+ cmd + " fan 0-100\" to set fan duty percetage")    
-    print("    use \""+ cmd + " sfp 1-32 {0|1}\" to set sfp# tx_disable") 
-    sys.exit(0)  
-    
-def  show_eeprom_help():
-    cmd =  sys.argv[0].split("/")[-1]+ " "  + args[0]
-    print("    use \""+ cmd + " 1-32 \" to dump sfp# eeprom") 
-    sys.exit(0)           
-            
-def my_log(txt):
-    if DEBUG == True:
-        print("[ROY]"+txt)    
-    return
-    
-def log_os_system(cmd, show):
-    logging.info('Run :'+cmd)  
-    status, output = subprocess.getstatusoutput(cmd)    
-    my_log (cmd +"with result:" + str(status))
-    my_log ("      output:"+output)    
-    if status:
-        logging.info('Failed :'+cmd)
-        if show:
-            print(('Failed :'+cmd))
-    return  status, output
-            
-def driver_check():
-    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
-    logging.info('mods:'+lsmod)
-    if ret :
-        return False
-    else :
-        return True
-
-
-
-kos = [
-'modprobe i2c_dev',
-'modprobe i2c_mux_pca954x force_deselect_on_exit=1',
-'modprobe accton_i2c_cpld'  ,
-'modprobe ym2651y'                  ,
-'modprobe accton_as7712_32x_fan'     ,
-'modprobe optoe'      ,
-'modprobe leds-accton_as7712_32x'      ,
-'modprobe accton_as7712_32x_psu' ]
-
-def driver_install():
-    global FORCE
-    status, output = log_os_system("depmod", 1)
-    for i in range(0,len(kos)):
-        status, output = log_os_system(kos[i], 1)
-        if status:
-            if FORCE == 0:        
-                return status              
-    return 0
-    
-def driver_uninstall():
-    global FORCE
-    for i in range(0,len(kos)):
-        rm = kos[-(i+1)].replace("modprobe", "modprobe -rq")
-        rm = rm.replace("insmod", "rmmod")        
-        status, output = log_os_system(rm, 1)
-        if status:
-            if FORCE == 0:        
-                return status              
-    return 0
-
-led_prefix ='/sys/class/leds/accton_'+PROJECT_NAME+'_led::'
-hwmon_types = {'led': ['diag','fan','loc','psu1','psu2']}
-hwmon_nodes = {'led': ['brightness'] }
-hwmon_prefix ={'led': led_prefix}
+ALL_DEVICE = {}
 
 i2c_prefix = '/sys/bus/i2c/devices/'
+'''
 i2c_bus = {'fan': ['2-0066']                 ,
            'thermal': ['3-0048','3-0049', '3-004a', '3-004b'] ,
            'psu': ['10-0050','11-0053'], 
@@ -199,7 +48,8 @@ i2c_nodes = {'fan': ['present', 'front_speed_rpm', 'rear_speed_rpm'] ,
            'thermal': ['hwmon/hwmon*/temp1_input'] ,
            'psu': ['psu_present ', 'psu_power_good']    ,
            'sfp': ['module_present', 'sfp_tx_disable_all']}
-                   
+'''
+                  
 sfp_map =  [22,23,24,25,27,26,29,28,
                  18,19,20,21,30,31,32,33,
                  34,35,36,37,46,47,48,49,
@@ -247,6 +97,125 @@ mknod2 =[
 'echo cpld_as7712 0x60 > /sys/bus/i2c/devices/i2c-4/new_device',
 'echo cpld_plain 0x62 > /sys/bus/i2c/devices/i2c-5/new_device',
 'echo cpld_plain 0x64 > /sys/bus/i2c/devices/i2c-6/new_device']
+
+FORCE = 0
+logging.basicConfig(filename= PROJECT_NAME+'.log', filemode='w',level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
+
+
+if DEBUG == True:
+    print(sys.argv[0])
+    print('ARGV      :', sys.argv[1:])
+
+
+def main():
+    global DEBUG
+    global args
+    global FORCE
+
+    if len(sys.argv)<2:
+        show_help()
+
+    options, args = getopt.getopt(sys.argv[1:], 'hdf', ['help',
+                                                       'debug',
+                                                       'force',
+                                                          ])
+    if DEBUG == True:
+        print(options)
+        print(args)
+        print(len(sys.argv))
+
+    for opt, arg in options:
+        if opt in ('-h', '--help'):
+            show_help()
+        elif opt in ('-d', '--debug'):
+            DEBUG = True
+            logging.basicConfig(level=logging.INFO)
+        elif opt in ('-f', '--force'):
+            FORCE = 1
+        else:
+            print("TEST")
+            logging.info('no option')
+    for arg in args:
+        if arg == 'install':
+           do_install()
+        elif arg == 'clean':
+           do_uninstall()
+        else:
+            show_help()
+            
+    return 0              
+        
+def show_help():
+    print(__doc__ % {'scriptName' : sys.argv[0].split("/")[-1]})
+    sys.exit(0)
+
+def my_log(txt):
+    if DEBUG == True:
+         print("[ACCTON DBG]: ",txt)
+    return
+
+def log_os_system(cmd, show):
+    logging.info('Run :'+cmd)  
+    status, output = subprocess.getstatusoutput(cmd)    
+    my_log (cmd +"with result:" + str(status))
+    my_log ("      output:"+output)    
+    if status:
+        logging.info('Failed :'+cmd)
+        if show:
+            print('Failed :'+cmd)
+    return  status, output
+            
+def driver_check():
+    ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
+    logging.info('mods:'+lsmod)
+    if ret :
+        return False
+    else :
+        return True
+
+
+
+kos = [
+'modprobe i2c_dev',
+'modprobe i2c_mux_pca954x force_deselect_on_exit=1',
+'modprobe accton_i2c_cpld'  ,
+'modprobe ym2651y'                  ,
+'modprobe accton_as7712_32x_fan'     ,
+'modprobe optoe'      ,
+'modprobe leds-accton_as7712_32x'      ,
+'modprobe accton_as7712_32x_psu' ]
+
+def driver_install():
+    global FORCE
+    status, output = log_os_system("depmod", 1)
+    for i in range(0,len(kos)):
+        status, output = log_os_system(kos[i], 1)
+        if status:
+            if FORCE == 0:        
+                return status  
+
+    print("Done driver_install")
+
+    return 0
+    
+def driver_uninstall():
+    global FORCE
+    for i in range(0,len(kos)):
+        rm = kos[-(i+1)].replace("modprobe", "modprobe -rq")
+        rm = rm.replace("insmod", "rmmod")        
+        lst = rm.split(" ")
+
+        if len(lst) > 3:
+            del(lst[3])
+        rm = " ".join(lst)
+        status, output = log_os_system(rm, 1)
+        if status:
+            if FORCE == 0:        
+                return status              
+    return 0
+
+
        
        
 def i2c_order_check():    
@@ -296,6 +265,9 @@ def device_install():
             print(output)
             if FORCE == 0:            
                 return status                                  
+    
+    print("Done device_install")
+    
     return 
     
 def device_uninstall():
@@ -351,7 +323,7 @@ def do_install():
     else:
         print(PROJECT_NAME.upper()+" drivers detected....")                      
     if not device_exist():
-        print("No device, installing....")     
+        print("No device, installing....")
         status = device_install() 
         if status:
             if FORCE == 0:        
@@ -363,9 +335,9 @@ def do_install():
 def do_uninstall():
     print("Checking system....")
     if not device_exist():
-        print(PROJECT_NAME.upper() +" has no device installed....")         
+        print(PROJECT_NAME.upper() +" has no device installed....")
     else:
-        print("Removing device....")     
+        print("Removing device....")
         status = device_uninstall() 
         if status:
             if FORCE == 0:            
@@ -382,184 +354,7 @@ def do_uninstall():
                     
     return       
 
-def devices_info():
-    global DEVICE_NO
-    global ALL_DEVICE
-    global i2c_bus, hwmon_types
-    for key in DEVICE_NO:   
-        ALL_DEVICE[key]= {} 
-        for i in range(0,DEVICE_NO[key]):
-            ALL_DEVICE[key][key+str(i+1)] = []
-            
-    for key in i2c_bus:
-        buses = i2c_bus[key]
-        nodes = i2c_nodes[key]    
-        for i in range(0,len(buses)):
-            for j in range(0,len(nodes)):
-                if  'fan' == key:
-                    for k in range(0,DEVICE_NO[key]):
-                        node = key+str(k+1)
-                        path = i2c_prefix+ buses[i]+"/fan"+str(k+1)+"_"+ nodes[j]
-                        my_log(node+": "+ path)
-                        ALL_DEVICE[key][node].append(path) 
-                elif  'sfp' == key:
-                    for k in range(0,DEVICE_NO[key]):
-                        node = key+str(k+1)
-                        path = i2c_prefix+ str(sfp_map[k])+ buses[i]+"/"+ nodes[j]                
-                        my_log(node+": "+ path)
-                        ALL_DEVICE[key][node].append(path)                                        
-                else:
-                    node = key+str(i+1)
-                    path = i2c_prefix+ buses[i]+"/"+ nodes[j]                
-                    my_log(node+": "+ path)
-                    ALL_DEVICE[key][node].append(path)  
-                                     
-    for key in hwmon_types:
-        itypes = hwmon_types[key]
-        nodes = hwmon_nodes[key]    
-        for i in range(0,len(itypes)):
-            for j in range(0,len(nodes)): 
-                node = key+"_"+itypes[i]
-                path = hwmon_prefix[key]+ itypes[i]+"/"+ nodes[j]           
-                my_log(node+": "+ path)
-                ALL_DEVICE[key][ key+str(i+1)].append(path)                   
-    
-    #show dict all in the order
-    if DEBUG == True:
-        for i in sorted(ALL_DEVICE.keys()):
-            print((i+": "))
-            for j in sorted(ALL_DEVICE[i].keys()):    
-                print(("   "+j))
-                for k in (ALL_DEVICE[i][j]):    
-                    print(("   "+"   "+k))
-    return 
-        
-def show_eeprom(index):
-    if system_ready()==False:
-        print("System's not ready.")        
-        print("Please install first!")
-        return 
-              
-    if len(ALL_DEVICE)==0:
-        devices_info()        
-    node = ALL_DEVICE['sfp'] ['sfp'+str(index)][0]
-    node = node.replace(node.split("/")[-1], 'sfp_eeprom')
-    # check if got hexdump command in current environment
-    ret, log = log_os_system("which hexdump", 0)
-    ret, log2 = log_os_system("which busybox hexdump", 0)    
-    if len(log):
-        hex_cmd = 'hexdump'
-    elif len(log2):
-        hex_cmd = ' busybox hexdump'
-    else:
-        log = 'Failed : no hexdump cmd!!'
-        logging.info(log)
-        print(log)
-        return 1                                 
-            
-    print(node + ":")
-    ret, log = log_os_system("cat "+node+"| "+hex_cmd+" -C", 1)
-    if ret==0:                                      
-        print(log) 
-    else:
-        print("**********device no found**********")       
-    return 
-         
-def set_device(args):
-    global DEVICE_NO
-    global ALL_DEVICE
-    if system_ready()==False:
-        print("System's not ready.")        
-        print("Please install first!")
-        return     
-    
-    if len(ALL_DEVICE)==0:
-        devices_info()  
-        
-    if args[0]=='led':
-        if int(args[1])>4:
-            show_set_help()
-            return
-        #print  ALL_DEVICE['led']
-        for i in range(0,len(ALL_DEVICE['led'])):   
-            for k in (ALL_DEVICE['led']['led'+str(i+1)]):  
-                ret, log = log_os_system("echo "+args[1]+" >"+k, 1)
-                if ret:
-                    return ret  
-    elif args[0]=='fan':
-        if int(args[1])>100:
-            show_set_help()
-            return
-        #print  ALL_DEVICE['fan']
-        #fan1~6 is all fine, all fan share same setting        
-        node = ALL_DEVICE['fan'] ['fan1'][0] 
-        node = node.replace(node.split("/")[-1], 'fan_duty_cycle_percentage')
-        ret, log = log_os_system("cat "+ node, 1)            
-        if ret==0:
-            print(("Previous fan duty: " + log.strip() +"%"))            
-        ret, log = log_os_system("echo "+args[1]+" >"+node, 1)
-        if ret==0:
-            print(("Current fan duty: " + args[1] +"%"))          
-        return ret
-    elif args[0]=='sfp':
-        if int(args[1])> DEVICE_NO[args[0]] or int(args[1])==0:
-            show_set_help()
-            return     
-        if len(args)<2:
-            show_set_help()
-            return 
-                            
-        if int(args[2])>1:
-            show_set_help()
-            return
-       
-        #print  ALL_DEVICE[args[0]]   
-        for i in range(0,len(ALL_DEVICE[args[0]])):   
-            for j in ALL_DEVICE[args[0]][args[0]+str(args[1])]:        
-                if j.find('tx_disable')!= -1:  
-                    ret, log = log_os_system("echo "+args[2]+" >"+ j, 1)
-                    if ret:
-                        return ret  
-                                                                           
-    return
-    
-#get digits inside a string. 
-#Ex: 31 for "sfp31"   
-def get_value(input):
-    digit = re.findall('\d+', input)
-    return int(digit[0])
-              
-def device_traversal():
-    if system_ready()==False:
-        print("System's not ready.")        
-        print("Please install first!")
-        return 
-        
-    if len(ALL_DEVICE)==0:
-        devices_info()
-    for i in sorted(ALL_DEVICE.keys()):
-        print("============================================")        
-        print((i.upper()+": "))
-        print("============================================")
-         
-        for j in sorted(list(ALL_DEVICE[i].keys()), key=get_value):    
-            print("   "+j+":", end=' ')
-            for k in (ALL_DEVICE[i][j]):
-                ret, log = log_os_system("cat "+k, 0)
-                func = k.split("/")[-1].strip()
-                func = re.sub(j+'_','',func,1)
-                func = re.sub(i.lower()+'_','',func,1)                 
-                if ret==0:
-                    print(func+"="+log+" ", end=' ')                  
-                else:
-                    print(func+"="+"X"+" ", end=' ')
-            print()                    
-            print("----------------------------------------------------------------")
-                                              
-     
-        print()
-    return
-            
+
 def device_exist():
     ret1, log = log_os_system("ls "+i2c_prefix+"*0076", 0)
     ret2, log = log_os_system("ls "+i2c_prefix+"i2c-2", 0)

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/utils/accton_as7712_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/utils/accton_as7712_util.py
@@ -16,20 +16,27 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Usage: %(scriptName)s [options] command object
-options:
-    -h | --help     : this help message
-    -d | --debug    : run with debug mode
-    -f | --force    : ignore error during installation or clean
-command:
-    install     : install drivers and generate related sysfs nodes
-    clean       : uninstall drivers and remove related sysfs nodes
+usage: accton_as7712_util.py [-h] [-d] [-f] {install,clean,threshold} ...
+
+AS7712-32X Platform Utility
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -d, --debug           run with debug mode
+  -f, --force           ignore error during installation or clean
+
+Utility Command:
+  {install,clean,threshold}
+    install             : install drivers and generate related sysfs nodes
+    clean               : uninstall drivers and remove related sysfs nodes
+    threshold           : modify thermal threshold
 """
 import subprocess
-import getopt
 import sys
 import logging
 import time
+import argparse
+from sonic_py_common.general import getstatusoutput_noshell
 
 PROJECT_NAME = 'as7712_32x'
 version = '0.1.0'
@@ -42,23 +49,23 @@ i2c_prefix = '/sys/bus/i2c/devices/'
 '''
 i2c_bus = {'fan': ['2-0066']                 ,
            'thermal': ['3-0048','3-0049', '3-004a', '3-004b'] ,
-           'psu': ['10-0050','11-0053'], 
+           'psu': ['10-0050','11-0053'],
            'sfp': ['-0050']}
 i2c_nodes = {'fan': ['present', 'front_speed_rpm', 'rear_speed_rpm'] ,
            'thermal': ['hwmon/hwmon*/temp1_input'] ,
            'psu': ['psu_present ', 'psu_power_good']    ,
            'sfp': ['module_present', 'sfp_tx_disable_all']}
 '''
-                  
+
 sfp_map =  [22,23,24,25,27,26,29,28,
                  18,19,20,21,30,31,32,33,
                  34,35,36,37,46,47,48,49,
                  38,39,40,41,42,43,44,45]
-mknod =[                 
+mknod =[
 'echo pca9548 0x76 > /sys/bus/i2c/devices/i2c-0/new_device',
-'echo pca9548 0x71 > /sys/bus/i2c/devices/i2c-1/new_device' ,
-'echo pca9548 0x72 > /sys/bus/i2c/devices/i2c-1/new_device' ,
-'echo pca9548 0x73 > /sys/bus/i2c/devices/i2c-1/new_device' ,
+'echo pca9548 0x71 > /sys/bus/i2c/devices/i2c-1/new_device',
+'echo pca9548 0x72 > /sys/bus/i2c/devices/i2c-1/new_device',
+'echo pca9548 0x73 > /sys/bus/i2c/devices/i2c-1/new_device',
 'echo pca9548 0x74 > /sys/bus/i2c/devices/i2c-1/new_device',
 'echo pca9548 0x75 > /sys/bus/i2c/devices/i2c-1/new_device',
 'echo 24c02 0x57 > /sys/bus/i2c/devices/i2c-1/new_device',
@@ -76,11 +83,11 @@ mknod =[
 'echo cpld_plain 0x62 > /sys/bus/i2c/devices/i2c-5/new_device',
 'echo cpld_plain 0x64 > /sys/bus/i2c/devices/i2c-6/new_device']
 
-mknod2 =[                 
+mknod2 =[
 'echo pca9548 0x76 > /sys/bus/i2c/devices/i2c-1/new_device',
-'echo pca9548 0x71 > /sys/bus/i2c/devices/i2c-0/new_device' ,
-'echo pca9548 0x72 > /sys/bus/i2c/devices/i2c-0/new_device' ,
-'echo pca9548 0X73 > /sys/bus/i2c/devices/i2c-0/new_device' ,
+'echo pca9548 0x71 > /sys/bus/i2c/devices/i2c-0/new_device',
+'echo pca9548 0x72 > /sys/bus/i2c/devices/i2c-0/new_device',
+'echo pca9548 0X73 > /sys/bus/i2c/devices/i2c-0/new_device',
 'echo pca9548 0x74 > /sys/bus/i2c/devices/i2c-0/new_device',
 'echo pca9548 0x75 > /sys/bus/i2c/devices/i2c-0/new_device',
 'echo 24c02 0x57 > /sys/bus/i2c/devices/i2c-0/new_device',
@@ -112,42 +119,44 @@ def main():
     global DEBUG
     global args
     global FORCE
+    global THRESHOLD_RANGE_LOW, THRESHOLD_RANGE_HIGH
 
-    if len(sys.argv)<2:
-        show_help()
+    util_parser = argparse.ArgumentParser(description="AS7712-32X Platform Utility")
+    util_parser.add_argument("-d", "--debug", dest='debug', action='store_true', default=False,
+                             help="run with debug mode")
+    util_parser.add_argument("-f", "--force", dest='force', action='store_true', default=False,
+                             help="ignore error during installation or clean")
+    subcommand = util_parser.add_subparsers(dest='cmd', title='Utility Command', required=True)
+    subcommand.add_parser('install', help=': install drivers and generate related sysfs nodes')
+    subcommand.add_parser('clean', help=': uninstall drivers and remove related sysfs nodes')
+    threshold_parser = subcommand.add_parser('threshold', help=': modify thermal threshold')
+    threshold_parser.add_argument("-l", dest='list', action='store_true', default=False,
+                                  help="list avaliable thermal")
+    threshold_parser.add_argument("-t", dest='thermal', type=str, metavar='THERMAL_NAME',
+                                  help="thermal name, ex: -t 'Temp sensor 1'")
+    threshold_parser.add_argument("-ht", dest='high_threshold', type=restricted_float,
+                                  metavar='THRESHOLD_VALUE',
+                                  help="high threshold: %.1f ~ %.1f" % (THRESHOLD_RANGE_LOW, THRESHOLD_RANGE_HIGH))
+    threshold_parser.add_argument("-hct", dest='high_crit_threshold', type=restricted_float,
+                                  metavar='THRESHOLD_VALUE',
+                                  help="high critical threshold : %.1f ~ %.1f" % (THRESHOLD_RANGE_LOW, THRESHOLD_RANGE_HIGH))
+    args = util_parser.parse_args()
 
-    options, args = getopt.getopt(sys.argv[1:], 'hdf', ['help',
-                                                       'debug',
-                                                       'force',
-                                                          ])
     if DEBUG == True:
-        print(options)
         print(args)
         print(len(sys.argv))
 
-    for opt, arg in options:
-        if opt in ('-h', '--help'):
-            show_help()
-        elif opt in ('-d', '--debug'):
-            DEBUG = True
-            logging.basicConfig(level=logging.INFO)
-        elif opt in ('-f', '--force'):
-            FORCE = 1
-        else:
-            logging.info('no option')
-    for arg in args:
-        if arg == 'install':
-           do_install()
-        elif arg == 'clean':
-           do_uninstall()
-        else:
-            show_help()
-            
-    return 0              
-        
-def show_help():
-    print(__doc__ % {'scriptName' : sys.argv[0].split("/")[-1]})
-    sys.exit(0)
+    DEBUG = args.debug
+    FORCE = 1 if args.force else 0
+
+    if args.cmd == 'install':
+        do_install()
+    elif args.cmd == 'clean':
+        do_uninstall()
+    elif args.cmd == 'threshold':
+        do_threshold()
+
+    return 0
 
 def my_log(txt):
     if DEBUG == True:
@@ -155,16 +164,16 @@ def my_log(txt):
     return
 
 def log_os_system(cmd, show):
-    logging.info('Run :'+cmd)  
-    status, output = subprocess.getstatusoutput(cmd)    
+    logging.info('Run :'+cmd)
+    status, output = subprocess.getstatusoutput(cmd)
     my_log (cmd +"with result:" + str(status))
-    my_log ("      output:"+output)    
+    my_log ("      output:"+output)
     if status:
         logging.info('Failed :'+cmd)
         if show:
             print('Failed :'+cmd)
     return  status, output
-            
+
 def driver_check():
     ret, lsmod = log_os_system("ls /sys/module/*accton*", 0)
     logging.info('mods:'+lsmod)
@@ -178,12 +187,12 @@ def driver_check():
 kos = [
 'modprobe i2c_dev',
 'modprobe i2c_mux_pca954x',
-'modprobe accton_i2c_cpld'  ,
-'modprobe ym2651y'                  ,
-'modprobe accton_as7712_32x_fan'     ,
-'modprobe optoe'      ,
-'modprobe leds-accton_as7712_32x'      ,
-'modprobe accton_as7712_32x_psu' ]
+'modprobe accton_i2c_cpld',
+'modprobe ym2651y',
+'modprobe accton_as7712_32x_fan',
+'modprobe optoe',
+'modprobe leds-accton_as7712_32x',
+'modprobe accton_as7712_32x_psu']
 
 def driver_install():
     global FORCE
@@ -191,18 +200,18 @@ def driver_install():
     for i in range(0,len(kos)):
         status, output = log_os_system(kos[i], 1)
         if status:
-            if FORCE == 0:        
-                return status  
+            if FORCE == 0:
+                return status
 
     print("Done driver_install")
 
     return 0
-    
+
 def driver_uninstall():
     global FORCE
     for i in range(0,len(kos)):
         rm = kos[-(i+1)].replace("modprobe", "modprobe -rq")
-        rm = rm.replace("insmod", "rmmod")        
+        rm = rm.replace("insmod", "rmmod")
         lst = rm.split(" ")
 
         if len(lst) > 3:
@@ -210,14 +219,11 @@ def driver_uninstall():
         rm = " ".join(lst)
         status, output = log_os_system(rm, 1)
         if status:
-            if FORCE == 0:        
-                return status              
+            if FORCE == 0:
+                return status
     return 0
 
-
-       
-       
-def i2c_order_check():    
+def i2c_order_check():
     # i2c bus 0 and 1 might be installed in different order.
     # Here check if 0x76 is exist @ i2c-0
     tmp = "echo pca9548 0x76 > /sys/bus/i2c/devices/i2c-0/new_device"
@@ -226,38 +232,37 @@ def i2c_order_check():
         order = 1
     else:
         order = 0
-    tmp = "echo 0x76 > /sys/bus/i2c/devices/i2c-0/delete_device"       
-    status, output = log_os_system(tmp, 0)       
+    tmp = "echo 0x76 > /sys/bus/i2c/devices/i2c-0/delete_device"
+    status, output = log_os_system(tmp, 0)
     return order
-                     
+
 def device_install():
     global FORCE
-    
     order = i2c_order_check()
-                
-    # if 0x76 is not exist @i2c-0, use reversed bus order    
-    if order:       
+
+    # if 0x76 is not exist @i2c-0, use reversed bus order
+    if order:
         for i in range(0,len(mknod2)):
-            #for pca954x need times to built new i2c buses            
+            #for pca954x need times to built new i2c buses
             if mknod2[i].find('pca954') != -1:
-               time.sleep(1)         
-               
+               time.sleep(1)
+
             status, output = log_os_system(mknod2[i], 1)
             if status:
                 print(output)
                 if FORCE == 0:
-                    return status  
+                    return status
     else:
         for i in range(0,len(mknod)):
-            #for pca954x need times to built new i2c buses            
+            #for pca954x need times to built new i2c buses
             if mknod[i].find('pca954') != -1:
-               time.sleep(1)         
+               time.sleep(1)
                
             status, output = log_os_system(mknod[i], 1)
             if status:
                 print(output)
-                if FORCE == 0:                
-                    return status  
+                if FORCE == 0:
+                    return status
     # set all pca954x idle_disconnect
     cmd = 'echo -2 | tee /sys/bus/i2c/drivers/pca954x/*-00*/idle_state'
     status, output = log_os_system(cmd, 1)
@@ -269,35 +274,35 @@ def device_install():
         status, output =log_os_system("echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-"+str(sfp_map[i])+"/new_device", 1)
         if status:
             print(output)
-            if FORCE == 0:            
-                return status                                  
-    
+            if FORCE == 0:
+                return status
+
     print("Done device_install")
-    
+
     return 
     
 def device_uninstall():
     global FORCE
-    
+
     status, output =log_os_system("ls /sys/bus/i2c/devices/1-0076", 0)
     if status==0:
         I2C_ORDER=1
     else:
-        I2C_ORDER=0                    
+        I2C_ORDER=0
 
     for i in range(0,len(sfp_map)):
         target = "/sys/bus/i2c/devices/i2c-"+str(sfp_map[i])+"/delete_device"
         status, output =log_os_system("echo 0x50 > "+ target, 1)
         if status:
             print(output)
-            if FORCE == 0:            
+            if FORCE == 0:
                 return status
-       
+
     if I2C_ORDER==0:
         nodelist = mknod
-    else:            
+    else:
         nodelist = mknod2
-           
+
     for i in range(len(nodelist)):
         target = nodelist[-(i+1)]
         temp = target.split()
@@ -306,65 +311,222 @@ def device_uninstall():
         status, output = log_os_system(" ".join(temp), 1)
         if status:
             print(output)
-            if FORCE == 0:            
-                return status  
-                                  
-    return 
-        
+            if FORCE == 0:
+                return status
+
+    return
+
 def system_ready():
     if driver_check() == False:
         return False
-    if not device_exist(): 
+    if not device_exist():
         return False
     return True
-               
+
 def do_install():
     print("Checking system....")
     if driver_check() == False:
-        print("No driver, installing....")    
+        print("No driver, installing....")
         status = driver_install()
         if status:
-            if FORCE == 0:        
+            if FORCE == 0:
                 return  status
     else:
-        print(PROJECT_NAME.upper()+" drivers detected....")                      
+        print(PROJECT_NAME.upper()+" drivers detected....")
     if not device_exist():
         print("No device, installing....")
-        status = device_install() 
+        status = device_install()
         if status:
-            if FORCE == 0:        
-                return  status        
+            if FORCE == 0:
+                return  status
     else:
-        print(PROJECT_NAME.upper()+" devices detected....")           
+        print(PROJECT_NAME.upper()+" devices detected....")
     return
-    
+
 def do_uninstall():
     print("Checking system....")
     if not device_exist():
         print(PROJECT_NAME.upper() +" has no device installed....")
     else:
         print("Removing device....")
-        status = device_uninstall() 
+        status = device_uninstall()
         if status:
-            if FORCE == 0:            
-                return  status  
-                
+            if FORCE == 0:
+                return  status
+
     if driver_check()== False :
         print(PROJECT_NAME.upper() +" has no driver installed....")
     else:
         print("Removing installed driver....")
         status = driver_uninstall()
         if status:
-            if FORCE == 0:        
-                return  status                          
-                    
-    return       
+            if FORCE == 0:
+                return  status
+
+    return
 
 
 def device_exist():
     ret1, log = log_os_system("ls "+i2c_prefix+"*0076", 0)
     ret2, log = log_os_system("ls "+i2c_prefix+"i2c-2", 0)
     return not(ret1 or ret2)
+
+THRESHOLD_RANGE_LOW = 30.0
+THRESHOLD_RANGE_HIGH = 110.0
+# Code to initialize chassis object
+init_chassis_code = \
+    "import sonic_platform.platform\n"\
+    "platform = sonic_platform.platform.Platform()\n"\
+    "chassis = platform.get_chassis()\n\n"
+
+# Looking for thermal
+looking_for_thermal_code = \
+    "thermal = None\n"\
+    "all_thermals = chassis.get_all_thermals()\n"\
+    "for psu in chassis.get_all_psus():\n"\
+    "    all_thermals += psu.get_all_thermals()\n"\
+    "for tmp in all_thermals:\n"\
+    "    if '{}' == tmp.get_name():\n"\
+    "        thermal = tmp\n"\
+    "        break\n"\
+    "if thermal == None:\n"\
+    "    print('{} not found!')\n"\
+    "    exit(1)\n\n"
+
+def avaliable_thermals():
+    global init_chassis_code
+
+    get_all_thermal_name_code = \
+        "thermal_list = []\n"\
+        "all_thermals = chassis.get_all_thermals()\n"\
+        "for psu in chassis.get_all_psus():\n"\
+        "    all_thermals += psu.get_all_thermals()\n"\
+        "for tmp in all_thermals:\n"\
+        "    thermal_list.append(tmp.get_name())\n"\
+        "print(str(thermal_list)[1:-1])\n"
+
+    all_code = "{}{}".format(init_chassis_code, get_all_thermal_name_code)
+
+    status, output = getstatusoutput_noshell(["docker", "exec", "pmon", "python3", "-c", all_code])
+    if status != 0:
+        return ""
+    return output
+
+def restricted_float(x):
+    global THRESHOLD_RANGE_LOW, THRESHOLD_RANGE_HIGH
+
+    try:
+        x = float(x)
+    except ValueError:
+        raise argparse.ArgumentTypeError("%r not a floating-point literal" % (x,))
+
+    if x < THRESHOLD_RANGE_LOW or x > THRESHOLD_RANGE_HIGH:
+        raise argparse.ArgumentTypeError("%r not in range [%.1f ~ %.1f]" % 
+                                         (x, THRESHOLD_RANGE_LOW, THRESHOLD_RANGE_HIGH))
+
+    return x
+
+def get_high_threshold(name):
+    global init_chassis_code, looking_for_thermal_code
+
+    get_high_threshold_code = \
+        "try:\n"\
+        "    print(thermal.get_high_threshold())\n"\
+        "    exit(0)\n"\
+        "except NotImplementedError:\n"\
+        "    print('Not implement the get_high_threshold method!')\n"\
+        "    exit(1)"
+
+    all_code = "{}{}{}".format(init_chassis_code, looking_for_thermal_code.format(name, name),
+                               get_high_threshold_code)
+
+    status, output = getstatusoutput_noshell(["docker", "exec", "pmon", "python3", "-c", all_code])
+    if status == 1:
+        return None
+
+    return float(output)
+
+def get_high_crit_threshold(name):
+    global init_chassis_code, looking_for_thermal_code
+
+    get_high_crit_threshold_code = \
+        "try:\n"\
+        "    print(thermal.get_high_critical_threshold())\n"\
+        "    exit(0)\n"\
+        "except NotImplementedError:\n"\
+        "    print('Not implement the get_high_critical_threshold method!')\n"\
+        "    exit(1)"
+
+    all_code = "{}{}{}".format(init_chassis_code, looking_for_thermal_code.format(name, name),
+                               get_high_crit_threshold_code)
+
+    status, output = getstatusoutput_noshell(["docker", "exec", "pmon", "python3", "-c", all_code])
+    if status == 1:
+        return None
+
+    return float(output)
+
+def do_threshold():
+    global args, init_chassis_code, looking_for_thermal_code
+
+    if args.list:
+        print("Thermals: " + avaliable_thermals())
+        return
+
+    if args.thermal is None:
+        print("The following arguments are required: -t")
+        return
+
+    set_threshold_code = ""
+    if args.high_threshold is not None:
+        if args.high_crit_threshold is not None and \
+            args.high_threshold >= args.high_crit_threshold:
+           print("Invalid Threshold!(High threshold can not be more than " \
+                 "or equal to high critical threshold.)")
+           exit(1)
+
+        high_crit = get_high_crit_threshold(args.thermal)
+        if high_crit is not None and \
+           args.high_threshold >= high_crit:
+           print("Invalid Threshold!(High threshold can not be more than " \
+                 "or equal to high critical threshold.)")
+           exit(1)
+
+        set_threshold_code += \
+            "try:\n"\
+            "    if thermal.set_high_threshold({}) is False:\n"\
+            "        print('{}: set_high_threshold failure!')\n"\
+            "        exit(1)\n"\
+            "except NotImplementedError:\n"\
+            "    print('Not implement the set_high_threshold method!')\n"\
+            "print('Apply the new high threshold successfully.')\n"\
+            "\n".format(args.high_threshold, args.thermal)
+
+    if args.high_crit_threshold is not None:
+        high = get_high_threshold(args.thermal)
+        if high is not None and \
+            args.high_crit_threshold <= high:
+            print("Invalid Threshold!(High critical threshold can not " \
+                  "be less than or equal to high threshold.)")
+            exit(1)
+
+        set_threshold_code += \
+            "try:\n"\
+            "    if thermal.set_high_critical_threshold({}) is False:\n"\
+            "        print('{}: set_high_critical_threshold failure!')\n"\
+            "        exit(1)\n"\
+            "except NotImplementedError:\n"\
+            "    print('Not implement the set_high_critical_threshold method!')\n"\
+            "print('Apply the new high critical threshold successfully.')\n"\
+            "\n".format(args.high_crit_threshold, args.thermal)
+
+    if set_threshold_code == "":
+        return
+
+    all_code = "{}{}{}".format(init_chassis_code, looking_for_thermal_code.format(args.thermal, args.thermal), set_threshold_code)
+
+    status, output = getstatusoutput_noshell(["docker", "exec", "pmon", "python3", "-c", all_code])
+    print(output)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- To support platform **AS7712-32X**.
  - Sync community platform related PRs into 202411.0.

#### How I did it
- After investigating, the below community PRs we need to merge.
  - Notation => -: already merged; +: merged in this PR.
    - [ - ] PR#7615: [Accton] Support ACBEL FSF0xx PSU
    - [ + ] PR#8042: [AS7712_32X] Modify to Python3 format and remove extra code
    - [ + ] PR#8462: [AS7712-32X] Update SDK configuration
    - [ + ] PR#8580: [AS7712-32X]Fixes led drv and add fan_direction sysfs
    - [ - ] PR#11593: [Edgecore] Update installer.conf
    - [ - ] PR#11716: [Edge-core][device/accton] Add ssd_util plugin to AS4630-54PE, AS7326-56X, AS771…
    - [ - ] PR#11802: Preemphasis
    - [ - ] PR#11805: Dpb
    - [ + ] PR#12096: [Edgecore][PDDF] Add get_port_or_cage_type
    - [ + ] PR#14349: [Edgecore][AS7712-32X/PDDF] Enhance sonic_platform feature
    - [ - ] PR#16982: [Edgecore][sonic-platform-modules-accton]Support kernel 6.1 and bookworm
    - [ - ] PR#16983: [Edgecore][PDDF] Add debian prerm to remove unrelated service
- Bugfixes
  - Add symbolic links to fix build module ym2651y.o error.
  - Skip test_fan_drawer.py::TestFanDrawerApi::test_get_maximum_consumed_power due to unsupported.

#### How to verify it
- Build sonic-broadcom.bin successfully.
- Relevant platform commands can operate normally as well.
  - docker ps -a
  - sudo show system-health sysready-status detail
  - bcmcmd 'BCMSAI version'
  - bcmcmd 'version all'
  - bcmcmd 'show unit'
  - bcmcmd 'ps'
  - show interfaces status
  - show platform summary
  - show platform current
  - show platform fan
  - show platform firmware status
  - show platform pcieinfo
  - show platform pcieinfo -c
  - show platform psustatus
  - show platform ssdhealth
  - show platform syseeprom
  - show platform temperature
  - show platform voltage
  - sudo sfputil show eeprom
  - sudo sfputil show eeprom -p Ethernet0
  - sudo sfputil show error-status
  - sudo sfputil show error-status -p Ethernet0
  - sudo sfputil show lpmode
  - sudo sfputil show lpmode -p Ethernet0
  - sudo sfputil show presence
  - sudo sfputil show presence -p Ethernet0
  - sudo sfputil show fwversion Ethernet0
  - sudo sfputil reset Ethernet0
  - sudo config interface breakout -y -f Ethernet48
  - sudo config interface breakout -y -f Ethernet60
  - sudo show interfaces breakout current-mode
  - sudo systemctl status as7712-pddf-platform-monitor.service
  - sensors
  - sudo pddf_fanutil status
  - sudo pddf_fanutil direction
  - sudo pddf_fanutil setspeed 50
  - sudo pddf_fanutil getspeed
  - sudo pddf_fanutil numfans
  - sudo pddf_ledutil setstatusled DIAG_LED green
  - sudo pddf_ledutil getstatusled DIAG_LED
  - sudo pddf_psuutil mfrinfo
  - sudo pddf_psuutil numpsus
  - sudo pddf_psuutil seninfo
  - sudo pddf_psuutil status
  - sudo pddf_thermalutil gettemp
  - sudo pddf_thermalutil numthermals

