### PR TITLE
[FRR][frrcfgd][workaround] Set stopsignal to KILL to force immediate termination

### DIFF
--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -133,6 +133,7 @@ command=/usr/local/bin/frrcfgd
 command=/usr/local/bin/bgpcfgd
 {% endif %}
 priority=6
+stopsignal=KILL
 autostart=false
 autorestart=false
 startsecs=0


### PR DESCRIPTION
#### Why I did it
Modified `frrcfgd` to use `stopsignal=KILL` to ensure immediate termination during container shutdown.
This is a temporary workaround to prevent other services in the BGP container from failing to handle `SIGTERM` properly during shutdown.

#### How I did it
Modified `frrcfgd` and `bgpcfgd` to use `stopsignal=KILL` to ensure immediate termination during container shutdown.

#### How to verify it
Run `sudo systemctl stop bgp` and check the `supervisord` log messages to confirm proper shutdown behavior.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

