### PR TITLE
[NTP] ignore lo to avoid error message of failed socket creation when enable mgmt-vrf

### DIFF
--- a/files/image_config/ntp/ntp.conf.j2
+++ b/files/image_config/ntp/ntp.conf.j2
@@ -83,6 +83,9 @@ trustedkey {{ trusted_keys_arr|join(' ') }}
 LOOPBACK_INTERFACE ip when MGMT_INTERFACE is not defined, or eth0 if we don't
 have both of them (default is to listen on all ip addresses) -#}
 interface ignore wildcard
+{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
+interface ignore lo
+{% endif %}
 
 {# Set interface to listen on:
      * Set global variable for configured source interface name.


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
"lo-m" only configured localhost loopback IPv4 address (127.0.0.1/8).
This will cause NTP service bind IPv6 loopback failed and unable to create socket on lo for ::1#123 when mgmt VRF is enabled.
Ignore lo to avoid error message of failed socket creation when enable mgmt-vrf
#### How I did it
N/A
#### How to verify it
N/A
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

