### PR TITLE
[Dhcp Relay] Skip mgmt intf when finding interface for boot reply

### DIFF
--- a/src/isc-dhcp/patch/0019-skip-mgmt-intf-when-finding-interface-for-boot-reply.patch
+++ b/src/isc-dhcp/patch/0019-skip-mgmt-intf-when-finding-interface-for-boot-reply.patch
@@ -1,0 +1,36 @@
+From 9ce4b1f103d134f91a85dbb4974e4eaddc258277 Mon Sep 17 00:00:00 2001
+From: irene_pan <irene_pan@edge-core.com>
+Date: Wed, 2 Apr 2025 06:49:47 +0000
+Subject: [PATCH] skip mgmt intf when finding interface for boot reply
+
+---
+ relay/dhcrelay.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/relay/dhcrelay.c b/relay/dhcrelay.c
+index 94ce67d..c8ee9d4 100644
+--- a/relay/dhcrelay.c
++++ b/relay/dhcrelay.c
+@@ -36,7 +36,7 @@
+ TIME default_lease_time = 43200; /* 12 hours... */
+ TIME max_lease_time = 86400; /* 24 hours... */
+ struct tree_cache *global_options[256];
+-
++const char *MGMT_INTF = "eth0";
+ struct option *requested_opts[2];
+ 
+ /* Needed to prevent linking against conflex.c. */
+@@ -985,6 +985,10 @@ do_relay4(struct interface_info *ip, struct dhcp_packet *packet,
+ 			for (out = interfaces; out; out = out->next) {
+ 				int i;
+ 
++				if (strcmp(out->name, MGMT_INTF) == 0) {
++					continue;
++				}
++
+ 				for (i = 0 ; i < out->address_count ; i++ ) {
+ 					if (out->addresses[i].s_addr ==
+ 						packet->giaddr.s_addr) {
+-- 
+2.49.0
+

--- a/src/isc-dhcp/patch/series
+++ b/src/isc-dhcp/patch/series
@@ -17,3 +17,4 @@
 0016-Don-t-look-up-the-ifindex-for-fallback.patch
 0017-Support-for-interfaces-with-IPv6-linklocal.patch
 0018-Enlarge-alias-size-to-be-equal-to-the-def-of-linux.patch
+0019-skip-mgmt-intf-when-finding-interface-for-boot-reply.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
DHCPv4 relay not work when downstream subnet overlap with eth0, skip mgmt intf when finding interface for boot reply
#### How I did it
N/A
#### How to verify it
N/A
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

