### PR TITLE
[Platform][AS9817-32D/O] Support 10G/1G on management ports

### DIFF
--- a/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D-100G/hwsku.json
+++ b/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D-100G/hwsku.json
@@ -161,11 +161,11 @@
         },
 
         "Ethernet256": {
-            "default_brkout_mode": "1x25G"
+            "default_brkout_mode": "1x25G[10G,1G]"
         },
 
         "Ethernet257": {
-            "default_brkout_mode": "1x25G"
+            "default_brkout_mode": "1x25G[10G,1G]"
         }
     }
 }

--- a/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D-400G/hwsku.json
+++ b/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D-400G/hwsku.json
@@ -161,11 +161,11 @@
         },
 
         "Ethernet256": {
-            "default_brkout_mode": "1x25G"
+            "default_brkout_mode": "1x25G[10G,1G]"
         },
 
         "Ethernet257": {
-            "default_brkout_mode": "1x25G"
+            "default_brkout_mode": "1x25G[10G,1G]"
         }
     }
 }

--- a/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D/hwsku.json
+++ b/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D/hwsku.json
@@ -161,11 +161,11 @@
         },
 
         "Ethernet256": {
-            "default_brkout_mode": "1x25G"
+            "default_brkout_mode": "1x25G[10G,1G]"
         },
 
         "Ethernet257": {
-            "default_brkout_mode": "1x25G"
+            "default_brkout_mode": "1x25G[10G,1G]"
         }
     }
 }

--- a/device/accton/x86_64-accton_as9817_32d-r0/platform.json
+++ b/device/accton/x86_64-accton_as9817_32d-r0/platform.json
@@ -1120,7 +1120,7 @@
             "index": "33",
             "lanes": "513",
             "breakout_modes": {
-                "1x25G": ["Eth33(Port33)"]
+                "1x25G[10G,1G]": ["Eth33(Port33)"]
             }
         },
 
@@ -1128,7 +1128,7 @@
             "index": "34",
             "lanes": "515",
             "breakout_modes": {
-                "1x25G": ["Eth34(Port34)"]
+                "1x25G[10G,1G]": ["Eth34(Port34)"]
             }
         }
     }

--- a/device/accton/x86_64-accton_as9817_32o-r0/Accton-AS9817-32O-100G/hwsku.json
+++ b/device/accton/x86_64-accton_as9817_32o-r0/Accton-AS9817-32O-100G/hwsku.json
@@ -161,11 +161,11 @@
         },
 
         "Ethernet256": {
-            "default_brkout_mode": "1x25G"
+            "default_brkout_mode": "1x25G[10G,1G]"
         },
 
         "Ethernet257": {
-            "default_brkout_mode": "1x25G"
+            "default_brkout_mode": "1x25G[10G,1G]"
         }
     }
 }

--- a/device/accton/x86_64-accton_as9817_32o-r0/Accton-AS9817-32O-2x400G/hwsku.json
+++ b/device/accton/x86_64-accton_as9817_32o-r0/Accton-AS9817-32O-2x400G/hwsku.json
@@ -321,11 +321,11 @@
         },
 
         "Ethernet256": {
-            "default_brkout_mode": "1x25G"
+            "default_brkout_mode": "1x25G[10G,1G]"
         },
 
         "Ethernet257": {
-            "default_brkout_mode": "1x25G"
+            "default_brkout_mode": "1x25G[10G,1G]"
         }
     }
 }

--- a/device/accton/x86_64-accton_as9817_32o-r0/Accton-AS9817-32O/hwsku.json
+++ b/device/accton/x86_64-accton_as9817_32o-r0/Accton-AS9817-32O/hwsku.json
@@ -161,11 +161,11 @@
         },
 
         "Ethernet256": {
-            "default_brkout_mode": "1x25G"
+            "default_brkout_mode": "1x25G[10G,1G]"
         },
 
         "Ethernet257": {
-            "default_brkout_mode": "1x25G"
+            "default_brkout_mode": "1x25G[10G,1G]"
         }
     }
 }

--- a/device/accton/x86_64-accton_as9817_32o-r0/platform.json
+++ b/device/accton/x86_64-accton_as9817_32o-r0/platform.json
@@ -1120,7 +1120,7 @@
             "index": "33",
             "lanes": "513",
             "breakout_modes": {
-                "1x25G": ["Eth33(Port33)"]
+                "1x25G[10G,1G]": ["Eth33(Port33)"]
             }
         },
 
@@ -1128,7 +1128,7 @@
             "index": "34",
             "lanes": "515",
             "breakout_modes": {
-                "1x25G": ["Eth34(Port34)"]
+                "1x25G[10G,1G]": ["Eth34(Port34)"]
             }
         }
     }


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
There is a retimer between SFP ports and MAC chip, and preemphasis has to be configured on this retimer.

This funcion is based on set_sfp_mux, which is a platform api of sfp

Note:
xcvrd listents to config DB and call the platform api to set the correct configuration on the re-timer.
Refer to the following PR.
    * https://github.com/edge-core/sonic-buildimage/pull/320
    * https://github.com/edge-core/sonic-platform-daemons/pull/17

#### How I did it
Modify hwsku.json and platform.json

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

