### PR TITLE
[rsyslog] Change the default remote syslog format to RFC 3164

### DIFF
--- a/files/image_config/rsyslog/rsyslog.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.conf.j2
@@ -52,6 +52,8 @@ $UDPServerRun 514
 
 # Define a custom template
 $template SONiCFileFormat,"%timegenerated%.%timegenerated:::date-subseconds% %HOSTNAME% %syslogseverity-text:::uppercase% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"
+$template SONiCFileFormat_RFC3164,"<%PRI%>%timegenerated%.%timegenerated:::date-subseconds% %HOSTNAME% %syslogseverity-text:::uppercase% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n"
+$template SONiCFileFormat_RFC5424,"<%PRI%>1 %TIMESTAMP:::date-rfc3339% %HOSTNAME% %APP-NAME% %PROCID% %MSGID% %STRUCTURED-DATA% %msg%\n"
 $ActionFileDefaultTemplate SONiCFileFormat
 
 template(name="WelfRemoteFormat" type="string" string="%TIMESTAMP% id=firewall time=\"%timereported\
@@ -108,7 +110,7 @@ $RepeatedMsgReduction on
 
 {% set fmodifier = '!' if filter == 'exclude' else '' %}
 {% set device = 'eth0' if vrf == 'default' else vrf -%}
-{% set template = 'WelfRemoteFormat' if format == 'welf' else 'SONiCFileFormat' -%}
+{% set template = 'WelfRemoteFormat' if format == 'welf' else 'SONiCFileFormat_RFC3164' -%}
 
 {# Server extra options -#}
 {% set options = '' -%}


### PR DESCRIPTION
#### Why I did it
Change default remote syslog format to RFC 3164 and support for RFC 5424 template.

#### How I did it
Modified the rsyslog.conf.j2 to change the format.

#### How to verify it
The default rsyslog messages are sent using the RFC 3164 format.