### PR TITLE
[Dhcp Relay] No need to wait forever for the interface to be ready and require IP

### DIFF
--- a/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
@@ -1,19 +1,11 @@
 [group:dhcpmon]
 programs=
 {%- set add_preceding_comma = { 'flag': False } %}
-{% set monitor_instance = { 'flag': False } %}
 {% for vlan_name in VLAN_INTERFACE %}
-{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
-{% set _dummy = monitor_instance.update({'flag': True}) %}
-{%- endif %}
-{% if DHCP_RELAY and vlan_name in DHCP_RELAY and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
-{% set _dummy = monitor_instance.update({'flag': True}) %}
-{%- endif %}
-{% if monitor_instance.flag %}
+{% if vlan_name in ipv4_vlan_interfaces or vlan_name in ipv6_vlan_interfaces %}
 {% if add_preceding_comma.flag %},{% endif %}
 {% set _dummy = add_preceding_comma.update({'flag': True}) %}
 dhcpmon-{{ vlan_name }}
-{%- set _dummy = monitor_instance.update({'flag': False}) %}
 {%- endif %}
 {% endfor %}
 
@@ -23,20 +15,12 @@ dhcpmon-{{ vlan_name }}
 {% set relay_for_ipv6 = { 'flag': False } %}
 {% for vlan_name in VLAN_INTERFACE %}
 {# Check DHCPv4 agents #}
-{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
-{% for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
-{% if dhcp_server | ipv4 %}
+{% if vlan_name in ipv4_vlan_interfaces %}
 {% set _dummy = relay_for_ipv4.update({'flag': True}) %}
 {% endif %}
-{% endfor %}
-{% endif %}
 {# Check DHCPv6 agents #}
-{% if DHCP_RELAY and vlan_name in DHCP_RELAY and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
-{% for dhcpv6_server in DHCP_RELAY[vlan_name]['dhcpv6_servers'] %}
-{% if dhcpv6_server | ipv6 %}
+{% if vlan_name in ipv6_vlan_interfaces %}
 {% set _dummy = relay_for_ipv6.update({'flag': True}) %}
-{% endif %}
-{% endfor %}
 {% endif %}
 {% if relay_for_ipv4.flag or relay_for_ipv6.flag %}
 [program:dhcpmon-{{ vlan_name }}]

--- a/dockers/docker-dhcp-relay/dhcp-relay.programs.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.programs.j2
@@ -3,7 +3,7 @@ programs=dhcprelayd
 {%- set relay_for_ipv6 = { 'flag': False } %}
 {%- set add_preceding_comma = { 'flag': True } %}
 {% for vlan_name in VLAN_INTERFACE %}
-{% if DHCP_RELAY and vlan_name in DHCP_RELAY and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
+{% if vlan_name in ipv6_vlan_interfaces %}
 {% set _dummy = relay_for_ipv6.update({'flag': True})  %}
 {%- endif %}
 {% endfor %}

--- a/dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2
@@ -1,12 +1,5 @@
 {# Append DHCPv4 agents #}
-{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
-{% for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
-{% if dhcp_server | ipv4 %}
-{% set _dummy = relay_for_ipv4.update({'flag': True}) %}
-{% endif %}
-{% endfor %}
-{% if relay_for_ipv4.flag %}
-{% set _dummy = relay_for_ipv4.update({'flag': False}) %}
+{% if vlan_name in ipv4_vlan_interfaces %}
 [program:isc-dhcpv4-relay-{{ vlan_name }}]
 {# We treat this VLAN as a downstream interface (-id), as we only want to listen for requests #}
 command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id {{ vlan_name }}
@@ -21,8 +14,31 @@ command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /t
 {% for (name, prefix) in INTERFACE|pfx_filter %}
 {% if prefix | ipv4 %} -iu {{ name }}{% endif -%}
 {% endfor %}
-{% for (name, prefix) in PORTCHANNEL_INTERFACE|pfx_filter %}
-{% if prefix | ipv4 %} -iu {{ name }}{% endif -%}
+{% for port in PORT %}
+{% set portchannel_member = namespace(found=false) %}
+{% set vlan_member = namespace(found=false) %}
+{% for key in PORTCHANNEL_MEMBER %}
+{% if key[1] == port %}
+{% set portchannel_member.found = true %}
+{% endif %}
+{% endfor %}
+{% for key in VLAN_MEMBER %}
+{% if key[1] == port %}
+{% set vlan_member.found = true %}
+{% endif %}
+{% endfor %}
+{% if not portchannel_member.found %}
+{% if not vlan_member.found %} -iu {{ port }}{% endif -%}
+{% endif %}
+{% endfor %}
+{% for port in PORTCHANNEL %}
+{% set vlan_member = namespace(found=false) %}
+{% for key in VLAN_MEMBER %}
+{% if key[1] == port %}
+{% set vlan_member.found = true %}
+{% endif %}
+{% endfor %}
+{% if not vlan_member.found %} -iu {{ port }}{% endif -%}
 {% endfor %}
 {% for (name, gateway) in VLAN_INTERFACE|get_primary_addr %}
 {% if gateway | ipv4 and name == vlan_name %} -pg {{ gateway }}{% endif -%}
@@ -39,5 +55,4 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=start:exited
 
-{% endif %}
 {% endif %}

--- a/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
@@ -1,11 +1,7 @@
 {# Append DHCPv6 agents #}
 {% for vlan_name in VLAN_INTERFACE %}
-{% if DHCP_RELAY and vlan_name in DHCP_RELAY and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
-{% for dhcpv6_server in DHCP_RELAY[vlan_name]['dhcpv6_servers'] %}
-{% if dhcpv6_server | ipv6 %}
+{% if vlan_name in ipv6_vlan_interfaces %}
 {% set _dummy = relay_for_ipv6.update({'flag': True}) %}
-{% endif %}
-{% endfor %}
 {% endif %}
 {% endfor %}
 {% if relay_for_ipv6.flag %}

--- a/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
+++ b/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
@@ -42,18 +42,22 @@ dependent_startup_wait_for=rsyslogd:running
 {# If our configuration has VLANs... #}
 {% if VLAN_INTERFACE %}
 {# Count how many VLANs require a DHCP relay agent... #}
-{% set ipv4_num_relays = { 'count': 0 } %}
-{% set ipv6_num_relays = { 'count': 0 } %}
-{% for vlan_name in VLAN_INTERFACE %}
+{% set ipv4_vlan_interfaces = [] %}
+{% set ipv6_vlan_interfaces = [] %}
+{% for (vlan_name, prefix) in VLAN_INTERFACE|pfx_filter %}
+{% if prefix | ipv4 and vlan_name not in ipv4_vlan_interfaces %}
 {% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
-{% set _dummy = ipv4_num_relays.update({'count': ipv4_num_relays.count + 1}) %}
+{% set ipv4_vlan_interfaces = ipv4_vlan_interfaces.append(vlan_name) %}
 {% endif %}
+{% endif %}
+{% if prefix | ipv6 and vlan_name not in ipv6_vlan_interfaces %}
 {% if DHCP_RELAY and vlan_name in DHCP_RELAY and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
-{% set _dummy = ipv6_num_relays.update({'count': ipv6_num_relays.count + 1}) %}
+{% set ipv6_vlan_interfaces = ipv6_vlan_interfaces.append(vlan_name) %}
+{% endif %}
 {% endif %}
 {% endfor %}
 {# If one or more of the VLANs require a DHCP relay agent... #}
-{% if ipv4_num_relays.count > 0 or ipv6_num_relays.count > 0 %}
+{% if ipv4_vlan_interfaces|length > 0 or ipv6_vlan_interfaces|length > 0 %}
 {% include 'dhcp-relay.programs.j2' %}
 
 {# Create a program entry for each DHCP relay agent instance #}

--- a/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
+++ b/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
@@ -4,6 +4,7 @@ function wait_until_iface_ready
 {
     IFACE_NAME=$1
     IFACE_CIDR=$2
+    COUNT=${3:-600}
 
     echo "Waiting until interface ${IFACE_NAME} is ready..."
 
@@ -12,13 +13,16 @@ function wait_until_iface_ready
     while true; do
         RESULT=$(sonic-db-cli STATE_DB HGET "INTERFACE_TABLE|${IFACE_NAME}|${IFACE_CIDR}" "state" 2> /dev/null)
         if [ x"$RESULT" == x"ok" ]; then
+            echo "Interface ${IFACE_NAME} is ready!"
             break
         fi
-
+        if [ $COUNT == 0 ]; then
+            echo "Interface ${IFACE_NAME} is not ready!"
+            break
+        fi
         sleep 1
+        COUNT=$((COUNT-1))
     done
-
-    echo "Interface ${IFACE_NAME} is ready!"
 }
 
 function check_for_ipv6_link_local

--- a/src/sonic-config-engine/tests/sample_output/py2/wait_for_intf.sh
+++ b/src/sonic-config-engine/tests/sample_output/py2/wait_for_intf.sh
@@ -4,6 +4,7 @@ function wait_until_iface_ready
 {
     IFACE_NAME=$1
     IFACE_CIDR=$2
+    COUNT=${3:-600}
 
     echo "Waiting until interface ${IFACE_NAME} is ready..."
 
@@ -12,13 +13,16 @@ function wait_until_iface_ready
     while true; do
         RESULT=$(sonic-db-cli STATE_DB HGET "INTERFACE_TABLE|${IFACE_NAME}|${IFACE_CIDR}" "state" 2> /dev/null)
         if [ x"$RESULT" == x"ok" ]; then
+            echo "Interface ${IFACE_NAME} is ready!"
             break
         fi
-
+        if [ $COUNT == 0 ]; then
+            echo "Interface ${IFACE_NAME} is not ready!"
+            break
+        fi
         sleep 1
+        COUNT=$((COUNT-1))
     done
-
-    echo "Interface ${IFACE_NAME} is ready!"
 }
 
 function check_for_ipv6_link_local

--- a/src/sonic-config-engine/tests/sample_output/py3/wait_for_intf.sh
+++ b/src/sonic-config-engine/tests/sample_output/py3/wait_for_intf.sh
@@ -4,6 +4,7 @@ function wait_until_iface_ready
 {
     IFACE_NAME=$1
     IFACE_CIDR=$2
+    COUNT=${3:-600}
 
     echo "Waiting until interface ${IFACE_NAME} is ready..."
 
@@ -12,13 +13,16 @@ function wait_until_iface_ready
     while true; do
         RESULT=$(sonic-db-cli STATE_DB HGET "INTERFACE_TABLE|${IFACE_NAME}|${IFACE_CIDR}" "state" 2> /dev/null)
         if [ x"$RESULT" == x"ok" ]; then
+            echo "Interface ${IFACE_NAME} is ready!"
             break
         fi
-
+        if [ $COUNT == 0 ]; then
+            echo "Interface ${IFACE_NAME} is not ready!"
+            break
+        fi
         sleep 1
+        COUNT=$((COUNT-1))
     done
-
-    echo "Interface ${IFACE_NAME} is ready!"
 }
 
 function check_for_ipv6_link_local

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -160,14 +160,14 @@ class TestJ2Files(TestCase):
         self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR, 'wait_for_intf.sh'), self.output_file))
 
         template_path = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-dhcp-relay', 'docker-dhcp-relay.supervisord.conf.j2')
-        argument = ['-m', self.t0_minigraph, '-p', self.t0_port_config, '-t', template_path]
+        argument = ['-m', self.t0_minigraph, '-j', dhc_sample_data, '-p', self.t0_port_config, '-t', template_path]
         self.run_script(argument, output_file=self.output_file)
         self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR, 'docker-dhcp-relay.supervisord.conf'), self.output_file))
 
         # Test generation of docker-dhcp-relay.supervisord.conf when a vlan is missing ip/ipv6 helpers
         template_path = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-dhcp-relay',
                                      'docker-dhcp-relay.supervisord.conf.j2')
-        argument = ['-m', self.no_ip_helper_minigraph, '-p', self.t0_port_config, '-t', template_path]
+        argument = ['-m', self.no_ip_helper_minigraph, '-j', dhc_sample_data, '-p', self.t0_port_config, '-t', template_path]
         self.run_script(argument, output_file=self.output_file)
         self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR,
                                                'docker-dhcp-relay-no-ip-helper.supervisord.conf'), self.output_file))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
* No need to wait forever for the interface to be ready
* Requires IP address on client vlan interface
#### How I did it
N/A
#### How to verify it
N/A
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

