### PR TITLE
[Dhcp Relay] Send renew packet to client through unicast forward

### DIFF
--- a/src/isc-dhcp/patch/0020-Send-renew-packet-to-client-through-unicast-forward.patch
+++ b/src/isc-dhcp/patch/0020-Send-renew-packet-to-client-through-unicast-forward.patch
@@ -1,0 +1,38 @@
+From 15f04c4d5dbe6fd161f77187317716f23942fa16 Mon Sep 17 00:00:00 2001
+From: irene_pan <irene_pan@edge-core.com>
+Date: Wed, 2 Apr 2025 07:21:56 +0000
+Subject: [PATCH] Send renew packet to client through unicast forward
+
+---
+ common/socket.c  | 2 +-
+ relay/dhcrelay.c | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/common/socket.c b/common/socket.c
+index e707a7f..17cec61 100644
+--- a/common/socket.c
++++ b/common/socket.c
+@@ -1238,7 +1238,7 @@ isc_result_t fallback_discard (object)
+ int can_unicast_without_arp (ip)
+ 	struct interface_info *ip;
+ {
+-	return 0;
++	return 1;
+ }
+ 
+ int can_receive_unicast_unconfigured (ip)
+diff --git a/relay/dhcrelay.c b/relay/dhcrelay.c
+index c8ee9d4..16fa941 100644
+--- a/relay/dhcrelay.c
++++ b/relay/dhcrelay.c
+@@ -1017,6 +1017,7 @@ do_relay4(struct interface_info *ip, struct dhcp_packet *packet,
+ 			return;
+ 
+ 		if (!(packet->flags & htons(BOOTP_BROADCAST)) &&
++			(packet->ciaddr.s_addr) &&
+ 			can_unicast_without_arp(out)) {
+ 			to.sin_addr = packet->yiaddr;
+ 			to.sin_port = remote_port;
+-- 
+2.49.0
+

--- a/src/isc-dhcp/patch/series
+++ b/src/isc-dhcp/patch/series
@@ -18,3 +18,4 @@
 0017-Support-for-interfaces-with-IPv6-linklocal.patch
 0018-Enlarge-alias-size-to-be-equal-to-the-def-of-linux.patch
 0019-skip-mgmt-intf-when-finding-interface-for-boot-reply.patch
+0020-Send-renew-packet-to-client-through-unicast-forward.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The isc-dhcp relay does not seem to support unicast reply
Add a patch to allow renew packets to be sent to client via unicast forward
#### How I did it
N/A
#### How to verify it
N/A
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

