### PR TITLE
Insert l3_mem_enries and specific to 32K in the bcm config for helix 5 platforms

### DIFF
--- a/device/accton/x86_64-accton_as4630_54npe-r0/Accton-AS4630-54NPE/hx5-as4630-36x2p5G+12x10G+4x25G+2x100G.config.bcm
+++ b/device/accton/x86_64-accton_as4630_54npe-r0/Accton-AS4630-54NPE/hx5-as4630-36x2p5G+12x10G+4x25G+2x100G.config.bcm
@@ -19,7 +19,7 @@ mem_cache_enable=1
 l2_mem_entries=32768
 l3_alpm_enable=2
 ipv6_lpm_128b_enable=1
-#l3_mem_entries=49152
+l3_mem_entries=32768
 #fpem_mem_entries=16384
 l2xmsg_mode=1
 port_flex_enable=1
@@ -146,7 +146,7 @@ portmap_34=34:2.5
 portmap_35=35:2.5
 portmap_36=36:2.5
 
-#3x PM4x25 (3 * 4 --> 12 physical ports) 
+#3x PM4x25 (3 * 4 --> 12 physical ports)
 #FC0
 
 dport_map_port_49=51

--- a/device/accton/x86_64-accton_as4630_54pe-r0/Accton-AS4630-54PE/hx5-as4630-48x1G+4x25G+2x100G_ec.bcm
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/Accton-AS4630-54PE/hx5-as4630-48x1G+4x25G+2x100G_ec.bcm
@@ -16,7 +16,7 @@ parity_enable=0
 mem_cache_enable=1
 
 l2_mem_entries=32768
-#l3_mem_entries=49152
+l3_mem_entries=32768
 #fpem_mem_entries=16384
 l2xmsg_mode=1
 l3_alpm_enable=2

--- a/device/accton/x86_64-accton_as4630_54te-r0/Accton-AS4630-54TE/hx5-as4630-48x1G+4x25G+2x100G_ec.bcm
+++ b/device/accton/x86_64-accton_as4630_54te-r0/Accton-AS4630-54TE/hx5-as4630-48x1G+4x25G+2x100G_ec.bcm
@@ -16,7 +16,7 @@ parity_enable=0
 mem_cache_enable=1
 
 l2_mem_entries=32768
-#l3_mem_entries=49152
+l3_mem_entries=32768
 #fpem_mem_entries=16384
 l2xmsg_mode=1
 l3_alpm_enable=2


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

