### PR TITLE
Add management port down rules to remove default route in dhcp mode

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -111,6 +111,9 @@ iface eth0 inet dhcp
 {% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
     vrf mgmt
 {% endif %}
+    ########## management network policy routing rules
+    # management port down rules
+    pre-down ip route delete default dev eth0
 iface eth0 inet6 dhcp
     up sysctl net.ipv6.conf.eth0.accept_ra=1
     down sysctl net.ipv6.conf.eth0.accept_ra=0

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt
@@ -16,6 +16,9 @@ iface lo inet loopback
 auto eth0
 iface eth0 inet dhcp
     metric 202
+    ########## management network policy routing rules
+    # management port down rules
+    pre-down ip route delete default dev eth0
 iface eth0 inet6 dhcp
     up sysctl net.ipv6.conf.eth0.accept_ra=1
     down sysctl net.ipv6.conf.eth0.accept_ra=0

--- a/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces_nomgmt
+++ b/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces_nomgmt
@@ -26,6 +26,9 @@ auto eth0
 iface eth0 inet dhcp
     metric 202
     vrf mgmt
+    ########## management network policy routing rules
+    # management port down rules
+    pre-down ip route delete default dev eth0
 iface eth0 inet6 dhcp
     up sysctl net.ipv6.conf.eth0.accept_ra=1
     down sysctl net.ipv6.conf.eth0.accept_ra=0

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt
@@ -16,6 +16,9 @@ iface lo inet loopback
 auto eth0
 iface eth0 inet dhcp
     metric 202
+    ########## management network policy routing rules
+    # management port down rules
+    pre-down ip route delete default dev eth0
 iface eth0 inet6 dhcp
     up sysctl net.ipv6.conf.eth0.accept_ra=1
     down sysctl net.ipv6.conf.eth0.accept_ra=0

--- a/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces_nomgmt
+++ b/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces_nomgmt
@@ -26,6 +26,9 @@ auto eth0
 iface eth0 inet dhcp
     metric 202
     vrf mgmt
+    ########## management network policy routing rules
+    # management port down rules
+    pre-down ip route delete default dev eth0
 iface eth0 inet6 dhcp
     up sysctl net.ipv6.conf.eth0.accept_ra=1
     down sysctl net.ipv6.conf.eth0.accept_ra=0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The metric of the default route in dhcp mode is 202, the kernel moves the default route to table mgmt after enabling mgmt vrf, but specifies the metric as 0 instead of 202.

Different metrics will not be regarded as the same route, so it will not be free implicit routes.
#### How I did it
N/A
#### How to verify it
N/A
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

