### PR TITLE
[ctrmgrd] Fix the container restart during config reload (#19528)

### DIFF
--- a/src/sonic-ctrmgrd/ctrmgr/ctrmgrd.py
+++ b/src/sonic-ctrmgrd/ctrmgr/ctrmgrd.py
@@ -489,7 +489,9 @@ class FeatureTransitionHandler:
         service_restart = False
 
         if set_owner == "local":
-            if ct_owner != "local":
+            # NOTE: no need to restart if the current owner is none,
+            # as none implies the container is not running.
+            if ct_owner != "local" and ct_owner != "none":
                 service_restart = True
         else:
             if (ct_owner != "none") and (remote_state == "pending"):

--- a/src/sonic-ctrmgrd/tests/ctrmgrd_test.py
+++ b/src/sonic-ctrmgrd/tests/ctrmgrd_test.py
@@ -355,6 +355,38 @@ feature_test_data = {
                 }
             }
         }
+    },
+    5: {
+        common_test.DESCR: "No restart for current_owner == none in config reload",
+        common_test.ARGS: "ctrmgrd",
+        common_test.PRE: {
+            common_test.CONFIG_DB_NO: {
+                common_test.FEATURE_TABLE: {
+                    "swss": {
+                        "set_owner": "local",
+                        "state": "enabled",
+                        "auto_restart": "enabled"
+                    }
+                }
+            }
+        },
+        common_test.UPD: {
+            common_test.STATE_DB_NO: {
+                common_test.FEATURE_TABLE: {
+                    "swss": {
+                        "system_state": "down",
+                        "remote_state": "none",
+                        "current_owner": "none",
+                        "container_id": "",
+                        "state": "enabled"
+                    }
+                }
+            }
+        },
+        common_test.POST: {
+            common_test.STATE_DB_NO: {
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix the config reload failure due to the container(swss/teamd) restart introduced by ctrmgrd:
```
Jun 21 11:16:32.844005 xxx NOTICE swss#orchagent: :- syncd_apply_view: Notify syncd APPLY_VIEW
Jun 21 11:16:32.844005 xxx NOTICE swss#orchagent: :- notifySyncd: sending syncd: APPLY_VIEW
Jun 21 11:16:32.845219 xxx WARNING syncd#syncd: :- processNotifySyncd: syncd received APPLY VIEW, will translate
Jun 21 11:16:32.846684 xxx NOTICE syncd#syncd: :- dump: getting took 0.000931 sec
Jun 21 11:16:32.846908 xxx NOTICE syncd#syncd: :- getAsicView: ASIC_STATE switch count: 0:
Jun 21 11:16:32.847129 xxx NOTICE syncd#syncd: :- getAsicView: get asic view from ASIC_STATE took 0.002006 sec
Jun 21 11:16:32.850585 xxx NOTICE syncd#syncd: :- dump: getting took 0.001547 sec
Jun 21 11:16:32.850998 xxx NOTICE syncd#syncd: :- getAsicView: TEMP_ASIC_STATE switch count: 1:
Jun 21 11:16:32.851208 xxx NOTICE syncd#syncd: :- getAsicView: oid:0x21000000000000: objects count: 47
Jun 21 11:16:32.851400 xxx NOTICE syncd#syncd: :- getAsicView: get asic view from TEMP_ASIC_STATE took 0.003422 sec
Jun 21 11:16:32.851586 xxx ERR syncd#syncd: :- applyView: current view switches: 0 != temporary view switches: 1, FATAL
Jun 21 11:16:32.852132 xxx NOTICE syncd#syncd: :- applyView: apply took 0.006951 sec
Jun 21 11:16:32.853039 xxx ERR swss#orchagent: :- syncd_apply_view: Failed to notify syncd APPLY_VIEW -1
```
The APPLY_VIEW failure is due to swss is restarted twice during config reload, and the second restart
is introduced by ctrmgrd, which should be avoided.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

