### PR TITLE
Fix ndppd occupy high CPU usage issue

### DIFF
--- a/dockers/docker-orchagent/ndppd.conf.j2
+++ b/dockers/docker-orchagent/ndppd.conf.j2
@@ -6,6 +6,7 @@
 {% endblock banner %}
 # Config file for ndppd, the NDP Proxy Daemon
 # See man page for ndppd.conf.5 for descriptions of all available options
+route-ttl 2147483647
 {%  if VLAN_INTERFACE and VLAN_INTERFACE|pfx_filter|length > 0%}
 {#      Get all VLAN interfaces that have proxy_arp enabled #}
 {%      set proxy_interfaces = {} %}
@@ -21,7 +22,7 @@
 {%              set _x = proxy_interfaces[intf].append(prefix) %}
 {%          endif %}
 {%      endfor -%}
-route-ttl 2147483647
+
 {%      for intf, prefix_list in proxy_interfaces.items() %}
 {%          if prefix_list %}
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Refer to the PR https://github.com/Azure/sonic-buildimage/pull/7456, set the ndppd interval to a largest value can prevent it from frequently access route table. However, the route-ttl which is putted inside the if-block of the template won't exists inside the swss container.

#### How I did it
Move the setting out of the if-block to make it generate every time.
