### PR TITLE
Remove gwaddr restriction for Breakout config

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-mgmt_interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mgmt_interface.yang
@@ -41,7 +41,7 @@ module sonic-mgmt_interface {
                 }
 
                 leaf ip_prefix {
-                    must "(contains(current(), ':') and contains(../gwaddr, ':')) or (contains(current(), '.') and contains(../gwaddr, '.'))";
+                    must "(contains(current(), ':')) or (contains(current(), '.'))";
                     type stypes:sonic-ip-prefix;
                 }
 


### PR DESCRIPTION
This commit removes the mandatory requirement for gwaddr in the MGMT_INTERFACE 
configuration. The previous validation enforced that gwaddr must exist and its 
format (IPv4/IPv6) must match the ip_prefix format.

The new validation only checks that ip_prefix is in a valid IPv4 or IPv6 format,
without requiring gwaddr to be present. This change enables more flexible 
Breakout configurations where gateway address might not be needed.