### PR TITLE
[ZTP] To disable interface forwarding in kernel for 'dhclient -6'

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -58,6 +58,8 @@ iface {{ port }} inet dhcp
 {% endif %}
 {% if ZTP['mode']['ipv6'] == 'true' %}
 iface {{ port }} inet6 dhcp
+    post-up sysctl net.ipv6.conf.{{ port }}.forwarding=0
+    pre-down sysctl net.ipv6.conf.{{ port }}.forwarding=1
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_inband_ip
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_inband_ip
@@ -29,6 +29,8 @@ auto Ethernet0
 allow-hotplug Ethernet0
 iface Ethernet0 inet dhcp
 iface Ethernet0 inet6 dhcp
+    post-up sysctl net.ipv6.conf.Ethernet0.forwarding=0
+    pre-down sysctl net.ipv6.conf.Ethernet0.forwarding=1
 
 #
 source /etc/network/interfaces.d/*

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_inband_ip
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_inband_ip
@@ -29,6 +29,8 @@ auto Ethernet0
 allow-hotplug Ethernet0
 iface Ethernet0 inet dhcp
 iface Ethernet0 inet6 dhcp
+    post-up sysctl net.ipv6.conf.Ethernet0.forwarding=0
+    pre-down sysctl net.ipv6.conf.Ethernet0.forwarding=1
 
 #
 source /etc/network/interfaces.d/*


### PR DESCRIPTION
#### Why I did it
- When the forwarding is disabled, if ipv6 RA packet is received, the ipv6 stateless address with prefix-length will be generated. (there would be local route in chip)

#### How I did it
- Disable forwarding in DHCPv6 client mode
- Update sample_output files for sonic-config-engine unit-test

#### How I verified it
Test ZTP IPv6 with inband port.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:


#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)



- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006


- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog

Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:


#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes

Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md


#### A picture of a cute animal (not mandatory but encouraged)
-->
