### PR TITLE
[ICCPD] build docker-iccpd for mclag support

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -108,7 +108,7 @@ function preStartAction()
     fi
 {%- elif docker_container_name == "snmp" %}
     $SONIC_DB_CLI STATE_DB HSET 'DEVICE_METADATA|localhost' chassis_serial_number $(decode-syseeprom -s)
-{%- elif docker_container_name == "dhcp_relay" %}
+{%- elif docker_container_name == "dhcp_relay" or docker_container_name == "iccpd" %}
     until [[ $($SONIC_DB_CLI APPL_DB EXISTS "PORT_TABLE:PortInitDone" | grep -c 1) -gt 0 ]]; do
         sleep 1;
     done

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -45,7 +45,7 @@
 {% do features.append(("dhcp_relay", "{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] is not in ['ToRRouter', 'EPMS', 'MgmtTsToR', 'MgmtToRRouter', 'BmcMgmtToRRouter']) %}enabled{% else %}disabled{% endif %}", false, "enabled")) %}
 {%- if include_dhcp_server == "y" %}{% do features.append(("dhcp_server", "disabled", false, "enabled")) %}{% endif %}
 {%- if sonic_asic_platform == "vs" %}{% do features.append(("gbsyncd", "enabled", false, "enabled")) %}{% endif %}
-{%- if include_iccpd == "y" %}{% do features.append(("iccpd", "disabled", false, "enabled")) %}{% endif %}
+{%- if include_iccpd == "y" %}{% do features.append(("iccpd", "enabled", false, "enabled")) %}{% endif %}
 {%- if include_mgmt_framework == "y" %}{% do features.append(("mgmt-framework", "enabled", true, "enabled")) %}{% endif %}
 {%- if include_mux == "y" %}{% do features.append(("mux", "{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %}enabled{% else %}always_disabled{% endif %}", false, "enabled")) %}{% endif %}
 {%- if include_nat == "y" %}{% do features.append(("nat", "disabled", false, "enabled")) %}{% endif %}

--- a/rules/config
+++ b/rules/config
@@ -134,7 +134,7 @@ INCLUDE_SYSTEM_EVENTD = y
 INCLUDE_SYSTEM_TELEMETRY = n
 
 # INCLUDE_ICCPD - build docker-iccpd for mclag support
-INCLUDE_ICCPD = n
+INCLUDE_ICCPD = y
 
 # INCLUDE_SFLOW - build docker-sflow for sFlow support
 INCLUDE_SFLOW = y

--- a/src/iccpd/include/iccp_cli.h
+++ b/src/iccpd/include/iccp_cli.h
@@ -67,4 +67,6 @@ int unset_local_system_id();
 int set_keepalive_time(int mid, int keepalive_time);
 int set_session_timeout(int mid, int session_timeout_val);
 
+void set_mclag_system_mac(int domain_id, const char* mac);
+void unset_mclag_system_mac(int domain_id);
 #endif

--- a/src/iccpd/include/iccp_csm.h
+++ b/src/iccpd/include/iccp_csm.h
@@ -143,6 +143,8 @@ struct CSM
     /* Log */
     struct MsgLog msg_log;
 
+    bool is_set_mclag_sys_mac;
+
     LIST_ENTRY(CSM) next;
     LIST_HEAD(csm_if_list, If_info) if_bind_list;
 };

--- a/src/iccpd/include/iccp_netlink.h
+++ b/src/iccpd/include/iccp_netlink.h
@@ -66,4 +66,13 @@ void recover_if_ipmac_on_standby(struct LocalInterface* lif_po, int dir);
 void update_vlan_if_mac_on_standby(struct LocalInterface* lif_vlan, int dir);
 void recover_vlan_if_mac_on_standby(struct LocalInterface* lif_vlan, int dir, uint8_t *remote_system_mac);
 void update_vlan_if_mac_on_iccp_up(struct LocalInterface* lif_peer, int is_up, uint8_t *remote_system_mac);
+
+
+bool update_po_mclag_sys_mac(struct LocalInterface *lif_po, uint8_t *k_mac, int dir);
+void update_l3_po_mclag_sys_mac(struct LocalInterface *lif_po, char *c_mac, uint8_t *k_mac);
+bool update_l3_vlan_mclag_sys_mac(struct LocalInterface *lif_po, char *c_mac, uint8_t *k_mac, int dir);
+bool mclag_sys_mac_helper(struct CSM *csm, char *c_mac, uint8_t *k_mac, int dir);
+bool update_all_if_mclag_sys_mac(struct CSM* csm, uint8_t *mac, int dir);
+bool recover_all_if_mclag_sys_mac(struct CSM* csm, stp_role_type_et role, uint8_t *mac, int dir);
+bool update_if_mclag_sys_mac(struct CSM *csm, struct LocalInterface *lif_po, uint8_t *k_mac, int dir);
 #endif

--- a/src/iccpd/include/mlacp_fsm.h
+++ b/src/iccpd/include/mlacp_fsm.h
@@ -160,6 +160,7 @@ struct mLACP
     uint8_t need_to_sync;
     uint8_t node_id;
     uint8_t system_id[ETHER_ADDR_LEN];
+    uint8_t mclag_system_mac[ETHER_ADDR_LEN];
     uint16_t system_priority;
     uint8_t system_config_changed;
 

--- a/src/iccpd/include/mlacp_link_handler.h
+++ b/src/iccpd/include/mlacp_link_handler.h
@@ -69,9 +69,11 @@ int iccp_connect_syncd();
 
 void mlacp_link_disable_traffic_distribution(struct LocalInterface *lif);
 void mlacp_link_enable_traffic_distribution(struct LocalInterface *lif);
-int mlacp_link_set_iccp_state(int mlag_id, bool is_oper_up);
+int mlacp_link_set_iccp_state(int mlag_id, bool is_oper_up, char *peer_link_mbr);
 int mlacp_link_set_iccp_role(int mlag_id, bool is_active_role, uint8_t *system_id);
 int mlacp_link_set_iccp_system_id(int mlag_id, uint8_t *system_id);
+int mlacp_link_set_iccp_peer_link(int mlag_id, char *po_name);
+int mlacp_link_del_iccp_peer_link(int mlag_id, char *po_name);
 int mlacp_link_del_iccp_info(int mlag_id);
 int mlacp_link_set_remote_if_state(int mlag_id, char *po_name, bool is_oper_up);
 int mlacp_link_del_remote_if_info(int mlag_id, char *po_name);
@@ -94,4 +96,6 @@ void mlacp_fix_bridge_mac(struct CSM* csm);
 void update_orphan_port_mac(struct CSM *csm, struct LocalInterface *lif, int state);
 void mlacp_convert_remote_mac_to_local(struct CSM *csm, char *po_name);
 int sync_unique_ip();
+void mlacp_clean_fdb_by_port(const char *port_name);
+void update_l2_mac_state(struct CSM *csm, struct LocalInterface *lif, int po_state);
 #endif

--- a/src/iccpd/include/mlacp_tlv.h
+++ b/src/iccpd/include/mlacp_tlv.h
@@ -25,6 +25,7 @@
 #define MLACP_TLV_H_
 
 #include <sys/queue.h>
+#include <stdbool.h>
 
 #include "../include/msg_format.h"
 #include "../include/port.h"
@@ -500,6 +501,8 @@ enum MAC_OP_TYPE
     MAC_SYNC_ADD    = 1,
     MAC_SYNC_DEL    = 2,
     MAC_SYNC_ACK    = 4,
+    MAC_SYNC_FORCE_DEL   = 8,    /*MAC is peer's CPU MAC need to delete*/
+    MAC_SYNC_DEL_APP_DB  = 16,
 };
 
 enum MAC_TYPE
@@ -525,6 +528,7 @@ struct MACMsg
     uint8_t age_flag;/*local or peer is age?*/
     uint8_t pending_local_del;
     uint8_t add_to_syncd;
+    bool is_peer_cpu_mac;
 
     TAILQ_ENTRY(MACMsg) tail;     // entry into mac_msg_list
 };

--- a/src/iccpd/include/msg_format.h
+++ b/src/iccpd/include/msg_format.h
@@ -460,7 +460,10 @@ typedef enum mclag_msg_type_e_
     MCLAG_MSG_TYPE_SET_REMOTE_IF_STATE      = 12,
     MCLAG_MSG_TYPE_DEL_REMOTE_IF_INFO       = 13,
     MCLAG_MSG_TYPE_SET_PEER_LINK_ISOLATION  = 14,
-    MCLAG_MSG_TYPE_SET_ICCP_PEER_SYSTEM_ID  = 15
+    MCLAG_MSG_TYPE_SET_ICCP_PEER_SYSTEM_ID  = 15,
+    MCLAG_MSG_TYPE_SET_ICCP_PEER_LINK       = 16,
+    MCLAG_MSG_TYPE_DEL_ICCP_PEER_LINK       = 17,
+    MCLAG_MSG_TYPE_FLUSH_FDB_BY_PORT        = 18
 }mclag_msg_type_e;
 
 
@@ -479,7 +482,9 @@ typedef enum mclag_sub_option_type_e_
     MCLAG_SUB_OPTION_TYPE_SYSTEM_ID         = 10,
     MCLAG_SUB_OPTION_TYPE_OPER_STATUS       = 11,
     MCLAG_SUB_OPTION_TYPE_ISOLATION_STATE   = 12,
-    MCLAG_SUB_OPTION_TYPE_PEER_SYSTEM_ID    = 13
+    MCLAG_SUB_OPTION_TYPE_PEER_SYSTEM_ID    = 13,
+    MCLAG_SUB_OPTION_TYPE_PEER_LINK         = 14,
+    MCLAG_SUB_OPTION_TYPE_PEER_LINK_MEMBER  = 15
 } mclag_sub_option_type_e;
 
 enum MCLAG_DOMAIN_CFG_OP_TYPE {
@@ -492,12 +497,13 @@ enum MCLAG_DOMAIN_CFG_OP_TYPE {
 
 
 enum MCLAG_DOMAIN_CFG_ATTR_BMAP_FLAGS {
-    MCLAG_CFG_ATTR_NONE                  = 0x0,
-    MCLAG_CFG_ATTR_SRC_ADDR              = 0x1,
-    MCLAG_CFG_ATTR_PEER_ADDR             = 0x2,
-    MCLAG_CFG_ATTR_PEER_LINK             = 0x4,
-    MCLAG_CFG_ATTR_KEEPALIVE_INTERVAL    = 0x8,
-    MCLAG_CFG_ATTR_SESSION_TIMEOUT       = 0x10
+    MCLAG_CFG_ATTR_NONE                  = 0x0,  
+    MCLAG_CFG_ATTR_SRC_ADDR              = 0x1,  
+    MCLAG_CFG_ATTR_PEER_ADDR             = 0x2,  
+    MCLAG_CFG_ATTR_PEER_LINK             = 0x4,   
+    MCLAG_CFG_ATTR_KEEPALIVE_INTERVAL    = 0x8,   
+    MCLAG_CFG_ATTR_SESSION_TIMEOUT       = 0x10,
+    MCLAG_CFG_ATTR_MCLAG_SYS_MAC         = 0x20
 };
 
 struct IccpSyncdHDr
@@ -538,6 +544,7 @@ struct mclag_domain_cfg_info
     char peer_ip[INET_ADDRSTRLEN];
     char peer_ifname[MAX_L_PORT_NAME];
     uint8_t  system_mac[ETHER_ADDR_LEN];
+    uint8_t  mclag_system_mac[ETHER_ADDR_LEN];
     int attr_bmap;
 };
 

--- a/src/iccpd/src/app_csm.c
+++ b/src/iccpd/src/app_csm.c
@@ -238,8 +238,16 @@ int mlacp_bind_local_if(struct CSM* csm, struct LocalInterface* lif)
     {
         if (lif_po->type == IF_T_PORT_CHANNEL && lif_po->po_id == lif->po_id)
         {
-            /*if join a po member, may swss restart, reset portchannel ip mac  to mclagsyncd*/
-            update_if_ipmac_on_standby(lif_po, 1);
+            if (csm->is_set_mclag_sys_mac)
+            {
+                update_if_mclag_sys_mac(csm, lif_po, MLACP(csm).mclag_system_mac, 1);
+            }
+            else
+            {
+                /*if join a po member, may swss restart, reset portchannel ip mac  to mclagsyncd*/
+                update_if_ipmac_on_standby(lif_po, 1);
+            }
+
             return 0;
         }
     }
@@ -311,6 +319,10 @@ int mlacp_bind_port_channel_to_csm(struct CSM* csm, const char *ifname)
     mlacp_mlag_link_add_handler(csm, lif_po);
 
     /*ICCPD_LOG_WARN(tag, "po%d active =  %d\n", po_id, po_is_active);*/
+
+    ICCPD_LOG_NOTICE(__FUNCTION__, "Update MAC after binding MACLAG member!");
+    update_l2_mac_state(csm, lif_po, (lif_po->state == PORT_STATE_UP) ? 1 : 0);
+
     return 0;
 }
 

--- a/src/iccpd/src/iccp_cli.c
+++ b/src/iccpd/src/iccp_cli.c
@@ -132,11 +132,16 @@ int set_peer_link(int mid, const char* ifname)
         if (lif->type == IF_T_PORT_CHANNEL)
             iccp_get_port_member_list(lif);
 
+        set_peerlink_mlag_port_learn(csm->peer_link_if, 0);
         set_peerlink_learn_kernel(csm, 0, 4);
+        mlacp_clean_fdb_by_port(csm->peer_itf_name);
     }
 
     /*disconnect the link for mac and arp sync up*/
     scheduler_session_disconnect_handler(csm);
+
+    /* Set ICCP peer link to STATE_DB */
+    mlacp_link_set_iccp_peer_link(csm->mlag_id, csm->peer_itf_name);
 
     return 0;
 }
@@ -160,6 +165,9 @@ int unset_peer_link(int mid)
 
     /* update peer-link link handler*/
     scheduler_session_disconnect_handler(csm);
+
+    /* Remove ICCP peer link from STATE_DB */
+    mlacp_link_del_iccp_peer_link(csm->mlag_id, csm->peer_itf_name);
 
     /* clean peer-link*/
     memset(csm->peer_itf_name, 0, MAX_L_PORT_NAME);
@@ -553,3 +561,64 @@ int unset_local_system_id( )
     return 0;
 }
 
+void set_mclag_system_mac(int domain_id, const char* mac)
+{
+    struct CSM* csm = system_get_csm_by_mlacp_id(domain_id);
+    struct LocalInterface *lif_po = NULL;
+    uint8_t mclag_sys_mac[ETHER_ADDR_LEN];
+
+    if (!csm)
+    {
+        ICCPD_LOG_NOTICE(__FUNCTION__, "MCLAG domain doesn't exist!!!!");
+        return;
+    }
+
+    ICCPD_LOG_NOTICE(__FUNCTION__, "mac = %s", mac);
+
+    parseMacString(mac, mclag_sys_mac);
+
+    if (update_all_if_mclag_sys_mac(csm, mclag_sys_mac, 1))
+    {
+        ICCPD_LOG_NOTICE(__FUNCTION__, "Set MCLAG system MAC [%02X:%02X:%02X:%02X:%02X:%02X].",
+                        mclag_sys_mac[0], mclag_sys_mac[1],
+                        mclag_sys_mac[2], mclag_sys_mac[3],
+                        mclag_sys_mac[4], mclag_sys_mac[5]);
+
+        memcpy(MLACP(csm).mclag_system_mac, mclag_sys_mac, ETHER_ADDR_LEN);
+        csm->is_set_mclag_sys_mac = true;
+        mlacp_link_set_iccp_system_id(domain_id, mclag_sys_mac);
+    }
+    else
+    {
+        ICCPD_LOG_NOTICE(__FUNCTION__, "Failed to set MCLAG system MAC [%02X:%02X:%02X:%02X:%02X:%02X].",
+                        mclag_sys_mac[0], mclag_sys_mac[1],
+                        mclag_sys_mac[2], mclag_sys_mac[3],
+                        mclag_sys_mac[4], mclag_sys_mac[5]);
+    }
+}
+
+void unset_mclag_system_mac(int domain_id)
+{
+    uint8_t null_mac[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    uint8_t recover_mac[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    struct CSM* csm = system_get_csm_by_mlacp_id(domain_id);
+    struct LocalInterface *lif_po = NULL;
+
+    if (!csm)
+    {
+        ICCPD_LOG_NOTICE(__FUNCTION__, "MCLAG domain doesn't exist!!!!");
+        return;
+    }
+
+    if (recover_all_if_mclag_sys_mac(csm, csm->role_type, recover_mac, 1))
+    {
+        ICCPD_LOG_NOTICE(__FUNCTION__, "Successed to recover MCLAG system MAC");
+        memcpy(MLACP(csm).mclag_system_mac, null_mac, ETHER_ADDR_LEN);
+        csm->is_set_mclag_sys_mac = false;
+        mlacp_link_set_iccp_system_id(domain_id, recover_mac);
+    }
+    else
+    {
+        ICCPD_LOG_NOTICE(__FUNCTION__, "Failed to recover MCLAG system MAC");
+    }
+}

--- a/src/iccpd/src/iccp_csm.c
+++ b/src/iccpd/src/iccp_csm.c
@@ -855,7 +855,11 @@ void iccp_csm_stp_role_count(struct CSM *csm)
             ICCPD_LOG_INFO(__FUNCTION__, "Role: [Active]");
             csm->role_type = STP_ROLE_ACTIVE;
             /* Send ICCP role update and system ID */
-            mlacp_link_set_iccp_role(csm->mlag_id, true, MLACP(csm).system_id);
+
+            if (csm->is_set_mclag_sys_mac)
+                mlacp_link_set_iccp_role(csm->mlag_id, true, MLACP(csm).mclag_system_mac);
+            else
+                mlacp_link_set_iccp_role(csm->mlag_id, true, MLACP(csm).system_id);
         }
         else
         {

--- a/src/iccpd/src/iccp_netlink.c
+++ b/src/iccpd/src/iccp_netlink.c
@@ -634,7 +634,7 @@ void update_if_ipmac_on_standby(struct LocalInterface* lif_po, int dir)
     int ret = 0;
     struct PeerInterface* pif = NULL;
 
-    if (!csm)
+    if (!csm || csm->is_set_mclag_sys_mac)
         return;
 
     if (lif_po->type != IF_T_PORT_CHANNEL)
@@ -750,7 +750,12 @@ void recover_if_ipmac_on_standby(struct LocalInterface *lif_po, int dir)
     if (lif_po->type != IF_T_PORT_CHANNEL)
         return;
 
-    if (csm->role_type != STP_ROLE_STANDBY)
+    if (csm->is_set_mclag_sys_mac)
+    {
+        if (dir != 1)
+            return;
+    }
+    else if (csm->role_type != STP_ROLE_STANDBY)
     {
         return;
     }
@@ -1316,8 +1321,17 @@ void iccp_event_handler_obj_input_newaddr(struct nl_object *obj, void *arg)
         lif->port_config_sync = 1;
         if (memcmp((char *)lif->ipv6_addr, addr_null, 16) == 0)
         {
-            update_if_ipmac_on_standby(lif, 6);
-            update_vlan_if_mac_on_standby(lif, 2);
+            if (lif->csm && lif->csm->is_set_mclag_sys_mac)
+            {
+                struct CSM *csm = lif->csm;
+                update_if_mclag_sys_mac(csm, lif, MLACP(csm).mclag_system_mac, 6);
+            }
+            else
+            {
+                update_if_ipmac_on_standby(lif, 6);
+                update_vlan_if_mac_on_standby(lif, 2);
+            }
+
             sync_mac = 1;
         }
         iccp_del_self_ip_from_neigh_table (lif, AF_INET);
@@ -1353,8 +1367,17 @@ void iccp_event_handler_obj_input_newaddr(struct nl_object *obj, void *arg)
         lif->port_config_sync = 1;
         if (lif->ipv4_addr == 0)
         {
-            update_if_ipmac_on_standby(lif, 7);
-            update_vlan_if_mac_on_standby(lif, 3);
+            if (lif->csm && lif->csm->is_set_mclag_sys_mac)
+            {
+                struct CSM* csm = lif->csm;
+                update_if_mclag_sys_mac(csm, lif, MLACP(csm).mclag_system_mac, 7);
+            }
+            else
+            {
+                update_if_ipmac_on_standby(lif, 7);
+                update_vlan_if_mac_on_standby(lif, 3);
+            }
+
             sync_mac = 1;
         }
         iccp_del_self_ip_from_neigh_table (lif, AF_INET6);
@@ -2304,19 +2327,31 @@ void update_vlan_if_mac_on_standby(struct LocalInterface* lif_vlan, int dir)
         return;
     }
 
-    if (csm->role_type != STP_ROLE_STANDBY)
+    if (csm->role_type != STP_ROLE_STANDBY && !csm->is_set_mclag_sys_mac)
         return;
 
     memset(macaddr, 0, 64);
     memset(system_mac, 0, ETHER_ADDR_LEN);
     if (lif_vlan->is_l3_proto_enabled == false)
     {
-        if (memcmp(MLACP(csm).remote_system.system_id, null_mac, ETHER_ADDR_LEN) == 0) {
-            ICCPD_LOG_DEBUG(__FUNCTION__, " remote system_id not initialised.");
-            return;
+        if (csm->is_set_mclag_sys_mac)
+        {
+            if (memcmp(MLACP(csm).mclag_system_mac, null_mac, ETHER_ADDR_LEN) == 0) {
+                ICCPD_LOG_DEBUG(__FUNCTION__, " MCLAG system MAC is not initialised.");
+                return;
+            }
+            memcpy(system_mac, MLACP(csm).mclag_system_mac, ETHER_ADDR_LEN);
+            SET_MAC_STR(macaddr, MLACP(csm).mclag_system_mac);
         }
-        memcpy(system_mac, MLACP(csm).remote_system.system_id, ETHER_ADDR_LEN);
-        SET_MAC_STR(macaddr, MLACP(csm).remote_system.system_id);
+        else
+        {
+            if (memcmp(MLACP(csm).remote_system.system_id, null_mac, ETHER_ADDR_LEN) == 0) {
+                ICCPD_LOG_DEBUG(__FUNCTION__, " remote system_id not initialised.");
+                return;
+            }
+            memcpy(system_mac, MLACP(csm).remote_system.system_id, ETHER_ADDR_LEN);
+            SET_MAC_STR(macaddr, MLACP(csm).remote_system.system_id);
+        }
     } else {
         if (memcmp(MLACP(csm).system_id, null_mac, ETHER_ADDR_LEN) == 0){
             ICCPD_LOG_NOTICE(__FUNCTION__, " system_id not initialised.");
@@ -2354,7 +2389,7 @@ void update_vlan_if_mac_on_standby(struct LocalInterface* lif_vlan, int dir)
 
             iccp_set_interface_ipadd_mac(lif_vlan, macaddr);
             memcpy(lif_vlan->l3_mac_addr, system_mac, ETHER_ADDR_LEN);
-            if (lif_vlan->is_l3_proto_enabled == false) {
+            if (lif_vlan->is_l3_proto_enabled == false && csm->is_set_mclag_sys_mac == false) {
                 set_peer_mac_in_kernel (macaddr, vid, 1);
             }
         } else {
@@ -2376,7 +2411,11 @@ void recover_vlan_if_mac_on_standby(struct LocalInterface* lif_vlan, int dir, ui
     char remote_macaddr[64] = { 0 };
     uint8_t system_mac[ETHER_ADDR_LEN] = { 0 };
     int ret = 0;
-    int vid = 0;
+    struct VLAN_ID vlan_key = { 0 };
+    struct VLAN_ID *vlan = NULL;
+    int vid = 0, vlan_member = 0;
+    struct LocalInterface *lif_peer = NULL;
+    struct LocalInterface *lif_po = NULL;
 
     if (lif_vlan->type != IF_T_VLAN)
         return;
@@ -2384,9 +2423,37 @@ void recover_vlan_if_mac_on_standby(struct LocalInterface* lif_vlan, int dir, ui
     if ((sys = system_get_instance()) == NULL)
         return;
 
+    sscanf (lif_vlan->name, "Vlan%d", &vid);
+
+    memset(&vlan_key, 0, sizeof(struct VLAN_ID));
+    vlan_key.vid = vid;
+
     LIST_FOREACH(csm, &(sys->csm_list), next)
     {
         if (csm->peer_link_if) {
+            lif_peer = csm->peer_link_if;
+            vlan = RB_FIND(vlan_rb_tree, &(lif_peer->vlan_tree), &vlan_key);
+            if (vlan && vlan->vlan_itf)
+            {
+                vlan_member = 1;
+                break;
+            }
+        }
+
+        LIST_FOREACH(lif_po, &(MLACP(csm).lif_list), mlacp_next)
+        {
+            if (lif_po->type == IF_T_PORT_CHANNEL)
+            {
+                vlan = RB_FIND(vlan_rb_tree, &(lif_po->vlan_tree), &vlan_key);
+                if (vlan)
+                {
+                    vlan_member = 1;
+                    break;
+                }
+            }
+        }
+        if (vlan_member)
+        {
             break;
         }
     }
@@ -2396,7 +2463,7 @@ void recover_vlan_if_mac_on_standby(struct LocalInterface* lif_vlan, int dir, ui
         return;
     }
 
-    if (csm->role_type != STP_ROLE_STANDBY)
+    if (csm->role_type != STP_ROLE_STANDBY && !csm->is_set_mclag_sys_mac)
         return;
 
     sscanf (lif_vlan->name, "Vlan%d", &vid);
@@ -2412,12 +2479,26 @@ void recover_vlan_if_mac_on_standby(struct LocalInterface* lif_vlan, int dir, ui
         memcpy(system_mac, MLACP(csm).remote_system.system_id, ETHER_ADDR_LEN);
         SET_MAC_STR(macaddr, MLACP(csm).remote_system.system_id);
     } else {
-        if (memcmp(MLACP(csm).system_id, null_mac, ETHER_ADDR_LEN) == 0) {
-            ICCPD_LOG_NOTICE(__FUNCTION__, " system_id not initialised.");
-            return;
+        /*ICCPD doesn't need to change the MAC of VLAN of MCLAG member if MCLAG system MAC is configured during rebooting.*/
+        /*dir 4 present that ICCPD session goes down.*/
+        if (csm->is_set_mclag_sys_mac && dir == 4)
+        {
+            if (memcmp(MLACP(csm).mclag_system_mac, null_mac, ETHER_ADDR_LEN) == 0) {
+                ICCPD_LOG_DEBUG(__FUNCTION__, " MCLAG system MAC is not initialised.");
+                return;
+            }
+            memcpy(system_mac, MLACP(csm).mclag_system_mac, ETHER_ADDR_LEN);
+            SET_MAC_STR(macaddr, MLACP(csm).mclag_system_mac);
         }
-        memcpy(system_mac, MLACP(csm).system_id, ETHER_ADDR_LEN);
-        SET_MAC_STR(macaddr, MLACP(csm).system_id);
+        else
+        {
+            if (memcmp(MLACP(csm).system_id, null_mac, ETHER_ADDR_LEN) == 0) {
+                ICCPD_LOG_NOTICE(__FUNCTION__, " system_id not initialised.");
+                return;
+            }
+            memcpy(system_mac, MLACP(csm).system_id, ETHER_ADDR_LEN);
+            SET_MAC_STR(macaddr, MLACP(csm).system_id);
+        }
     }
 
     if (memcmp(system_mac, null_mac, ETHER_ADDR_LEN) == 0) {
@@ -2483,4 +2564,163 @@ void update_vlan_if_mac_on_iccp_up(struct LocalInterface* lif_peer, int is_up, u
         }
 
     }
+}
+
+bool update_po_mclag_sys_mac(struct LocalInterface *lif_po, uint8_t *k_mac, int dir)
+{
+    int ret = 0;
+
+    if (memcmp(lif_po->mac_addr, k_mac, ETHER_ADDR_LEN) != 0)
+    {
+        ret =  iccp_netlink_if_hwaddr_set(lif_po->ifindex,  k_mac, ETHER_ADDR_LEN);
+        if (ret != 0)
+        {
+            ICCPD_LOG_ERR(__FUNCTION__, "Set %s mac error, ret = %d, dir = %d", lif_po->name, ret, dir);
+            return false;
+        }
+
+        /* Refresh link local address according the new MAC */
+        iccp_netlink_if_shutdown_set(lif_po->ifindex);
+        iccp_netlink_if_startup_set(lif_po->ifindex);
+        memcpy(lif_po->mac_addr, k_mac, ETHER_ADDR_LEN);
+    }
+
+    return true;
+}
+
+void update_l3_po_mclag_sys_mac(struct LocalInterface *lif_po, char *c_mac, uint8_t *k_mac)
+{
+    if (memcmp(lif_po->l3_mac_addr, k_mac, ETHER_ADDR_LEN) != 0)
+    {
+        iccp_set_interface_ipadd_mac(lif_po, c_mac);
+        memcpy(lif_po->l3_mac_addr, k_mac, ETHER_ADDR_LEN);
+    }
+}
+
+bool update_l3_vlan_mclag_sys_mac(struct LocalInterface *lif_po, char *c_mac, uint8_t *k_mac, int dir)
+{
+    struct LocalInterface *lif_vlan = NULL;
+    struct VLAN_ID *vlan = NULL;
+    int ret = 0;
+
+    RB_FOREACH(vlan, vlan_rb_tree, &(lif_po->vlan_tree))
+    {
+        lif_vlan = vlan->vlan_itf;
+        if (!lif_vlan)
+            continue;
+
+        if (local_if_is_l3_mode(lif_vlan))
+        {
+            if ((memcmp(lif_vlan->l3_mac_addr, k_mac, ETHER_ADDR_LEN) != 0) &&
+                lif_vlan->is_l3_proto_enabled == false)
+            {
+                ret = iccp_netlink_if_hwaddr_set(lif_vlan->ifindex, k_mac, ETHER_ADDR_LEN);
+                if (ret != 0)
+                {
+                    ICCPD_LOG_NOTICE(__FUNCTION__, "Set %s mac error, ret = %d", lif_vlan->name, ret);
+                    return false;
+                }
+
+                /* Refresh link local address according the new MAC */
+                iccp_netlink_if_shutdown_set(lif_vlan->ifindex);
+                iccp_netlink_if_startup_set(lif_vlan->ifindex);
+
+                iccp_set_interface_ipadd_mac(lif_vlan, c_mac);
+                memcpy(lif_vlan->l3_mac_addr, k_mac, ETHER_ADDR_LEN);
+            }
+        }
+        else
+            ICCPD_LOG_NOTICE(__FUNCTION__, "%s not L3 interface, dir %d", lif_vlan->name, dir);
+    }
+
+    return true;
+}
+
+bool mclag_sys_mac_helper(struct CSM *csm, char *c_mac, uint8_t *k_mac, int dir)
+{
+    struct LocalInterface *lif_po = NULL;
+    bool ret = true;
+
+    LIST_FOREACH(lif_po, &(MLACP(csm).lif_list), mlacp_next)
+    {
+        if (lif_po->type == IF_T_PORT_CHANNEL)
+        {
+            if (update_po_mclag_sys_mac(lif_po, k_mac, dir))
+            {
+                if (local_if_is_l3_mode(lif_po))
+                {
+                    update_l3_po_mclag_sys_mac(lif_po, c_mac, k_mac);
+                }
+                else
+                {
+                    ret = update_l3_vlan_mclag_sys_mac(lif_po, c_mac, k_mac, dir);
+                }
+            }
+            else
+                return false;
+        }
+    }
+
+    return ret;
+}
+
+bool update_all_if_mclag_sys_mac(struct CSM* csm, uint8_t *mac, int dir)
+{
+    char macaddr[64];
+
+    memset(macaddr, 0, 64);
+    SET_MAC_STR(macaddr, mac);
+
+    return mclag_sys_mac_helper(csm, macaddr, mac, dir);
+}
+
+
+bool recover_all_if_mclag_sys_mac(struct CSM* csm, stp_role_type_et role, uint8_t *mac, int dir)
+{
+    char macaddr[64];
+
+    int ret = 0;
+
+    memset(macaddr, 0, 64);
+
+    if (role == STP_ROLE_ACTIVE || MLACP(csm).current_state != MLACP_STATE_EXCHANGE)
+    {
+        memcpy(mac, MLACP(csm).system_id, ETHER_ADDR_LEN);
+        SET_MAC_STR(macaddr, MLACP(csm).system_id);
+    }
+    else
+    {
+        memcpy(mac, MLACP(csm).remote_system.system_id, ETHER_ADDR_LEN);
+        SET_MAC_STR(macaddr, MLACP(csm).remote_system.system_id);
+    }
+
+    return mclag_sys_mac_helper(csm, macaddr, mac, dir);
+}
+
+bool update_if_mclag_sys_mac(struct CSM *csm, struct LocalInterface *lif_po, uint8_t *k_mac, int dir)
+{
+    bool ret = true;
+    char macaddr[64];
+
+    memset(macaddr, 0, 64);
+    SET_MAC_STR(macaddr, k_mac);
+
+    if (lif_po->type == IF_T_PORT_CHANNEL)
+    {
+        if (update_po_mclag_sys_mac(lif_po, k_mac, dir))
+        {
+            if (local_if_is_l3_mode(lif_po))
+            {
+                update_l3_po_mclag_sys_mac(lif_po, macaddr, k_mac);
+            }
+            else
+            {
+                ret = update_l3_vlan_mclag_sys_mac(lif_po, macaddr, k_mac, dir);
+            }
+        }
+        else
+            return false;
+    }
+
+    return ret;
 }

--- a/src/iccpd/src/mlacp_link_handler.c
+++ b/src/iccpd/src/mlacp_link_handler.c
@@ -463,7 +463,7 @@ ssize_t iccp_send_to_mclagsyncd(uint8_t msg_type, char *send_buff, uint16_t msg_
 
 }
 
-#if 0
+#if 1
 static void mlacp_clean_fdb(void)
 {
     struct IccpSyncdHDr * msg_hdr;
@@ -494,6 +494,52 @@ static void mlacp_clean_fdb(void)
 
     }
     ICCPD_LOG_DEBUG(__FUNCTION__, "Notify mclagsyncd to clear FDB");
+    return;
+}
+
+void mlacp_clean_fdb_by_port(const char *port_name)
+{
+    struct IccpSyncdHDr * msg_hdr;
+    char *msg_buf = g_iccp_mlagsyncd_send_buf;
+    ssize_t rc;
+    struct System *sys;
+    mclag_sub_option_hdr_t * sub_msg;
+    int msg_len;
+
+    sys = system_get_instance();
+    if (sys == NULL)
+    {
+        ICCPD_LOG_ERR(__FUNCTION__, "Invalid system instance");
+        return;
+    }
+    memset(msg_buf, 0, ICCP_MLAGSYNCD_SEND_MSG_BUFFER_SIZE);
+    msg_hdr = (struct IccpSyncdHDr *)msg_buf;
+    msg_hdr->ver = ICCPD_TO_MCLAGSYNCD_HDR_VERSION;
+    msg_hdr->type = MCLAG_MSG_TYPE_FLUSH_FDB_BY_PORT;
+    msg_hdr->len = sizeof(struct IccpSyncdHDr);
+
+    sub_msg = (mclag_sub_option_hdr_t*)&msg_buf[msg_hdr->len];
+    sub_msg->op_type = MCLAG_SUB_OPTION_TYPE_PEER_LINK;
+
+    msg_len = strlen(port_name);
+    memcpy(sub_msg->data, port_name, msg_len);
+
+    sub_msg->op_len = msg_len;
+    msg_hdr->len += sizeof(mclag_sub_option_hdr_t);
+    msg_hdr->len += sub_msg->op_len;
+
+    if (sys->sync_fd)
+    {
+        rc = iccp_send_to_mclagsyncd(msg_hdr->type, msg_buf, msg_hdr->len);
+
+        if (rc <= 0)
+        {
+            ICCPD_LOG_WARN(__FUNCTION__, "Send to Mclagsyncd failed rc: %d",rc);
+        }
+
+    }
+    ICCPD_LOG_DEBUG(__FUNCTION__, "Notify mclagsyncd to clear FDB, port = [%s]",
+                    port_name);
     return;
 }
 #endif
@@ -619,7 +665,8 @@ static int mlacp_link_set_traffic_dist_mode(
  */
 int mlacp_link_set_iccp_state(
     int                     mlag_id,
-    bool                    is_oper_up)
+    bool                    is_oper_up,
+    char                    *peer_link_mbr)
 {
     struct IccpSyncdHDr     *msg_hdr;
     mclag_sub_option_hdr_t  *sub_msg;
@@ -663,6 +710,16 @@ int mlacp_link_set_iccp_state(
     sub_msg->op_len = sizeof(is_oper_up);
     memcpy(sub_msg->data, &is_oper_up, sub_msg->op_len);
     msg_hdr->len += (sizeof(mclag_sub_option_hdr_t) + sub_msg->op_len);
+
+    if (peer_link_mbr != NULL)
+    {
+        /* Sub-message: peer link interface name */
+        sub_msg = (mclag_sub_option_hdr_t *)&msg_buf[msg_hdr->len];
+        sub_msg->op_type = MCLAG_SUB_OPTION_TYPE_PEER_LINK_MEMBER;
+        sub_msg->op_len = strlen(peer_link_mbr);
+        memcpy(sub_msg->data, peer_link_mbr, sub_msg->op_len);
+        msg_hdr->len += (sizeof(mclag_sub_option_hdr_t) + sub_msg->op_len);
+    }
 
     if (sys->sync_fd)
         rc = iccp_send_to_mclagsyncd(msg_hdr->type, msg_buf, msg_hdr->len);
@@ -806,6 +863,128 @@ int mlacp_link_set_iccp_system_id(
         ICCPD_LOG_DEBUG(__FUNCTION__,
             "Set mlag %d, ICCP system ID to %s",
             mlag_id, mac_addr_to_str(system_id));
+        return 0;
+    }
+}
+
+/* Send request to Mclagsyncd to set ICCP peer link
+ * The message includes MLAG id and interface name
+ */
+int mlacp_link_set_iccp_peer_link(
+    int                     mlag_id,
+    char                    *po_name)
+{
+    struct IccpSyncdHDr     *msg_hdr;
+    mclag_sub_option_hdr_t  *sub_msg;
+    char                    *msg_buf = g_iccp_mlagsyncd_send_buf;
+    struct System           *sys;
+    ssize_t                 rc = 0;
+
+    sys = system_get_instance();
+    if (sys == NULL)
+    {
+        ICCPD_LOG_ERR(__FUNCTION__, "Invalid system instance");
+        return MCLAG_ERROR;
+    }
+
+    memset(msg_buf, 0, ICCP_MLAGSYNCD_SEND_MSG_BUFFER_SIZE);
+    msg_hdr = (struct IccpSyncdHDr *)msg_buf;
+    msg_hdr->ver = ICCPD_TO_MCLAGSYNCD_HDR_VERSION;
+    msg_hdr->type = MCLAG_MSG_TYPE_SET_ICCP_PEER_LINK;
+    msg_hdr->len = sizeof(struct IccpSyncdHDr);
+
+    /* Sub-message: mlag ID */
+    sub_msg = (mclag_sub_option_hdr_t *)&msg_buf[msg_hdr->len];
+    sub_msg->op_type = MCLAG_SUB_OPTION_TYPE_MCLAG_ID;
+    sub_msg->op_len = sizeof(mlag_id);
+    memcpy(sub_msg->data, &mlag_id, sub_msg->op_len);
+    msg_hdr->len += (sizeof(mclag_sub_option_hdr_t) + sub_msg->op_len);
+
+    /* Sub-message: peer link interface name */
+    sub_msg = (mclag_sub_option_hdr_t *)&msg_buf[msg_hdr->len];
+    sub_msg->op_type = MCLAG_SUB_OPTION_TYPE_PEER_LINK;
+    sub_msg->op_len = strlen(po_name);
+    memcpy(sub_msg->data, po_name, sub_msg->op_len);
+    msg_hdr->len += (sizeof(mclag_sub_option_hdr_t) + sub_msg->op_len);
+
+    if (sys->sync_fd)
+        rc = write(sys->sync_fd,msg_buf, msg_hdr->len);
+
+    if ((rc <= 0) || (rc != msg_hdr->len))
+    {
+        //SYSTEM_SET_SYNCD_TX_DBG_COUNTER(sys, msg_hdr->type, ICCP_DBG_CNTR_STS_ERR);
+        ICCPD_LOG_ERR(__FUNCTION__,
+            "Failed to write mlag %d, ICCP peer link if %s, rc %d",
+            mlag_id, po_name, rc);
+        return MCLAG_ERROR;
+    }
+    else
+    {
+        //SYSTEM_SET_SYNCD_TX_DBG_COUNTER(sys, msg_hdr->type, ICCP_DBG_CNTR_STS_OK);
+        ICCPD_LOG_DEBUG(__FUNCTION__,
+            "Set mlag %d, ICCP peer link if %s",
+            mlag_id, po_name);
+        return 0;
+    }
+}
+
+/* Send request to Mclagsyncd to del ICCP peer link
+ * The message includes MLAG id and interface name
+ */
+int mlacp_link_del_iccp_peer_link(
+    int                     mlag_id,
+    char                    *po_name)
+{
+    struct IccpSyncdHDr     *msg_hdr;
+    mclag_sub_option_hdr_t  *sub_msg;
+    char                    *msg_buf = g_iccp_mlagsyncd_send_buf;
+    struct System           *sys;
+    ssize_t                 rc = 0;
+
+    sys = system_get_instance();
+    if (sys == NULL)
+    {
+        ICCPD_LOG_ERR(__FUNCTION__, "Invalid system instance");
+        return MCLAG_ERROR;
+    }
+
+    memset(msg_buf, 0, ICCP_MLAGSYNCD_SEND_MSG_BUFFER_SIZE);
+    msg_hdr = (struct IccpSyncdHDr *)msg_buf;
+    msg_hdr->ver = ICCPD_TO_MCLAGSYNCD_HDR_VERSION;
+    msg_hdr->type = MCLAG_MSG_TYPE_DEL_ICCP_PEER_LINK;
+    msg_hdr->len = sizeof(struct IccpSyncdHDr);
+
+    /* Sub-message: mlag ID */
+    sub_msg = (mclag_sub_option_hdr_t *)&msg_buf[msg_hdr->len];
+    sub_msg->op_type = MCLAG_SUB_OPTION_TYPE_MCLAG_ID;
+    sub_msg->op_len = sizeof(mlag_id);
+    memcpy(sub_msg->data, &mlag_id, sub_msg->op_len);
+    msg_hdr->len += (sizeof(mclag_sub_option_hdr_t) + sub_msg->op_len);
+
+    /* Sub-message: peer link interface name */
+    sub_msg = (mclag_sub_option_hdr_t *)&msg_buf[msg_hdr->len];
+    sub_msg->op_type = MCLAG_SUB_OPTION_TYPE_PEER_LINK;
+    sub_msg->op_len = strlen(po_name);
+    memcpy(sub_msg->data, po_name, sub_msg->op_len);
+    msg_hdr->len += (sizeof(mclag_sub_option_hdr_t) + sub_msg->op_len);
+
+    if (sys->sync_fd)
+        rc = write(sys->sync_fd,msg_buf, msg_hdr->len);
+
+    if ((rc <= 0) || (rc != msg_hdr->len))
+    {
+        //SYSTEM_SET_SYNCD_TX_DBG_COUNTER(sys, msg_hdr->type, ICCP_DBG_CNTR_STS_ERR);
+        ICCPD_LOG_ERR(__FUNCTION__,
+            "Failed to write mlag %d, ICCP peer link if %s, rc %d",
+            mlag_id, po_name, rc);
+        return MCLAG_ERROR;
+    }
+    else
+    {
+        //SYSTEM_SET_SYNCD_TX_DBG_COUNTER(sys, msg_hdr->type, ICCP_DBG_CNTR_STS_OK);
+        ICCPD_LOG_DEBUG(__FUNCTION__,
+            "Set mlag %d, ICCP peer link if %s",
+            mlag_id, po_name);
         return 0;
     }
 }
@@ -1085,7 +1264,7 @@ void update_peerlink_isolate_from_all_csm_lif(
     char *msg_buf = g_iccp_mlagsyncd_send_buf;
     struct System *sys;
 
-    char mlag_po_buf[512];
+    char mlag_po_buf[4096];
     int src_len = 0, dst_len = 0;
     ssize_t rc;
 
@@ -1100,7 +1279,7 @@ void update_peerlink_isolate_from_all_csm_lif(
         return;
 
     memset(msg_buf, 0, ICCP_MLAGSYNCD_SEND_MSG_BUFFER_SIZE);
-    memset(mlag_po_buf, 0, 511);
+    memset(mlag_po_buf, 0, 4096);
 
     msg_hdr = (struct IccpSyncdHDr *)msg_buf;
     msg_hdr->ver = ICCPD_TO_MCLAGSYNCD_HDR_VERSION;
@@ -1700,6 +1879,13 @@ void del_mac_from_chip(struct MACMsg* mac_msg)
     return;
 }
 
+void del_mac_from_app_db(struct MACMsg* mac_msg)
+{
+    iccp_send_fdb_entry_to_syncd(  mac_msg, mac_msg->fdb_type, MAC_SYNC_DEL_APP_DB);
+
+    return;
+}
+
 uint8_t set_mac_local_age_flag(struct CSM *csm, struct MACMsg* mac_msg, uint8_t set, uint8_t update_peer )
 {
     uint8_t new_age_flag = 0;
@@ -1759,9 +1945,9 @@ uint8_t set_mac_local_age_flag(struct CSM *csm, struct MACMsg* mac_msg, uint8_t 
 }
 
 /*Deal with mac add,del,move when portchannel up or down*/
-static void update_l2_mac_state(struct CSM *csm,
-                                struct LocalInterface *lif,
-                                int po_state)
+void update_l2_mac_state(struct CSM *csm,
+                         struct LocalInterface *lif,
+                         int po_state)
 {
     struct MACMsg* mac_msg = NULL,  *mac_temp = NULL;
     struct PeerInterface* pif = NULL;
@@ -2026,6 +2212,8 @@ void mlacp_convert_remote_mac_to_local(struct CSM *csm, char *po_name)
                     "interface %s, MAC %s vlan-id %d age flag:%d", mac_msg->origin_ifname,
                     mac_msg->ifname, mac_addr_to_str(mac_msg->mac_addr), mac_msg->vid, mac_msg->age_flag);
 
+            memcpy(mac_msg->ifname, mac_msg->origin_ifname, MAX_L_PORT_NAME);
+
             /*Send mac add message to mclagsyncd with aging enabled*/
             add_mac_to_chip(mac_msg, MAC_TYPE_DYNAMIC_LOCAL);
 
@@ -2232,6 +2420,7 @@ void mlacp_peer_conn_handler(struct CSM* csm)
     struct LocalInterface *lif = NULL;
     struct PeerInterface* peer_if;
     static int once_connected = 0;
+    static int once_set_mclag_sys_mac = 0;
     struct System* sys = NULL;
     struct If_info * cif = NULL;
 
@@ -2266,9 +2455,10 @@ void mlacp_peer_conn_handler(struct CSM* csm)
     {
         once_connected = 1;
         mlacp_fix_bridge_mac(csm);
-        // do not required to flush FDB
-        //if (sys->warmboot_start != WARM_REBOOT)
-          //  mlacp_clean_fdb();
+        // SAG's MAC may be learned on peerlink if not flush FDB
+        // after session connected.
+        if (sys->warmboot_start != WARM_REBOOT)
+            mlacp_clean_fdb();
     }
 
     sys->csm_trans_time = time(NULL);
@@ -2279,11 +2469,31 @@ void mlacp_peer_conn_handler(struct CSM* csm)
         if (lif->type == IF_T_PORT_CHANNEL)
         {
             mlacp_portchannel_state_handler(csm, lif, (lif->state == PORT_STATE_UP) ? 1 : 0);
+
+            if (csm->is_set_mclag_sys_mac && once_set_mclag_sys_mac++ == 0)
+            {
+                ICCPD_LOG_NOTICE(__FUNCTION__, "peer connect to set MCLAG system MAC!!!!");
+                set_mclag_system_mac(csm->mlag_id, mac_addr_to_str(MLACP(csm).mclag_system_mac));
+            }
         }
     }
 
     /* Send ICCP up update to Mclagsyncd */
-    mlacp_link_set_iccp_state(csm->mlag_id, true);
+    if (csm->peer_link_if)
+    {
+        if (!memcmp(csm->peer_itf_name, "Ethernet", 8))
+        {
+            mlacp_link_set_iccp_state(csm->mlag_id, true, csm->peer_itf_name);
+        }
+        else
+        {
+            mlacp_link_set_iccp_state(csm->mlag_id, true, csm->peer_link_if->portchannel_member_buf);
+        }
+    }
+    else
+    {
+        mlacp_link_set_iccp_state(csm->mlag_id, true, NULL);
+    }
 
     /* Send remote interface status update to Mclagsyncd */
     LIST_FOREACH(peer_if, &(MLACP(csm).pif_list), mlacp_next)
@@ -2417,7 +2627,21 @@ void mlacp_peer_disconn_handler(struct CSM* csm)
      * so that mclagsync can differentiate between session down and all remote
      * MLAG interface down
      */
-    mlacp_link_set_iccp_state(csm->mlag_id, false);
+    if (csm->peer_link_if)
+    {
+        if (!memcmp(csm->peer_itf_name, "Ethernet", 8))
+        {
+            mlacp_link_set_iccp_state(csm->mlag_id, false, csm->peer_itf_name);
+        }
+        else
+        {
+            mlacp_link_set_iccp_state(csm->mlag_id, false, csm->peer_link_if->portchannel_member_buf);
+        }
+    }
+    else
+    {
+        mlacp_link_set_iccp_state(csm->mlag_id, false, NULL);
+    }
 
     /* Clean all port block*/
     peerlink_port_isolate_cleanup(csm);
@@ -2452,8 +2676,13 @@ void mlacp_peer_disconn_handler(struct CSM* csm)
     /* On standby, system ID is reverted back to its local system ID.
      * Update Mclagsyncd
      * */
-    if (csm->role_type == STP_ROLE_STANDBY)
-        mlacp_link_set_iccp_system_id(csm->mlag_id, MLACP(csm).system_id);
+    if (csm->is_set_mclag_sys_mac)
+        mlacp_link_set_iccp_system_id(csm->mlag_id, MLACP(csm).mclag_system_mac);
+    else
+    {
+        if (csm->role_type == STP_ROLE_STANDBY)
+            mlacp_link_set_iccp_system_id(csm->mlag_id, MLACP(csm).system_id);
+    }
 
     /* Delete remote interface info */
     LIST_FOREACH(peer_if, &(MLACP(csm).pif_list), mlacp_next)
@@ -2552,17 +2781,25 @@ void mlacp_mlag_link_add_handler(struct CSM *csm, struct LocalInterface *lif)
     //enable peerlink isolation only if the both mclag interfaces are up
     update_peerlink_isolate_from_lif(csm, lif, lif->po_active);
 
-    //if it is standby node and peer interface is configured, update
-    //standby node mac to active's mac for this lif
-    if (csm->role_type == STP_ROLE_STANDBY)
+    if (csm->is_set_mclag_sys_mac)
     {
-        struct PeerInterface* pif=NULL;
-        pif = peer_if_find_by_name(csm, lif->name);
-
-        if (pif)
+        update_if_mclag_sys_mac(csm, lif, MLACP(csm).mclag_system_mac, 4);
+        mlacp_link_set_iccp_system_id(csm->mlag_id, lif->mac_addr);
+    }
+    else
+    {
+        //if it is standby node and peer interface is configured, update
+        //standby node mac to active's mac for this lif
+        if (csm->role_type == STP_ROLE_STANDBY)
         {
-            update_if_ipmac_on_standby(lif, 4);
-            mlacp_link_set_iccp_system_id(csm->mlag_id, lif->mac_addr);
+            struct PeerInterface* pif=NULL;
+            pif = peer_if_find_by_name(csm, lif->name);
+
+            if (pif)
+            {
+                update_if_ipmac_on_standby(lif, 4);
+                mlacp_link_set_iccp_system_id(csm->mlag_id, lif->mac_addr);
+            }
         }
     }
 
@@ -2776,6 +3013,12 @@ void do_mac_update_from_syncd(uint8_t mac_addr[ETHER_ADDR_LEN], uint16_t vid, ch
         ICCPD_LOG_DEBUG("ICCP_FDB", "MAC update from mclagsyncd: RB_FIND success for the MAC entry : %s, "
             " vid: %d , ifname %s, type: %d, age flag: %d", mac_addr_to_str(mac_info->mac_addr),
             mac_info->vid, mac_info->ifname, mac_info->fdb_type, mac_info->age_flag );
+
+        if (mac_info->fdb_type == MAC_TYPE_STATIC && strcmp(mac_info->ifname, csm->peer_itf_name) == 0)
+        {
+            ICCPD_LOG_DEBUG("ICCP_FDB", "Ignore MAC for unique IP");
+            return;
+        }
     }
 
     /*handle mac add*/
@@ -2857,19 +3100,35 @@ void do_mac_update_from_syncd(uint8_t mac_addr[ETHER_ADDR_LEN], uint16_t vid, ch
                 sprintf(mac_info->ifname, "%s", mac_msg->ifname);
                 sprintf(mac_info->origin_ifname, "%s", mac_msg->ifname);
 
-                /*Remove MAC_AGE_LOCAL flag*/
-                mac_info->age_flag = set_mac_local_age_flag(csm, mac_info, 0, 1);
+                if (mac_info->age_flag == MAC_AGE_PEER)
+                {
+                    if ((MLACP(csm).current_state == MLACP_STATE_EXCHANGE))
+                    {
+                        mac_info->op_type = MAC_SYNC_ADD;
+                        if (!MAC_IN_MSG_LIST(&(MLACP(csm).mac_msg_list), mac_info, tail))
+                        {
+                            ICCPD_LOG_DEBUG("ICCP_FDB", "local learn move, need to notify peer to update it.");
+                            TAILQ_INSERT_TAIL(&(MLACP(csm).mac_msg_list), mac_info, tail);
+                        }
+                    }
+                }
+                else
+                {
+                    ICCPD_LOG_DEBUG("ICCP_FDB", "remote learn move, need to notify peer to update it.");
+                    /*Remove MAC_AGE_LOCAL flag*/
+                    mac_info->age_flag = set_mac_local_age_flag(csm, mac_info, 0, 1);
+                }
 
                 ICCPD_LOG_DEBUG("ICCP_FDB", "MAC update from mclagsyncd: Update MAC %s, vlan %d ifname %s",
                     mac_addr_to_str(mac_msg->mac_addr), mac_msg->vid, mac_msg->ifname);
                 // MAC is local now Del entry from MCLAG_FDB_TABLE if peer not aged.
-                if (!(mac_msg->age_flag & MAC_AGE_PEER))
+                if (!(mac_info->age_flag & MAC_AGE_PEER))
                 {
                     ICCPD_LOG_DEBUG("ICCP_FDB", " MAC update from mclagsyncd: MAC move Update MAC remote to local %s, vlan %d"
                             " ifname %s, del entry from MCLAG_FDB_TABLE",
                             mac_addr_to_str(mac_msg->mac_addr), mac_msg->vid, mac_msg->ifname);
 		    mac_info->age_flag = MAC_AGE_PEER;
-                    del_mac_from_chip(mac_msg);
+                    del_mac_from_app_db(mac_msg);
                 }
             }
             else
@@ -2880,12 +3139,12 @@ void do_mac_update_from_syncd(uint8_t mac_addr[ETHER_ADDR_LEN], uint16_t vid, ch
                 ICCPD_LOG_DEBUG("ICCP_FDB", "MAC update from mclagsyncd: Duplicate update MAC %s, vlan %d ifname %s",
                         mac_addr_to_str(mac_msg->mac_addr), mac_msg->vid, mac_msg->ifname);
                 // MAC is local now Del entry from MCLAG_FDB_TABLE if peer not aged.
-                if (!(mac_msg->age_flag & MAC_AGE_PEER))
+                if (!(mac_info->age_flag & MAC_AGE_PEER))
                 {
                     ICCPD_LOG_DEBUG("ICCP_FDB", "MAC update from mclagsyncd: Update MAC remote to local %s, vlan %d"
                             " ifname %s, del entry from MCLAG_FDB_TABLE",
                             mac_addr_to_str(mac_msg->mac_addr), mac_msg->vid, mac_msg->ifname);
-                    del_mac_from_chip(mac_msg);
+                    del_mac_from_app_db(mac_msg);
                 }
                 return;
             }
@@ -2987,10 +3246,7 @@ void do_mac_update_from_syncd(uint8_t mac_addr[ETHER_ADDR_LEN], uint16_t vid, ch
                         "MAC %s vlan-id %d", mac_info->ifname,
                         mac_addr_to_str(mac_info->mac_addr), mac_info->vid);
 
-                    if (mac_info->add_to_syncd)
-                    {
-                        del_mac_from_chip(mac_info);
-                    }
+                    del_mac_from_chip(mac_info);
 
                     /*If peer link is down, del the mac*/
                     MAC_RB_REMOVE(mac_rb_tree, &MLACP(csm).mac_rb, mac_info);
@@ -3025,10 +3281,8 @@ void do_mac_update_from_syncd(uint8_t mac_addr[ETHER_ADDR_LEN], uint16_t vid, ch
                     mac_addr_to_str(mac_info->mac_addr), mac_info->vid);
 
                 //before removing the MAC send del to syncd if added before.
-                if (mac_info->add_to_syncd)
-                {
-                    del_mac_from_chip(mac_info);
-                }
+                del_mac_from_chip(mac_info);
+
                 /*If local and peer both aged, del the mac (local orphan mac is here)*/
                 MAC_RB_REMOVE(mac_rb_tree, &MLACP(csm).mac_rb, mac_info);
 
@@ -3143,6 +3397,12 @@ int iccp_mclagsyncd_mclag_domain_cfg_handler(struct System *sys, char *msg_buf)
                     set_session_timeout(cfg_info->domain_id, HEARTBEAT_TIMEOUT_SEC);
                 }
             }
+
+            if(cfg_info->attr_bmap & MCLAG_CFG_ATTR_MCLAG_SYS_MAC)
+            {
+                ICCPD_LOG_NOTICE(__FUNCTION__, "config MCLAG system MAC = %s", mac_addr_to_str(cfg_info->mclag_system_mac));
+                set_mclag_system_mac(cfg_info->domain_id, mac_addr_to_str(cfg_info->mclag_system_mac));
+            }
         } //MCLAG Domain create/update End
         else if (cfg_info->op_type == MCLAG_CFG_OPER_DEL) //mclag domain delete
         {
@@ -3171,6 +3431,11 @@ int iccp_mclagsyncd_mclag_domain_cfg_handler(struct System *sys, char *msg_buf)
             else if(cfg_info->attr_bmap & MCLAG_CFG_ATTR_PEER_ADDR)
             {
                 unset_peer_address(cfg_info->domain_id);
+            }
+            else if(cfg_info->attr_bmap & MCLAG_CFG_ATTR_MCLAG_SYS_MAC)
+            {
+                ICCPD_LOG_NOTICE(__FUNCTION__, "Pepare for removing MCLAG system MAC!!!!!!");
+                unset_mclag_system_mac(cfg_info->domain_id);
             }
         } //MCLAG Domain Attribute delete End
     }
@@ -4284,6 +4549,7 @@ int syn_local_arp_info_to_peer(struct CSM* csm, struct LocalInterface *local_if,
 {
     struct ARPMsg arp_msg = {0};
     int msg_len = 0, rc = MCLAG_ERROR;
+    uint8_t null_mac[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
     if (!csm || !local_if) {
         ICCPD_LOG_DEBUG(__FUNCTION__,"invalid parameters");
@@ -4302,7 +4568,19 @@ int syn_local_arp_info_to_peer(struct CSM* csm, struct LocalInterface *local_if,
     arp_msg.ipv4_addr = local_if->ipv4_addr;
     arp_msg.flag |= NEIGH_SYNC_FLAG_SELF_IP;
     memcpy(arp_msg.ifname, local_if->name, MAX_L_PORT_NAME);
-    memcpy(arp_msg.mac_addr, local_if->mac_addr, ETHER_ADDR_LEN);
+    if (csm->role_type == STP_ROLE_ACTIVE)
+        memcpy(arp_msg.mac_addr, local_if->mac_addr, ETHER_ADDR_LEN);
+    else
+    {
+        /*
+         * If lif is session or orphant port, its mac_addr will be all zero. Under the situation,
+         * There use the l3_mac_addr instead of mac_addr.
+         */
+        if (memcmp(local_if->l3_mac_addr, null_mac,ETHER_ADDR_LEN))
+            memcpy(arp_msg.mac_addr, local_if->l3_mac_addr, ETHER_ADDR_LEN);
+        else
+            memcpy(arp_msg.mac_addr, local_if->mac_addr, ETHER_ADDR_LEN);
+    }
 
     ICCPD_LOG_DEBUG(__FUNCTION__," add %d ack %d ifname %s, ip %s", sync_add, ack, arp_msg.ifname, show_ip_str(arp_msg.ipv4_addr));
     ICCPD_LOG_DEBUG(__FUNCTION__," mac [%02X:%02X:%02X:%02X:%02X:%02X]",

--- a/src/iccpd/src/mlacp_sync_update.c
+++ b/src/iccpd/src/mlacp_sync_update.c
@@ -70,7 +70,8 @@ int mlacp_fsm_update_system_conf(struct CSM* csm, mLACPSysConfigTLV*sysconf)
 
     /* On standby, update system ID upon receiving change from active */
     if ((csm->role_type == STP_ROLE_STANDBY) &&
-        (memcmp(old_remote_system_id, sysconf->sys_id, ETHER_ADDR_LEN) != 0))
+        (memcmp(old_remote_system_id, sysconf->sys_id, ETHER_ADDR_LEN) != 0) &&
+         !csm->is_set_mclag_sys_mac)
     {
         mlacp_link_set_iccp_system_id(csm->mlag_id, sysconf->sys_id);
     }
@@ -219,6 +220,7 @@ int mlacp_fsm_update_mac_entry_from_peer( struct CSM* csm, struct mLACPMACData *
     struct MACMsg *mac_msg = NULL, *new_mac_msg = NULL;
     struct MACMsg mac_data, mac_find;
     struct LocalInterface* local_if = NULL;
+    struct LocalInterface* peer_link_if = NULL;
     uint8_t from_mclag_intf = 0;/*0: orphan port, 1: MCLAG port*/
     memset(&mac_data, 0, sizeof(struct MACMsg));
     memset(&mac_find, 0, sizeof(struct MACMsg));
@@ -244,6 +246,31 @@ int mlacp_fsm_update_mac_entry_from_peer( struct CSM* csm, struct mLACPMACData *
             from_mclag_intf = 1;
             break;
         }
+    }
+
+    peer_link_if = local_if_find_by_name(csm->peer_itf_name);
+    if (peer_link_if && memcmp(peer_link_if->mac_addr, MacData->mac_addr, ETHER_ADDR_LEN) == 0)
+    {
+        ICCPD_LOG_NOTICE(__FUNCTION__, "Received MAC is CPU MAC, ignore");
+
+        if (from_mclag_intf)
+        {
+            if (MacData->type == MAC_SYNC_ADD)
+            {
+                mac_msg = (struct MACMsg*)&mac_data;
+                mac_msg->op_type = MAC_SYNC_FORCE_DEL;
+                mac_msg->vid = ntohs(MacData->vid);
+                memcpy(mac_msg->mac_addr, MacData->mac_addr, ETHER_ADDR_LEN);
+
+                if (iccp_csm_init_mac_msg(&new_mac_msg, (char*)mac_msg, sizeof(struct MACMsg)) == 0)
+                {
+                    ICCPD_LOG_NOTICE(__FUNCTION__, "Tell to peer about CPU MAC need to delete!!!");
+                    TAILQ_INSERT_TAIL(&(MLACP(csm).mac_msg_list), new_mac_msg, tail);
+                }
+            }
+        }
+
+        return 0;
     }
 
     mac_find.vid = ntohs(MacData->vid);
@@ -472,6 +499,14 @@ int mlacp_fsm_update_mac_entry_from_peer( struct CSM* csm, struct mLACPMACData *
         }
         else
         {
+            ICCPD_LOG_NOTICE("ICCP_FDB", "Recv MAC DEL from peer: age flag: %d MAC %s vlan %d, notify peer readd!",
+                             mac_msg->age_flag, mac_addr_to_str(mac_msg->mac_addr), mac_msg->vid);
+            mac_msg->op_type = MAC_SYNC_ADD;
+            if (!MAC_IN_MSG_LIST(&(MLACP(csm).mac_msg_list), mac_msg, tail))
+            {
+                TAILQ_INSERT_TAIL(&(MLACP(csm).mac_msg_list), mac_msg, tail);
+            }
+
             return 0;
         }
     }
@@ -547,6 +582,12 @@ int mlacp_fsm_update_mac_entry_from_peer( struct CSM* csm, struct mLACPMACData *
             }
             #endif
         }
+    }
+    else if (mac_msg && MacData->type == MAC_SYNC_FORCE_DEL)
+    {
+        ICCPD_LOG_NOTICE(__FUNCTION__, "Force delete peer's CPU MAC");
+        add_mac_to_chip(mac_msg, MAC_TYPE_STATIC);
+        mac_msg->is_peer_cpu_mac = true;
     }
 
     return 0;
@@ -785,6 +826,19 @@ int mlacp_fsm_update_arp_entry(struct CSM* csm, struct ARPMsg *arp_entry)
         return 0;
     }
 
+    /* update ARP list*/
+    TAILQ_FOREACH(msg, &(MLACP(csm).arp_list), tail)
+    {
+        arp_msg = (struct ARPMsg*)msg->buf;
+        if (arp_msg->ipv4_addr == arp_entry->ipv4_addr)
+        {
+            /*arp_msg->op_type = tlv->type;*/
+            sprintf(arp_msg->ifname, "%s", arp_entry->ifname);
+            memcpy(arp_msg->mac_addr, arp_entry->mac_addr, ETHER_ADDR_LEN);
+            break;
+        }
+    }
+
     /* set dynamic ARP*/
     if (set_arp_flag == 1)
     {
@@ -813,15 +867,18 @@ int mlacp_fsm_update_arp_entry(struct CSM* csm, struct ARPMsg *arp_entry)
         }
         else
         {
-            err = iccp_netlink_neighbor_request(AF_INET, (uint8_t *)&arp_entry->ipv4_addr, 0, arp_entry->mac_addr, arp_entry->ifname, permanent_neigh, 9);
-            if (err < 0)
+            if (msg)
             {
-                if (err != ICCP_NLE_SEQ_MISMATCH) {
-                    ICCPD_LOG_ERR(__FUNCTION__, "ARP delete failure for %s %s %s, status %d",
+                err = iccp_netlink_neighbor_request(AF_INET, (uint8_t *)&arp_entry->ipv4_addr, 0, arp_entry->mac_addr, arp_entry->ifname, permanent_neigh, 9);
+                if (err < 0)
+                {
+                    if (err != ICCP_NLE_SEQ_MISMATCH) {
+                        ICCPD_LOG_ERR(__FUNCTION__, "ARP delete failure for %s %s %s, status %d",
                                 arp_entry->ifname, show_ip_str(arp_entry->ipv4_addr), mac_str, err);
-                    return MCLAG_ERROR;
+                        return MCLAG_ERROR;
+                    }
                 }
-            }
+	    }
         }
 
         ICCPD_LOG_DEBUG(__FUNCTION__, "ARP update for %s %s %s",
@@ -837,19 +894,6 @@ int mlacp_fsm_update_arp_entry(struct CSM* csm, struct ARPMsg *arp_entry)
                 ICCPD_LOG_DEBUG(__FUNCTION__, "ignore my ip %s", show_ip_str(arp_entry->ipv4_addr));
                 return 0;
             }
-        }
-    }
-
-    /* update ARP list*/
-    TAILQ_FOREACH(msg, &(MLACP(csm).arp_list), tail)
-    {
-        arp_msg = (struct ARPMsg*)msg->buf;
-        if (arp_msg->ipv4_addr == arp_entry->ipv4_addr)
-        {
-            /*arp_msg->op_type = tlv->type;*/
-            sprintf(arp_msg->ifname, "%s", arp_entry->ifname);
-            memcpy(arp_msg->mac_addr, arp_entry->mac_addr, ETHER_ADDR_LEN);
-            break;
         }
     }
 

--- a/src/iccpd/src/port.c
+++ b/src/iccpd/src/port.c
@@ -177,7 +177,9 @@ struct LocalInterface* local_if_create(int ifindex, char* ifname, int type, uint
         {
             local_if->is_peer_link = 1;
             csm->peer_link_if = local_if;
+            set_peerlink_mlag_port_learn(csm->peer_link_if, 0);
             set_peerlink_learn_kernel(csm, 0, 3);
+            mlacp_clean_fdb_by_port(csm->peer_itf_name);
             break;
         }
         /*check the intf is bind with csm*/

--- a/src/libteam/patch/series
+++ b/src/libteam/patch/series
@@ -14,3 +14,4 @@
 0014-dont-move-the-port-state-from-disabled-when-admin-state-is-down.patch
 0015-add-support-for-custom-retry.patch
 0016-block-retry-count-changes.patch
+0017-Ignore-ENOBUFS-error-message-while-plugging-out-LAG-.patch


### PR DESCRIPTION
#### Why I did it
Start iccp docker container by default and sync the following modifications for MCLAG.

JIRA-SONIC-10049: [ICCPD] Container will start once "PORT_TABLE:PortInitDone" are completed.
JIRA-SONIC-10049: [ICCPD] Building iccpd to enable it by default.
JIRA-SONIC-10049: [ICCPD] Adjusting the mlag_po_buf size to support 88 isolation group member.
JIRA-SONIC-10049: [ICCPD] Flushing FDB after session is connected.
JIRA-SONIC-10049: [ICCPD] Defining mlacp_clean_fdb function.
JIRA-SONIC-10049: [ICCPD] Ignoring the MAC heared from mclagsyncd because it is related to unique IP.
JIRA-SONIC-10049: [ICCPD] Don't process the CPU MAC between active and standby.
JIRA-SONIC-10049: [ICCPD] ICCPD need to check arp_list before deleting ARP from kernel.
JIRA-SONIC-10049: [ICCPD] Adding patch to ignore ENOBUFS error message when plugging out LAG member.
JIRA-SONIC-10049: [ICCPD] Standby will sync the correct ARP information to active when the unique IP is enabling on session's VLAN.
JIRA-SONIC-10049: [ICCPD] The MAC of VLAN interface can not be recovered in recover_vlan_if_mac_on_standby function if it is not peerlink and MCLAG member.
JIRA-SONIC-10049: [ICCPD] Adding peer_link field to STATE_MCLAG_TABLE for portorch.
JIRA-SONIC-10049: [ICCPD] Supporting system MAC.
JIRA-SONIC-10049: [ICCPD] Setting flood block on peerlink after session goes down or comes up.
JIRA-SONIC-10049: [ICCPD] These Modifications help maintain MCLAG MAC consistency.
JIRA-SONIC-7878: [ICCPD] notify peer when local learn MAC move.

#### How to verify it
Verified these modifications by building image.




