### PR TITLE
[Dhcp Relay] Support IPv6 linklocal and enlarge alias size

### DIFF
--- a/dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2
@@ -21,8 +21,31 @@ command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /t
 {% for (name, prefix) in INTERFACE|pfx_filter %}
 {% if prefix | ipv4 %} -iu {{ name }}{% endif -%}
 {% endfor %}
-{% for (name, prefix) in PORTCHANNEL_INTERFACE|pfx_filter %}
-{% if prefix | ipv4 %} -iu {{ name }}{% endif -%}
+{% for port in PORT %}
+{% set portchannel_member = namespace(found=false) %}
+{% set vlan_member = namespace(found=false) %}
+{% for key in PORTCHANNEL_MEMBER %}
+{% if key[1] == port %}
+{% set portchannel_member.found = true %}
+{% endif %}
+{% endfor %}
+{% for key in VLAN_MEMBER %}
+{% if key[1] == port %}
+{% set vlan_member.found = true %}
+{% endif %}
+{% endfor %}
+{% if not portchannel_member.found %}
+{% if not vlan_member.found %} -iu {{ port }}{% endif -%}
+{% endif %}
+{% endfor %}
+{% for port in PORTCHANNEL %}
+{% set vlan_member = namespace(found=false) %}
+{% for key in VLAN_MEMBER %}
+{% if key[1] == port %}
+{% set vlan_member.found = true %}
+{% endif %}
+{% endfor %}
+{% if not vlan_member.found %} -iu {{ port }}{% endif -%}
 {% endfor %}
 {% for (name, gateway) in VLAN_INTERFACE|get_primary_addr %}
 {% if gateway | ipv4 and name == vlan_name %} -pg {{ gateway }}{% endif -%}

--- a/src/isc-dhcp/patch/0017-Support-for-interfaces-with-IPv6-linklocal.patch
+++ b/src/isc-dhcp/patch/0017-Support-for-interfaces-with-IPv6-linklocal.patch
@@ -1,0 +1,41 @@
+From d931d0b4db0e513289bf573d4a23f5ed57afbf8a Mon Sep 17 00:00:00 2001
+From: irene_pan <irene_pan@edge-core.com>
+Date: Mon, 28 Oct 2024 08:15:54 +0000
+Subject: [PATCH] Support for interfaces with IPv6 linklocal
+
+---
+ relay/dhcrelay.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/relay/dhcrelay.c b/relay/dhcrelay.c
+index 31fe61b..fa7ff78 100644
+--- a/relay/dhcrelay.c
++++ b/relay/dhcrelay.c
+@@ -947,11 +947,6 @@ do_relay4(struct interface_info *ip, struct dhcp_packet *packet,
+ 			 "%s interface.", ip->name);
+ 		return;
+ 	}
+-	if (ip->address_count < 1 || ip->addresses == NULL) {
+-		log_info("Discarding packet received on %s interface that "
+-			 "has no IPv4 address assigned.", ip->name);
+-		return;
+-	}
+ 
+ 	if (enable_support_for_dual_tor) {
+ 		if (packet->yiaddr.s_addr) {
+@@ -1081,6 +1076,12 @@ do_relay4(struct interface_info *ip, struct dhcp_packet *packet,
+ 	if (!(ip->flags & INTERFACE_REQUESTED))
+ 		return;
+ 
++	if (ip->address_count < 1 || ip->addresses == NULL) {
++		log_info("Discarding packet received on %s interface that "
++		         "has no IPv4 address assigned.", ip->name);
++		return;
++	}
++
+ 	/* Add relay agent options if indicated.   If something goes wrong,
+ 	 * drop the packet.  Note this may set packet->giaddr if RFC3527
+ 	 * is enabled. */
+-- 
+2.47.0
+

--- a/src/isc-dhcp/patch/0018-Enlarge-alias-size-to-be-equal-to-the-def-of-linux.patch
+++ b/src/isc-dhcp/patch/0018-Enlarge-alias-size-to-be-equal-to-the-def-of-linux.patch
@@ -1,0 +1,78 @@
+From 550c41334eca79c9900c9e22c5ca3e686e391c52 Mon Sep 17 00:00:00 2001
+From: irene_pan <irene_pan@edge-core.com>
+Date: Mon, 28 Oct 2024 08:49:20 +0000
+Subject: [PATCH] Enlarge alias size to be equal to the def of linux
+
+---
+ relay/dhcrelay.c | 19 +++++++++++++------
+ 1 file changed, 13 insertions(+), 6 deletions(-)
+
+diff --git a/relay/dhcrelay.c b/relay/dhcrelay.c
+index fa7ff78..94ce67d 100644
+--- a/relay/dhcrelay.c
++++ b/relay/dhcrelay.c
+@@ -144,9 +144,16 @@ static void setup_streams(void);
+ char *dhcrelay_sub_id = NULL;
+ #endif
+ 
++/* * The IFALIASZ value 256 is referred from the linux/if.h
++ *   https://github.com/torvalds/linux/blob/master/include/uapi/linux/if.h#L35
++ */
++#ifndef IFALIASZ
++#define IFALIASZ        256
++#endif
++
+ struct interface_name_alias_tuple {
+ 	char if_name[IFNAMSIZ];
+-	char if_alias[IFNAMSIZ];
++	char if_alias[IFALIASZ];
+ };
+ 
+ static struct interface_name_alias_tuple *g_interface_name_alias_map = NULL;
+@@ -1445,6 +1452,7 @@ format_relay_agent_rfc3046_msg(const struct interface_info *ip, struct dhcp_pack
+ 	size_t len = 0;
+ 	char hostname[HOST_NAME_MAX] = { 0 };
+ 	char ifname[IFNAMSIZ] = { 0 };
++	char ifalias[IFALIASZ] = { 0 };
+ 	char *buf = msg;
+ 
+ 	for ( ; format && *format && len < msgn; ++format) {
+@@ -1474,7 +1482,7 @@ format_relay_agent_rfc3046_msg(const struct interface_info *ip, struct dhcp_pack
+ 					*/
+ 					if (packet->htype && !packet->giaddr.s_addr) {
+ 						int ret = 0, vlanid = 0;
+-						char ifalias[IFNAMSIZ] = { 0 };
++						memset(ifalias, 0, IFALIASZ);
+ 
+ 						ret = _bridgefdbquery(print_hw_addr(packet->htype, packet->hlen, packet->chaddr),
+ 											  ifname,
+@@ -1495,15 +1503,14 @@ format_relay_agent_rfc3046_msg(const struct interface_info *ip, struct dhcp_pack
+ 						ret = get_interface_alias_by_name(ifname, ifalias);
+ 						if (ret < 0) {
+ 							//log_debug("Failed to retrieve alias for interface name '%s'. Defaulting to interface name.", ifname);
++							str = ifname;
+ 						}
+ 						else {
+ 							//log_debug("Mapped interface name '%s' to alias '%s'. Adding as option 82 interface alias for MAC Address %s",
+ 							//		  ifname, ifalias, print_hw_addr (packet->htype, packet->hlen, packet->chaddr));
+ 
+-							strncpy(ifname, ifalias, IFNAMSIZ);
++							str = ifalias;
+ 						}
+-
+-						str = ifname;
+ 					}
+ 				break;
+ 
+@@ -2600,7 +2607,7 @@ get_interface_alias_by_name(const char *if_name, char *if_alias_out) {
+ 
+ 	for (i = 0; i < g_interface_name_alias_map_size; i++) {
+ 		if (strncmp(if_name, g_interface_name_alias_map[i].if_name, IFNAMSIZ) == 0) {
+-			strncpy(if_alias_out, g_interface_name_alias_map[i].if_alias, IFNAMSIZ);
++			strncpy(if_alias_out, g_interface_name_alias_map[i].if_alias, IFALIASZ);
+ 			return 0;
+ 		}
+ 	}
+-- 
+2.47.0
+

--- a/src/isc-dhcp/patch/series
+++ b/src/isc-dhcp/patch/series
@@ -15,3 +15,5 @@
 0014-enable-parallel-build.patch
 0015-option-to-set-primary-address-in-interface.patch
 0016-Don-t-look-up-the-ifindex-for-fallback.patch
+0017-Support-for-interfaces-with-IPv6-linklocal.patch
+0018-Enlarge-alias-size-to-be-equal-to-the-def-of-linux.patch

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-no-ip-helper.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-no-ip-helper.supervisord.conf
@@ -43,7 +43,7 @@ dependent_startup_wait_for=rsyslogd:running
 programs=dhcprelayd,dhcp6relay
 
 [program:isc-dhcpv4-relay-Vlan1000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 192.0.0.1 192.0.0.2
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu Ethernet0 -iu Ethernet108 -iu Ethernet104 -iu PortChannel02 -iu PortChannel04 192.0.0.1 192.0.0.2
 priority=3
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
@@ -43,7 +43,7 @@ dependent_startup_wait_for=rsyslogd:running
 programs=dhcprelayd,dhcp6relay
 
 [program:isc-dhcpv4-relay-Vlan1000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 192.0.0.1 192.0.0.2
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu Ethernet0 -iu Ethernet108 -iu Ethernet104 -iu PortChannel02 -iu PortChannel04 192.0.0.1 192.0.0.2
 priority=3
 autostart=false
 autorestart=false
@@ -53,7 +53,7 @@ dependent_startup=true
 dependent_startup_wait_for=start:exited
 
 [program:isc-dhcpv4-relay-Vlan2000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan2000 -iu Vlan1000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 192.0.0.3 192.0.0.4
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan2000 -iu Vlan1000 -iu Ethernet0 -iu Ethernet108 -iu Ethernet104 -iu PortChannel02 -iu PortChannel04 192.0.0.3 192.0.0.4
 priority=3
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-no-ip-helper.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-no-ip-helper.supervisord.conf
@@ -43,7 +43,7 @@ dependent_startup_wait_for=rsyslogd:running
 programs=dhcprelayd,dhcp6relay
 
 [program:isc-dhcpv4-relay-Vlan1000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 192.0.0.1 192.0.0.2
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu Ethernet0 -iu Ethernet104 -iu Ethernet108 -iu PortChannel02 -iu PortChannel04 192.0.0.1 192.0.0.2
 priority=3
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
@@ -43,7 +43,7 @@ dependent_startup_wait_for=rsyslogd:running
 programs=dhcprelayd,dhcp6relay
 
 [program:isc-dhcpv4-relay-Vlan1000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 192.0.0.1 192.0.0.2
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu Ethernet0 -iu Ethernet104 -iu Ethernet108 -iu PortChannel02 -iu PortChannel04 192.0.0.1 192.0.0.2
 priority=3
 autostart=false
 autorestart=false
@@ -53,7 +53,7 @@ dependent_startup=true
 dependent_startup_wait_for=start:exited
 
 [program:isc-dhcpv4-relay-Vlan2000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan2000 -iu Vlan1000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 192.0.0.3 192.0.0.4
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan2000 -iu Vlan1000 -iu Ethernet0 -iu Ethernet104 -iu Ethernet108 -iu PortChannel02 -iu PortChannel04 192.0.0.3 192.0.0.4
 priority=3
 autostart=false
 autorestart=false


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
* Support IPv6 linklocal for BGP unnumbered
* Enlarge alias size to be equal to the definition of linux source
#### How I did it
N/A
#### How to verify it
N/A
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

