### PR TITLE
[frrcfgd] Through vtysh cmd to add static route for split mode during reboot

### DIFF
--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -2197,18 +2197,19 @@ class BGPConfigDaemon:
         self.static_route_list = {}
         sroute_table = self.config_db.get_table('STATIC_ROUTE')
         get_list = lambda v: v.split(',') if v is not None else None
-        for key, entry in sroute_table.items():
-            if type(key) is tuple and len(key) == 2:
-                vrf, ip_prefix = key
-            else:
-                vrf = self.DEFAULT_VRF
-                ip_prefix = key
-            af, ip_prefix = IpNextHopSet.get_af_norm_prefix(ip_prefix)
-            nh_attr = lambda k: get_list(entry.get(k, None))
-            self.static_route_list.setdefault(vrf, {})[ip_prefix] = IpNextHopSet(af,
-                                        nh_attr('blackhole'), nh_attr('nexthop'),nh_attr('track'),
-                                        nh_attr('ifname'), nh_attr('tag'), nh_attr('distance'),
-                                        nh_attr('nexthop-vrf'))
+        if self.config_mode == "unified":
+            for key, entry in sroute_table.items():
+                if type(key) is tuple and len(key) == 2:
+                    vrf, ip_prefix = key
+                else:
+                    vrf = self.DEFAULT_VRF
+                    ip_prefix = key
+                af, ip_prefix = IpNextHopSet.get_af_norm_prefix(ip_prefix)
+                nh_attr = lambda k: get_list(entry.get(k, None))
+                self.static_route_list.setdefault(vrf, {})[ip_prefix] = IpNextHopSet(af,
+                                            nh_attr('blackhole'), nh_attr('nexthop'),nh_attr('track'),
+                                            nh_attr('ifname'), nh_attr('tag'), nh_attr('distance'),
+                                            nh_attr('nexthop-vrf'))
 
         self.table_handler_list = [
             ('VRF', self.vrf_handler),
@@ -2258,8 +2259,10 @@ class BGPConfigDaemon:
         syslog.syslog(syslog.LOG_DEBUG, 'Init Cached DB data')
         for key, entry in self.table_data_cache.items():
             syslog.syslog(syslog.LOG_DEBUG, '  %-20s : %s' % (key, entry))
-        if self.config_mode == "unified":
+        if self.config_mode == "unified" or self.config_mode == "split":
             for table, _ in self.table_handler_list:
+                if self.config_mode == "split" and table != "STATIC_ROUTE":
+                    continue
                 table_list = self.config_db.get_table(table)
                 for key, data in table_list.items():
                     syslog.syslog(syslog.LOG_DEBUG, 'config replay for table {} key {}'.format(table, key))


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
If using split mode, configDB doesn't generate anything, and FRR relies on its own files, need to save the FRR configuration.
Through vtysh cmd to add static route for split mode during reboot
#### How I did it
N/A
#### How to verify it
N/A
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

