### PR TITLE
[ntpd] commit new config from filesystem caches to disk

### DIFF
--- a/files/image_config/ntp/ntp-config.sh
+++ b/files/image_config/ntp/ntp-config.sh
@@ -29,6 +29,9 @@ sonic-cfggen -d -t /usr/share/sonic/templates/ntp.keys.j2 >/etc/ntp.keys
 chown root:ntp /etc/ntp.keys
 chmod o-r /etc/ntp.keys
 
+sync;sync;sync
+sleep 1
+
 get_database_reboot_type
 echo "Disabling NTP long jump for reboot type ${reboot_type} ..."
 modify_ntp_default "s/NTPD_OPTS='-g'/NTPD_OPTS='-x'/"


### PR DESCRIPTION
#### Why I did it
The new ntpd.conf would be created by the ntp-config and then restart the ntpd service. Add to execute sync 3 times to gurrante the new config be write to disk before service being re-launch
#### How I did it
N/A
#### How to verify it
N/A
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205


































