### PR TITLE
Fix frr route map add failed issue

### DIFF
--- a/src/sonic-frr/patch/0038-PATCH-yang-route-distinguisher-typedef-for-route-map.patch
+++ b/src/sonic-frr/patch/0038-PATCH-yang-route-distinguisher-typedef-for-route-map.patch
@@ -1,0 +1,117 @@
+From a092d1537fb260ade496ee2aec0716fa365b6088 Mon Sep 17 00:00:00 2001
+From: ecsonic <ecsonic@edge-core.com>
+Date: Thu, 6 Feb 2025 06:07:35 +0000
+Subject: [PATCH] [PATCH] yang: route-distinguisher typedef for route-maps
+ reworked #12385
+
+---
+ yang/frr-bgp-route-map.yang | 86 ++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 85 insertions(+), 1 deletion(-)
+
+diff --git a/yang/frr-bgp-route-map.yang b/yang/frr-bgp-route-map.yang
+index ad2a142fe..68a4aa607 100644
+--- a/yang/frr-bgp-route-map.yang
++++ b/yang/frr-bgp-route-map.yang
+@@ -356,6 +356,90 @@ module frr-bgp-route-map {
+     }
+   }
+ 
++  typedef route-distinguisher {
++    type string {
++      pattern
++        '(0:(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
++      +     '6[0-4][0-9]{3}|'
++      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0):(429496729[0-5]|'
++      +     '42949672[0-8][0-9]|'
++      +     '4294967[01][0-9]{2}|429496[0-6][0-9]{3}|'
++      +     '42949[0-5][0-9]{4}|'
++      +     '4294[0-8][0-9]{5}|429[0-3][0-9]{6}|'
++      +     '42[0-8][0-9]{7}|4[01][0-9]{8}|'
++      +     '[1-3][0-9]{9}|[1-9][0-9]{0,8}|0))|'
++      + '(1:((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|'
++      +     '25[0-5])\.){3}([0-9]|[1-9][0-9]|'
++      +     '1[0-9]{2}|2[0-4][0-9]|25[0-5])):(6553[0-5]|'
++      +     '655[0-2][0-9]|'
++      +     '65[0-4][0-9]{2}|6[0-4][0-9]{3}|'
++      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0))|'
++      + '(2:(429496729[0-5]|42949672[0-8][0-9]|'
++      +     '4294967[01][0-9]{2}|'
++      +     '429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|'
++      +     '4294[0-8][0-9]{5}|'
++      +     '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[01][0-9]{8}|'
++      +     '[1-3][0-9]{9}|[1-9][0-9]{0,8}|0):'
++      +     '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
++      +     '6[0-4][0-9]{3}|'
++      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0))|'
++      + '(6(:[a-fA-F0-9]{2}){6})|'
++      + '(([3-57-9a-fA-F]|[1-9a-fA-F][0-9a-fA-F]{1,3}):'
++      +     '[0-9a-fA-F]{1,12})|'
++      +  '((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
++      +     '6[0-4][0-9]{3}|'
++      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0):(429496729[0-5]|'
++      +     '42949672[0-8][0-9]|'
++      +     '4294967[01][0-9]{2}|429496[0-6][0-9]{3}|'
++      +     '42949[0-5][0-9]{4}|'
++      +     '4294[0-8][0-9]{5}|429[0-3][0-9]{6}|'
++      +     '42[0-8][0-9]{7}|4[01][0-9]{8}|'
++      +     '[1-3][0-9]{9}|[1-9][0-9]{0,8}|0)|'
++      +  '((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|'
++      +     '25[0-5])\.){3}([0-9]|[1-9][0-9]|'
++      +     '1[0-9]{2}|2[0-4][0-9]|25[0-5])):(6553[0-5]|'
++      +     '655[0-2][0-9]|'
++      +     '65[0-4][0-9]{2}|6[0-4][0-9]{3}|'
++      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0))|'
++      + '((429496729[0-5]|42949672[0-8][0-9]|'
++      +     '4294967[01][0-9]{2}|'
++      +     '429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|'
++      +     '4294[0-8][0-9]{5}|'
++      +     '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[01][0-9]{8}|'
++      +     '[1-3][0-9]{9}|[1-9][0-9]{0,8}|0):'
++      +     '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
++      +     '6[0-4][0-9]{3}|'
++      +     '[1-5][0-9]{4}|[1-9][0-9]{0,3}|0))';
++    }
++
++    description
++      "A Route Distinguisher is an 8-octet value used to
++       distinguish routes from different BGP VPNs (RFC 4364).
++       A Route Distinguisher will have the same format as a
++       Route Target as per RFC 4360 and will consist of
++       two or three fields: a 2-octet Type field, an administrator
++       field, and, optionally, an assigned number field.
++       According to the data formats for types 0, 1, 2, and 6 as
++       defined in RFC 4360, RFC 5668, and RFC 7432, the encoding
++       pattern is defined as:
++       0:2-octet-asn:4-octet-number
++       1:4-octet-ipv4addr:2-octet-number
++       2:4-octet-asn:2-octet-number
++       6:6-octet-mac-address
++       Additionally, a generic pattern is defined for future
++       route discriminator types:
++       2-octet-other-hex-number:6-octet-hex-number
++       Some valid examples are 0:100:100, 1:1.1.1.1:100,
++       2:1234567890:203, and 6:26:00:08:92:78:00.
++       The following route distinguisher with two fields are also
++       accepted : 10000:44 1.2.3.4:44.";
++    reference
++      "RFC 4360: BGP Extended Communities Attribute.
++       RFC 4364: BGP/MPLS IP Virtual Private Networks (VPNs).
++       RFC 5668: 4-Octet AS Specific BGP Extended Community.
++       RFC 7432: BGP MPLS-Based Ethernet VPN.";
++  }
++
+   typedef extcommunity-lb-type {
+     type enumeration {
+       enum "explicit-bandwidth" {
+@@ -598,7 +682,7 @@ module frr-bgp-route-map {
+       description
+         "Match eVPN route-distinguisher";
+       leaf route-distinguisher {
+-        type rt-types:route-distinguisher;
++        type route-distinguisher;
+       }
+     }
+ 
+-- 
+2.17.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -34,3 +34,4 @@ cross-compile-changes.patch
 0035-fpm-ignore-route-from-default-table.patch
 0036-Add-support-of-bgp-l3vni-evpn.patch
 0037-set-ZEBRA_DEFAULT_NHG_KEEP_TIMER-from-180s-to-1s.patch
+0038-PATCH-yang-route-distinguisher-typedef-for-route-map.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix frr parsing errors caused by incorrect route distinguisher
#### How I did it
Sync PR form https://github.com/FRRouting/frr/pull/12385
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

