### PR TITLE
[ZTP] Do dhcp discovery regardless profile status

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -31,7 +31,7 @@ iface lo inet loopback
 {% block mgmt_interface %}
 
 # The management network interface
-{% if (ZTP_DHCP_DISABLED is not defined) and (ZTP is defined) and (ZTP['mode'] is defined and ZTP['mode']['profile'] == 'active') %}
+{% if (ZTP_DHCP_DISABLED is not defined) and (ZTP is defined) and (ZTP['mode'] is defined) %}
 auto eth0
 
 


### PR DESCRIPTION
**Why I did it**
After sonic-ztp: [ZTP] Use config db instead of ZTP configuration profile
this is required for dhcp discovery

**How I did it**
- Do dhcp discovery regardless profile status
- Requires PR (https://github.com/edge-core/sonic-ztp/pull/4) for full functionality.

**How I verified it**
1. Modify etc/default/ztp to use USE_DEFAULT_CONFIG="no"
2. Config breakout for port and enable link up.
3. config save
4. 'ztp run' to start ZTP.
5. breakout port should be 'Link up detected' and ZTP should start to downloading provisioning data from the port.