### PR TITLE
insert l3_mem_enries and specific to 32K in the bcm config for helix 5 platforms  

### DIFF
--- a/device/accton/x86_64-accton_as4630_54npe-r0/Accton-AS4630-54NPE/hx5-as4630-36x2p5G+12x10G+4x25G+2x100G.config.bcm
+++ b/device/accton/x86_64-accton_as4630_54npe-r0/Accton-AS4630-54NPE/hx5-as4630-36x2p5G+12x10G+4x25G+2x100G.config.bcm
@@ -19,7 +19,7 @@ mem_cache_enable=1
 l2_mem_entries=32768
 l3_alpm_enable=2
 ipv6_lpm_128b_enable=1
-#l3_mem_entries=49152
+l3_mem_entries=32768
 #fpem_mem_entries=16384
 l2xmsg_mode=1
 port_flex_enable=1
@@ -146,7 +146,7 @@ portmap_34=34:2.5
 portmap_35=35:2.5
 portmap_36=36:2.5
 
-#3x PM4x25 (3 * 4 --> 12 physical ports) 
+#3x PM4x25 (3 * 4 --> 12 physical ports)
 #FC0
 
 dport_map_port_49=51

--- a/device/accton/x86_64-accton_as4630_54pe-r0/Accton-AS4630-54PE/hx5-as4630-48x1G+4x25G+2x100G_ec.bcm
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/Accton-AS4630-54PE/hx5-as4630-48x1G+4x25G+2x100G_ec.bcm
@@ -16,7 +16,7 @@ parity_enable=0
 mem_cache_enable=1
 
 l2_mem_entries=32768
-#l3_mem_entries=49152
+l3_mem_entries=32768
 #fpem_mem_entries=16384
 l2xmsg_mode=1
 l3_alpm_enable=2

--- a/device/accton/x86_64-accton_as4630_54te-r0/Accton-AS4630-54TE/hx5-as4630-48x1G+4x25G+2x100G_ec.bcm
+++ b/device/accton/x86_64-accton_as4630_54te-r0/Accton-AS4630-54TE/hx5-as4630-48x1G+4x25G+2x100G_ec.bcm
@@ -16,7 +16,7 @@ parity_enable=0
 mem_cache_enable=1
 
 l2_mem_entries=32768
-#l3_mem_entries=49152
+l3_mem_entries=32768
 #fpem_mem_entries=16384
 l2xmsg_mode=1
 l3_alpm_enable=2

--- a/files/image_config/ntp/ntp-config.sh
+++ b/files/image_config/ntp/ntp-config.sh
@@ -29,6 +29,9 @@ sonic-cfggen -d -t /usr/share/sonic/templates/ntp.keys.j2 >/etc/ntp.keys
 chown root:ntp /etc/ntp.keys
 chmod o-r /etc/ntp.keys
 
+sync;sync;sync
+sleep 1
+
 get_database_reboot_type
 echo "Disabling NTP long jump for reboot type ${reboot_type} ..."
 modify_ntp_default "s/NTPD_OPTS='-g'/NTPD_OPTS='-x'/"


### PR DESCRIPTION
insert l3_mem_enries and specific to 32K in the bcm config for helix 5 platforms
 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

