### PR TITLE
Modify dhcpv6_relay setting to config db by cli and restart dhcp_relay

### DIFF
--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_vlan_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_vlan_dhcp_relay.py
@@ -154,7 +154,7 @@ class TestConfigVlanDhcpRelay(object):
             assert result.exit_code == 0
             assert result.output == config_vlan_add_dhcpv6_relay_output
             assert mock_run_command.call_count == 3
-            db.cfgdb.set_entry.assert_called_once_with('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1'], 'dhcpv6_servers': ['fc02:2000::1']})
+            db.cfgdb.set_entry.assert_called_with('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1'], 'dhcpv6_servers': ['fc02:2000::1']})
 
         db.cfgdb.set_entry.reset_mock()
 
@@ -167,7 +167,8 @@ class TestConfigVlanDhcpRelay(object):
             assert result.exit_code == 0
             assert result.output == config_vlan_del_dhcpv6_relay_output
             assert mock_run_command.call_count == 3
-            db.cfgdb.set_entry.assert_called_once_with('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1']})
+            db.cfgdb.set_entry.assert_called_with('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1']})
+            assert 2 == db.cfgdb.set_entry.call_count
 
     def test_config_vlan_add_del_multiple_dhcpv6_relay_dest(self, mock_cfgdb):
         runner = CliRunner()
@@ -183,7 +184,8 @@ class TestConfigVlanDhcpRelay(object):
             assert result.exit_code == 0
             assert result.output == config_vlan_add_multiple_dhcpv6_relay_output
             assert mock_run_command.call_count == 3
-            db.cfgdb.set_entry.assert_called_once_with('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1'], 'dhcpv6_servers': ['fc02:2000::1', 'fc02:2000::2', 'fc02:2000::3']})
+            db.cfgdb.set_entry.assert_called_with('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1'], 'dhcpv6_servers': ['fc02:2000::1', 'fc02:2000::2', 'fc02:2000::3']})
+            assert 2 == db.cfgdb.set_entry.call_count
 
         db.cfgdb.set_entry.reset_mock()
 
@@ -196,7 +198,8 @@ class TestConfigVlanDhcpRelay(object):
             assert result.exit_code == 0
             assert result.output == config_vlan_del_multiple_dhcpv6_relay_output
             assert mock_run_command.call_count == 3
-            db.cfgdb.set_entry.assert_called_once_with('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1']})
+            db.cfgdb.set_entry.assert_called_with('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1']})
+            assert 2 == db.cfgdb.set_entry.call_count
 
     def test_config_vlan_remove_nonexist_dhcp_relay_dest(self, mock_cfgdb):
         runner = CliRunner()

--- a/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
@@ -204,6 +204,7 @@ def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
     # Verify vlan is valid
     vlan_name = 'Vlan{}'.format(vid)
     vlan = db.cfgdb.get_entry('VLAN', vlan_name)
+    dhcpv6_relay = db.cfgdb.get_entry('DHCP_RELAY', vlan_name)
     if len(vlan) == 0:
         ctx.fail("{} doesn't exist".format(vlan_name))
 
@@ -233,6 +234,8 @@ def add_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
         vlan['dhcp_servers'] = dhcp_servers
     if len(dhcpv6_servers):
         vlan['dhcpv6_servers'] = dhcpv6_servers
+        dhcpv6_relay['dhcpv6_servers'] = dhcpv6_servers
+        db.cfgdb.set_entry('DHCP_RELAY', vlan_name, dhcpv6_relay)
 
     db.cfgdb.set_entry('VLAN', vlan_name, vlan)
 
@@ -252,10 +255,11 @@ def del_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
     """ Remove a destination IP address from the VLAN's DHCP relay """
 
     ctx = click.get_current_context()
-
+    removed_ipv6_servers = []
     # Verify vlan is valid
     vlan_name = 'Vlan{}'.format(vid)
     vlan = db.cfgdb.get_entry('VLAN', vlan_name)
+    dhcpv6_relay = db.cfgdb.get_entry('DHCP_RELAY', vlan_name)
     if len(vlan) == 0:
         ctx.fail("{} doesn't exist".format(vlan_name))
 
@@ -273,6 +277,7 @@ def del_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
             dhcp_servers.remove(ip_addr)
         else:
             dhcpv6_servers.remove(ip_addr)
+            removed_ipv6_servers.append(ip_addr)
 
     # Update dhcp servers to config DB
     if len(dhcp_servers):
@@ -283,9 +288,15 @@ def del_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
 
     if len(dhcpv6_servers):
         vlan['dhcpv6_servers'] = dhcpv6_servers
+        dhcpv6_relay['dhcpv6_servers'] = dhcpv6_servers
     else:
         if 'dhcpv6_servers' in vlan.keys():
             del vlan['dhcpv6_servers']
+        if 'dhcpv6_servers' in dhcpv6_relay.keys():
+            del dhcpv6_relay['dhcpv6_servers']
+
+    if len(removed_ipv6_servers):
+        db.cfgdb.set_entry('DHCP_RELAY', vlan_name, dhcpv6_relay)
 
     db.cfgdb.set_entry('VLAN', vlan_name, vlan)
     click.echo("Removed DHCP relay destination addresses {} from {}".format(dhcp_relay_destination_ips, vlan_name))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When setting dhcpv6_relay, it needs to modify config to config_db.json and let dhcpv6_relay active.
Modify config of dhcpv6_relay to config db when setting by CLI and restart dhcp_relay container.
#### How I did it
N/A
#### How to verify it
N/A
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

