### PR TITLE
Escape spaces in SNMP community string

### DIFF
--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -48,8 +48,8 @@ view   systemonly  included   .1.3.6.1.2.1.25.1
 {% if SNMP_COMMUNITY is defined %}
 {% for community in SNMP_COMMUNITY %}
 {% if SNMP_COMMUNITY[community]['TYPE'] == 'RO' %}
-rocommunity {{ community }}
-rocommunity6 {{ community }}
+rocommunity {{ community|replace(" ", "\\ ") }}
+rocommunity6 {{ community|replace(" ", "\\ ") }}
 {% endif %}
 {% endfor %}
 {% endif %}
@@ -57,8 +57,8 @@ rocommunity6 {{ community }}
 {% if SNMP_COMMUNITY is defined %}
 {% for community in SNMP_COMMUNITY %}
 {% if SNMP_COMMUNITY[community]['TYPE'] == 'RW' %}
-rwcommunity {{ community }}
-rwcommunity6 {{ community }}
+rwcommunity {{ community|replace(" ", "\\ ") }}
+rwcommunity6 {{ community|replace(" ", "\\ ") }}
 {% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Fix SNMP configuration to properly handle community strings containing spaces.
Previously, when configuring a community string with spaces like:
  `sudo config snmp community add "ropassword 192.168.1.0/24" RO`
and then trying to use it with:
  `snmpwalk -v 2c -c "ropassword 192.168.1.0/24" 192.168.6.41 .1`
the operation would fail as the spaces in community string were not properly escaped.

This change adds escape sequences for spaces in both read-only and read-write
community strings, ensuring proper configuration generation and functionality.
