### PR TITLE
Store InterfaceAliasConverter to speed up 'show vlan brief'

### DIFF
--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_show_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_show_dhcp_relay.py
@@ -99,7 +99,7 @@ def test_plugin_registration():
                                            {"dhcp_server": {"state": "enabled"}}, {"dhcp_server": {}}])
 def test_dhcp_relay_column_output(feature_table):
     ctx = (
-        ({'Vlan1001': {'dhcp_servers': ['192.0.0.1', '192.168.0.2']}}, {}, {}),
+        ({'Vlan1001': {'dhcp_servers': ['192.0.0.1', '192.168.0.2']}}, {}, {}, ()),
         (MockDb({"FEATURE": feature_table})),
     )
     if "dhcp_server" in feature_table and "state" in feature_table["dhcp_server"] and \

--- a/dockers/docker-dhcp-relay/cli/show/plugins/show_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/show/plugins/show_dhcp_relay.py
@@ -33,7 +33,7 @@ config_db = ConfigDBConnector()
 
 def get_dhcp_helper_address(ctx, vlan):
     cfg, db = ctx
-    vlan_dhcp_helper_data, _, _ = cfg
+    vlan_dhcp_helper_data, _, _, _ = cfg
     vlan_config = vlan_dhcp_helper_data.get(vlan)
     if not vlan_config:
         return ""


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The design in show vlan brief has change: in old design it sorts them and loop once and display each columns, but in 202111 new design (remove dhcp-relay as dhcp-relay commands will come as a plugin), each columns will call a handler function and output data for that specific column, so the total running will be much larger.
#### How I did it
N/A
#### How to verify it
N/A
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

