### PR TITLE
Fix SNMP bug

### DIFF
--- a/dockers/docker-snmp/snmp_yml_to_configdb.py
+++ b/dockers/docker-snmp/snmp_yml_to_configdb.py
@@ -17,6 +17,8 @@ logger.set_min_log_priority_info()
 
 snmp_comm_config_db = db.get_table('SNMP_COMMUNITY')
 snmp_config_db_communities = snmp_comm_config_db.keys()
+snmp_user_config_db = db.get_table('SNMP_USER')
+snmp_config_db_users = snmp_user_config_db.keys()
 snmp_general_config_db = db.get_table('SNMP')
 snmp_general_keys = snmp_general_config_db.keys()
 
@@ -29,24 +31,25 @@ if not os.path.exists('/etc/sonic/snmp.yml'):
 with open('/etc/sonic/snmp.yml', 'r') as yaml_file:
     yaml_snmp_info = yaml.load(yaml_file, Loader=yaml.FullLoader)
 
-for comm_type in full_snmp_comm_list:
-    if comm_type in yaml_snmp_info.keys():
-        if comm_type.startswith('snmp_rocommunities'):
-            for community in yaml_snmp_info[comm_type]:
+if len(snmp_config_db_communities) == 0 and len(snmp_config_db_users) == 0:
+    for comm_type in full_snmp_comm_list:
+        if comm_type in yaml_snmp_info.keys():
+            if comm_type.startswith('snmp_rocommunities'):
+                for community in yaml_snmp_info[comm_type]:
+                    if community not in snmp_config_db_communities:
+                        db.set_entry('SNMP_COMMUNITY', community, {"TYPE": "RO"})
+            elif comm_type.startswith('snmp_rocommunity'):
+                community = yaml_snmp_info['snmp_rocommunity']
                 if community not in snmp_config_db_communities:
                     db.set_entry('SNMP_COMMUNITY', community, {"TYPE": "RO"})
-        elif comm_type.startswith('snmp_rocommunity'):
-            community = yaml_snmp_info['snmp_rocommunity']
-            if community not in snmp_config_db_communities:
-                db.set_entry('SNMP_COMMUNITY', community, {"TYPE": "RO"})
-        elif comm_type.startswith('snmp_rwcommunities'):
-            for community in yaml_snmp_info[comm_type]:
+            elif comm_type.startswith('snmp_rwcommunities'):
+                for community in yaml_snmp_info[comm_type]:
+                    if community not in snmp_config_db_communities:
+                        db.set_entry('SNMP_COMMUNITY', community, {"TYPE": "RW"})
+            elif comm_type.startswith('snmp_rwcommunity'):
+                community = yaml_snmp_info['snmp_rwcommunity']
                 if community not in snmp_config_db_communities:
                     db.set_entry('SNMP_COMMUNITY', community, {"TYPE": "RW"})
-        elif comm_type.startswith('snmp_rwcommunity'):
-            community = yaml_snmp_info['snmp_rwcommunity']
-            if community not in snmp_config_db_communities:
-                db.set_entry('SNMP_COMMUNITY', community, {"TYPE": "RW"})
 
 if yaml_snmp_info.get('snmp_location'):
     if 'LOCATION' not in snmp_general_keys:

--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -99,6 +99,52 @@ sysContact     Azure Cloud Switch vteam <linuxnetdev@microsoft.com>
                                                  # Application + End-to-End layers
 sysServices    72
 
+{% if DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_as4630_54pe-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.1
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_as4630_54npe-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.2
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_as4630_54te-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.3
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_as5835_54x-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.4
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_as5835_54t-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.5
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_as7326_56x-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.6
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_as7726_32x-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.7
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_as7816_64x-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.8
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_minipack-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.9
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_as9716_32d-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.10
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_wedge100bf_32x-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.11
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_as5835im-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.12
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_wedge100bf_32qs-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.13
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_wedge100bf_65x-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.14
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_as5812_54x-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.15
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_as7712_32x-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.16
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_as9726_32d-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.17
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_as9736_64d-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.18
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_as9737_32db-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.23
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_as9817_64d-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.24
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_as9817_64o-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.25
+{% elif DEVICE_METADATA['localhost']['platform'] == "x86_64-accton_as9817_64fk-r0" %}
+sysObjectID    1.3.6.1.4.1.259.11.1.1.1.26
+{% endif %}
+
 
 #
 #  Process Monitoring
@@ -147,7 +193,7 @@ load   12 10 5
 {% set v1SnmpTrapPort = SNMP_TRAP_CONFIG['v1TrapDest']['DestPort'] %}
 {% set v1SnmpTrapVrf = SNMP_TRAP_CONFIG['v1TrapDest']['vrf'] %}
 {% set v1SnmpTrapComm = SNMP_TRAP_CONFIG['v1TrapDest']['Community'] %}
-trapsink {{ v1SnmpTrapIp }}:{{ v1SnmpTrapPort }}{% if v1SnmpTrapVrf != 'None' %}%{{ v1SnmpTrapVrf }}{% endif %} {{ v1SnmpTrapComm }}{{ "" }}
+trapsink [{{ v1SnmpTrapIp }}]:{{ v1SnmpTrapPort }}{% if v1SnmpTrapVrf != 'None' %}%{{ v1SnmpTrapVrf }}{% endif %} {{ v1SnmpTrapComm }}{{ "" }}
 {% else %}
 #trapsink     localhost public
 {% endif %}
@@ -157,7 +203,7 @@ trapsink {{ v1SnmpTrapIp }}:{{ v1SnmpTrapPort }}{% if v1SnmpTrapVrf != 'None' %}
 {% set v2SnmpTrapPort = SNMP_TRAP_CONFIG['v2TrapDest']['DestPort'] %}
 {% set v2SnmpTrapVrf = SNMP_TRAP_CONFIG['v2TrapDest']['vrf'] %}
 {% set v2SnmpTrapComm = SNMP_TRAP_CONFIG['v2TrapDest']['Community'] %}
-trap2sink {{ v2SnmpTrapIp }}:{{ v2SnmpTrapPort }}{% if v2SnmpTrapVrf != 'None' %}%{{ v2SnmpTrapVrf }}{% endif %} {{ v2SnmpTrapComm }}{{ "" }}
+trap2sink [{{ v2SnmpTrapIp }}]:{{ v2SnmpTrapPort }}{% if v2SnmpTrapVrf != 'None' %}%{{ v2SnmpTrapVrf }}{% endif %} {{ v2SnmpTrapComm }}{{ "" }}
 {% else %}
 #trap2sink    localhost public
 {% endif %}
@@ -167,7 +213,7 @@ trap2sink {{ v2SnmpTrapIp }}:{{ v2SnmpTrapPort }}{% if v2SnmpTrapVrf != 'None' %
 {% set v3SnmpTrapPort = SNMP_TRAP_CONFIG['v3TrapDest']['DestPort'] %}
 {% set v3SnmpTrapVrf = SNMP_TRAP_CONFIG['v3TrapDest']['vrf'] %}
 {% set v3SnmpTrapComm = SNMP_TRAP_CONFIG['v3TrapDest']['Community'] %}
-trapsink {{ v3SnmpTrapIp }}:{{ v3SnmpTrapPort }}{% if v3SnmpTrapVrf != 'None' %}%{{ v3SnmpTrapVrf }}{% endif %} {{ v3SnmpTrapComm }}{{ "" }}
+trapsink [{{ v3SnmpTrapIp }}]:{{ v3SnmpTrapPort }}{% if v3SnmpTrapVrf != 'None' %}%{{ v3SnmpTrapVrf }}{% endif %} {{ v3SnmpTrapComm }}{{ "" }}
 {% else %}
 #informsink   localhost public
 {% endif %}

--- a/dockers/docker-snmp/supervisord.conf
+++ b/dockers/docker-snmp/supervisord.conf
@@ -40,7 +40,7 @@ dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 
 [program:snmpd]
-command=/usr/sbin/snmpd -f -LS0-2d -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf,ifTable,ifXTable,inetCidrRouteTable,ipCidrRouteTable,ip,disk_hw -p /run/snmpd.pid
+command=/usr/sbin/snmpd -C -c /etc/snmp/snmpd.conf -f -LS0-2d -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf,ifTable,ifXTable,inetCidrRouteTable,ipCidrRouteTable,ip,disk_hw -p /run/snmpd.pid
 priority=3
 autostart=false
 autorestart=false


### PR DESCRIPTION
#### Why I did it
Bug fix
* Fix SNMP IPv6 trap cannot be sent out.
* SNMPv3 authentication failure.
* Sync code to add all product model sysObjectID
* Request to disable SNMPv2.

#### How I did it
* net-snmp v5.9 has changed the interpretation logic of IP + trap port settings. Use [ ] to wrap the IP address to ensure that there will be no interpretation errors.
* Add option -C -c /etc/snmp/snmpd.conf in snmpd docker start, this will specify snmpd only use /etc/snmp/snmpd.conf which comes from sonic.
* Add the sysObjectID by Edge-Core definition.
* Add a checking when snmp config the community or user. If there do not has any community or user in config, it will automatically add the default community in snmp.yml
