### PR TITLE
Add interface to evpn remote vtep for uplink interface in dhcp relay

### DIFF
--- a/dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2
@@ -40,6 +40,25 @@ command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /t
 {% endfor %}
 {% if not vlan_member.found %} -iu {{ port }}{% endif -%}
 {% endfor %}
+{%- for vxlan_map_realy_from in VXLAN_TUNNEL_MAP %}
+    {%- if VXLAN_TUNNEL_MAP[vxlan_map_realy_from]['vlan'] == vlan_name %}
+        {%- set vxlan_intf_ip = namespace(found=false) %}
+        {%- for vxlan_map_realy_to in VXLAN_TUNNEL_MAP %}
+            {%- if VXLAN_TUNNEL_MAP[vxlan_map_realy_to]['vlan'] != vlan_name %}
+                {%- for (name, prefix) in VLAN_INTERFACE|pfx_filter %}
+                    {%- if prefix | ipv4 and name == VXLAN_TUNNEL_MAP[vxlan_map_realy_to]['vlan'] %}{%- set vxlan_intf_ip.found = true %}{%- endif -%}
+                {%- endfor %}
+                {%- if not vxlan_intf_ip.found %}
+                    {%- for vrf_name in VRF %}
+                        {%- if VRF[vrf_name]['vni'] == VXLAN_TUNNEL_MAP[vxlan_map_realy_to]['vni'] %}
+                            {%- if VXLAN_TUNNEL_MAP[vxlan_map_realy_to]['vlan'] %} -iu {{ VXLAN_TUNNEL_MAP[vxlan_map_realy_to]['vlan'] }}{%- endif -%}
+                        {%- endif %}
+                    {%- endfor %}
+                {%- endif %}
+            {%- endif %}
+        {%- endfor %}
+    {%- endif %}
+{%- endfor %}
 {% for (name, gateway) in VLAN_INTERFACE|get_primary_addr %}
 {% if gateway | ipv4 and name == vlan_name %} -pg {{ gateway }}{% endif -%}
 {% endfor %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add interface to the evpn remote vtep of the uplink interface in the dhcp relay, so that the dhcp discover packet can be relayed to the evpn remote vtep
#### How I did it
N/A
#### How to verify it
N/A
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

