### PR TITLE
[Platform][AS9726-32D] Update BRCM config.yml to avoid syncd crash

### DIFF
--- a/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D-100G/td4-as9726-32x100G.config.yml
+++ b/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D-100G/td4-as9726-32x100G.config.yml
@@ -33,7 +33,7 @@ bcm_device:
       vlan_flooding_l2mc_num_reserved: 0
       sai_tunnel_support: 0
       bcm_tunnel_term_compatible_mode: 1
-
+      shared_block_mask_section: uc_bc
 ...
 ---
 bcm_device:

--- a/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D/td4-as9726-32x400G.config.yml
+++ b/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D/td4-as9726-32x400G.config.yml
@@ -33,6 +33,7 @@ bcm_device:
       vlan_flooding_l2mc_num_reserved: 0
       sai_tunnel_support: 0
       bcm_tunnel_term_compatible_mode: 1
+      shared_block_mask_section: uc_bc
 ...
 ---
 bcm_device:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- Device boots up with HwSKU `Accton-AS9726-32D` or `Accton-AS9726-32D-100G` will occur syncd crash and the syslog will see the below messages.
  - `ERR syncd#syncd: [none] SAI_API_ROUTER_INTERFACE:_brcm_sai_block_flood_port_vlan:651 vlan block mask set failed with error Invalid parameter (0xfffffffc).`
  - `ERR syncd#syncd: [none] SAI_API_ROUTER_INTERFACE:_brcm_sai_xgs_add_router_port_vlan:2163 _brcm_sai_block_flood_port_vlan 41 set failed with error -5.`
  - `ERR syncd#syncd: [none] SAI_API_ROUTER_INTERFACE:_brcm_sai_xgs_create_port_router_interface:3636 Port RIF add router port vlan failed with error -5.`
  - `ERR syncd#syncd: [none] SAI_API_ROUTER_INTERFACE:_brcm_sai_xgs_create_port_router_interface:3741 Port/LAG Router Interface Create Failed for port:41 lag:no rv:-5`
  - `ERR syncd#syncd: [none] SAI_API_ROUTER_INTERFACE:brcm_sai_xgs_create_router_interface:5206 Error in create router interface failed with error -5.`
  - `ERR syncd#syncd: [none] SAI_API_ROUTER_INTERFACE:brcm_sai_create_router_interface:529 pd router intf create failed with error -5.`
  - `ERR syncd#syncd: [none] SAI_API_ROUTER_INTERFACE:brcm_sai_create_router_interface:558 Router Interface Create Failed rv:-5`
  - `ERR syncd#syncd: [none] SAI_API_ROUTER_INTERFACE:brcm_sai_router_interface_create_err_cleanup:7366 RIF Create failed: rif_id:0 type:0 vrf:0 port-lag-id:41 lag:no vlan:4095 virtual:no`
  - `ERR syncd#syncd: :- sendApiResponse: api SAI_COMMON_API_CREATE failed in syncd mode: SAI_STATUS_INVALID_PARAMETER`



#### How I did it
- Add the SDK configuration `shared_block_mask_section: uc_bc`, referring to the community branch 202411 BRCM TD4 settings.
  - device/broadcom/x86_64-broadcom_common/x86_64-broadcom_b78/broadcom-sonic-td4.config.bcm
  - device/broadcom/x86_64-broadcom_common/x86_64-broadcom_b88/broadcom-sonic-td4.config.bcm

#### How to verify it
- Container syncd can work normally for all HwSKUs.
  - docker ps -a --filter='name=syncd'
- The above mentioned error messages cannot exist in syslog.
  - sudo cat /var/log/syslog

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

