### PR TITLE
[Platform][AS9716-32D] Correct platform.json to skip pytest high critical threshold for LM75 sensors due to unsupported

### DIFF
--- a/device/accton/x86_64-accton_as9716_32d-r0/platform.json
+++ b/device/accton/x86_64-accton_as9716_32d-r0/platform.json
@@ -392,7 +392,7 @@
                 "low-threshold": false,
                 "high-threshold": true,
                 "low-crit-threshold": false,
-                "high-crit-threshold": true
+                "high-crit-threshold": false
             },
             {
                 "name": "MB_RightCenter_temp(0x49)",
@@ -400,7 +400,7 @@
                 "low-threshold": false,
                 "high-threshold": true,
                 "low-crit-threshold": false,
-                "high-crit-threshold": true
+                "high-crit-threshold": false
             },
             {
                 "name": "MB_LeftCenter_temp(0x4a)",
@@ -408,7 +408,7 @@
                 "low-threshold": false,
                 "high-threshold": true,
                 "low-crit-threshold": false,
-                "high-crit-threshold": true
+                "high-crit-threshold": false
             },
             {
                 "name": "CB_temp(0x4b)",
@@ -416,7 +416,7 @@
                 "low-threshold": false,
                 "high-threshold": true,
                 "low-crit-threshold": false,
-                "high-crit-threshold": true
+                "high-crit-threshold": false
             },
             {
                 "name": "OCXO_temp(0x4c)",
@@ -424,7 +424,7 @@
                 "low-threshold": false,
                 "high-threshold": true,
                 "low-crit-threshold": false,
-                "high-crit-threshold": true
+                "high-crit-threshold": false
             },
             {
                 "name": "FB_1_temp(0x4e)",
@@ -432,7 +432,7 @@
                 "low-threshold": false,
                 "high-threshold": true,
                 "low-crit-threshold": false,
-                "high-crit-threshold": true
+                "high-crit-threshold": false
             },
             {
                 "name": "FB_2_temp(0x4f)",
@@ -440,7 +440,7 @@
                 "low-threshold": false,
                 "high-threshold": true,
                 "low-crit-threshold": false,
-                "high-crit-threshold": true
+                "high-crit-threshold": false
             },
             {
                 "name": "CPU_Package_temp",


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- 202411 sonic-mgmt pytest reports test failed.
  - `platform_tests/api/test_thermal.py::TestThermalApi::test_get_high_critical_threshold`
    -  `Unable to retrieve Thermal 0 high critical threshold`
    -  `Unable to retrieve Thermal 1 high critical threshold`
    -  `Unable to retrieve Thermal 2 high critical threshold`
    -  `Unable to retrieve Thermal 3 high critical threshold`
    -  `Unable to retrieve Thermal 4 high critical threshold`
    -  `Unable to retrieve Thermal 5 high critical threshold`
    -  `Unable to retrieve Thermal 6 high critical threshold`

#### How I did it
- Set `"high-crit-threshold": false` in platform.json to skip this test for LM75 sensors.
  - In short, it's unsupport.
    - The `self.__default_threshold[HIGH_CRIT_THRESHOLD]` in platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/thermal.py is NOT_AVAILABLE.
    - The sysfs have no related attributes about high critical threshold for LM75.

#### How to verify it
- Re-run the test case and it can skip.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

