### PR TITLE
Add argument to set max packet size of dhcp relay

### DIFF
--- a/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
@@ -305,6 +305,34 @@ def del_vlan_dhcp_relay_destination(db, vid, dhcp_relay_destination_ips):
     except SystemExit as e:
         ctx.fail("Restart service dhcp_relay failed with error {}".format(e))
 
+@vlan_dhcp_relay.group(cls=clicommon.AbbreviationGroup, name='max_packet_size')
+def vlan_dhcp_relay_max_packet_size():
+    """Configure DHCP relay max packet size"""
+    pass
+
+@vlan_dhcp_relay_max_packet_size.command('add')
+@click.argument('vid', metavar='<vid>', required=True, type=int)
+@click.argument('dhcp_relay_max_packet_size', metavar='<dhcp_relay_max_packet_size>', required=True, type=int)
+@clicommon.pass_db
+def add_vlan_dhcp_relay_max_packet_size(db, vid, dhcp_relay_max_packet_size):
+    """ Set max packet size to the VLAN's DHCP relay """
+
+    ctx = click.get_current_context()
+
+    if dhcp_relay_max_packet_size < 576 or dhcp_relay_max_packet_size > 1500:
+        ctx.fail("Max packet size should be between 576 and 1500")
+
+    vlan_name = 'Vlan{}'.format(vid)
+    vlan = db.cfgdb.get_entry('VLAN', vlan_name)
+    if len(vlan) == 0:
+        ctx.fail("{} doesn't exist".format(vlan_name))
+
+    db.cfgdb.mod_entry('VLAN', vlan_name, {"dhcp_relay_max_packet_size": dhcp_relay_max_packet_size})
+    click.echo("Added DHCP relay max packet size {} for {}".format(dhcp_relay_max_packet_size, vlan_name))
+    try:
+        restart_dhcp_relay_service()
+    except SystemExit as e:
+        ctx.fail("Restart service dhcp_relay failed with error {}".format(e))
 
 def register(cli):
     cli.add_command(dhcp_relay)

--- a/dockers/docker-dhcp-relay/cli/show/plugins/show_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/show/plugins/show_dhcp_relay.py
@@ -47,6 +47,23 @@ def get_dhcp_helper_address(ctx, vlan):
 
 show_vlan.VlanBrief.register_column('DHCP Helper Address', get_dhcp_helper_address)
 
+def get_dhcp_relay_max_packet_size(ctx, vlan):
+    cfg, _ = ctx
+    vlan_dhcp_max_packet_size_data, _, _, _ = cfg
+    vlan_config = vlan_dhcp_max_packet_size_data.get(vlan)
+    if not vlan_config:
+        return ""
+
+    dhcp_relay_max_packet_size = vlan_config.get('dhcp_relay_max_packet_size', [])
+
+    if not dhcp_relay_max_packet_size:
+        return ""
+    else:
+        return dhcp_relay_max_packet_size
+
+
+show_vlan.VlanBrief.register_column('Max Packet Size', get_dhcp_relay_max_packet_size)
+
 class DHCPv4_Counter(object):
     def __init__(self):
         self.db = SonicV2Connector(use_unix_socket_path=False)

--- a/dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2
@@ -1,8 +1,12 @@
 {# Append DHCPv4 agents #}
+{%- set default_dhcp_relay_max_packet_size = 1300 %}
 {% if vlan_name in ipv4_vlan_interfaces %}
 [program:isc-dhcpv4-relay-{{ vlan_name }}]
 {# We treat this VLAN as a downstream interface (-id), as we only want to listen for requests #}
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id {{ vlan_name }}
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt
+{%- if 'dhcp_relay_max_packet_size' in VLAN[vlan_name] %} -A {{ VLAN[vlan_name]['dhcp_relay_max_packet_size'] }}
+{%- else %} -A {{default_dhcp_relay_max_packet_size}}
+{%- endif %} -id {{ vlan_name }}
 {#- Dual ToR Option #}
 {% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %} -U Loopback0 -dt{% endif -%}
 {#- si option to use intf addr in relay #}

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-no-ip-helper.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-no-ip-helper.supervisord.conf
@@ -43,7 +43,7 @@ dependent_startup_wait_for=rsyslogd:running
 programs=dhcprelayd,dhcp6relay
 
 [program:isc-dhcpv4-relay-Vlan1000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu Ethernet0 -iu Ethernet108 -iu Ethernet104 -iu PortChannel02 -iu PortChannel04 192.0.0.1 192.0.0.2
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -A 1300 -id Vlan1000 -iu Vlan2000 -iu Ethernet0 -iu Ethernet108 -iu Ethernet104 -iu PortChannel02 -iu PortChannel04 192.0.0.1 192.0.0.2
 priority=3
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
@@ -43,7 +43,7 @@ dependent_startup_wait_for=rsyslogd:running
 programs=dhcprelayd,dhcp6relay
 
 [program:isc-dhcpv4-relay-Vlan1000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu Ethernet0 -iu Ethernet108 -iu Ethernet104 -iu PortChannel02 -iu PortChannel04 192.0.0.1 192.0.0.2
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -A 1300 -id Vlan1000 -iu Vlan2000 -iu Ethernet0 -iu Ethernet108 -iu Ethernet104 -iu PortChannel02 -iu PortChannel04 192.0.0.1 192.0.0.2
 priority=3
 autostart=false
 autorestart=false
@@ -53,7 +53,7 @@ dependent_startup=true
 dependent_startup_wait_for=start:exited
 
 [program:isc-dhcpv4-relay-Vlan2000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan2000 -iu Vlan1000 -iu Ethernet0 -iu Ethernet108 -iu Ethernet104 -iu PortChannel02 -iu PortChannel04 192.0.0.3 192.0.0.4
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -A 1300 -id Vlan2000 -iu Vlan1000 -iu Ethernet0 -iu Ethernet108 -iu Ethernet104 -iu PortChannel02 -iu PortChannel04 192.0.0.3 192.0.0.4
 priority=3
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-no-ip-helper.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-no-ip-helper.supervisord.conf
@@ -43,7 +43,7 @@ dependent_startup_wait_for=rsyslogd:running
 programs=dhcprelayd,dhcp6relay
 
 [program:isc-dhcpv4-relay-Vlan1000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu Ethernet0 -iu Ethernet104 -iu Ethernet108 -iu PortChannel02 -iu PortChannel04 192.0.0.1 192.0.0.2
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -A 1300 -id Vlan1000 -iu Vlan2000 -iu Ethernet0 -iu Ethernet104 -iu Ethernet108 -iu PortChannel02 -iu PortChannel04 192.0.0.1 192.0.0.2
 priority=3
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
@@ -43,7 +43,7 @@ dependent_startup_wait_for=rsyslogd:running
 programs=dhcprelayd,dhcp6relay
 
 [program:isc-dhcpv4-relay-Vlan1000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu Ethernet0 -iu Ethernet104 -iu Ethernet108 -iu PortChannel02 -iu PortChannel04 192.0.0.1 192.0.0.2
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -A 1300 -id Vlan1000 -iu Vlan2000 -iu Ethernet0 -iu Ethernet104 -iu Ethernet108 -iu PortChannel02 -iu PortChannel04 192.0.0.1 192.0.0.2
 priority=3
 autostart=false
 autorestart=false
@@ -53,7 +53,7 @@ dependent_startup=true
 dependent_startup_wait_for=start:exited
 
 [program:isc-dhcpv4-relay-Vlan2000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan2000 -iu Vlan1000 -iu Ethernet0 -iu Ethernet104 -iu Ethernet108 -iu PortChannel02 -iu PortChannel04 192.0.0.3 192.0.0.4
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -A 1300 -id Vlan2000 -iu Vlan1000 -iu Ethernet0 -iu Ethernet104 -iu Ethernet108 -iu PortChannel02 -iu PortChannel04 192.0.0.3 192.0.0.4
 priority=3
 autostart=false
 autorestart=false


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Receive the DHCP Discover packet size that is 582 bytes (over 576 bytes), it will print the error log in syslog.
Add new argument max_packet_size to config max packet size, default size is 1300.
#### How I did it
N/A
#### How to verify it
N/A
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

