### PR TITLE
Support arp_reply in port/vlan/portchannel yang.

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -137,6 +137,10 @@ module sonic-port{
 					description "port name in asic and asic name, e.g Eth0-ASIC1";
 				}
 
+				leaf arp_reply {
+					type stypes:arp_reply;
+				}
+
 				leaf role {
 					type string {
 						pattern "Ext|Int|Inb|Rec";

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -153,6 +153,10 @@ module sonic-portchannel {
                     }
                 }
 
+                leaf arp_reply {
+                    type stypes:arp_reply;
+                }
+
                 leaf vrf_name {
                     type leafref {
                         path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -102,6 +102,10 @@ module sonic-vlan {
 					}
 				}
 
+				leaf arp_reply {
+					type stypes:arp_reply;
+				}
+
 				leaf ipv6_use_link_local_only {
 					description "Enable/Disable IPv6 link local address on vlan interface";
 					type stypes:mode-status;

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -138,6 +138,12 @@ module sonic-types {
         }
     }
 
+    typedef arp_reply {
+        type string {
+            pattern "reply_all|reply_iface|reply_subnet|ignore_all";
+        }
+    }
+
     typedef interface_type {
         type enumeration {
             enum CR;


### PR DESCRIPTION
Support arp_reply in port/vlan/portchannel yang.

#### Why I did it
N/A
#### How I did it
N/A
#### How to verify it
N/A
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

