### PR TITLE
Close rsyslog plugin when rsyslog SIGTERM and EOF is sent

### DIFF
--- a/files/build_templates/rsyslog_plugin.conf.j2
+++ b/files/build_templates/rsyslog_plugin.conf.j2
@@ -12,6 +12,7 @@ if re_match($programname, "{{ proc.name }}") then {
     action(type="omprog"
         binary="/usr/bin/rsyslog_plugin -r /etc/rsyslog.d/{{ proc.parse_json }} -m {{ yang_module }}"
         output="/var/log/rsyslog_plugin.log"
+        signalOnClose="on"
         template="prog_msg")
 }
 {% endfor %}

--- a/src/sonic-eventd/rsyslog_plugin/rsyslog_plugin.cpp
+++ b/src/sonic-eventd/rsyslog_plugin/rsyslog_plugin.cpp
@@ -9,6 +9,8 @@
 
 using json = nlohmann::json;
 
+std::atomic<bool> RsyslogPlugin::g_running{false};
+
 bool RsyslogPlugin::onMessage(string msg, lua_State* luaState) {
     string tag;
     event_params_t paramDict;
@@ -104,11 +106,11 @@ bool RsyslogPlugin::createRegexList() {
 }
 
 void RsyslogPlugin::run() {
+    signal(SIGTERM, RsyslogPlugin::signalHandler);
     lua_State* luaState = luaL_newstate();
     luaL_openlibs(luaState);
-    while(true) {
-        string line;
-        getline(cin, line);
+    string line;
+    while(RsyslogPlugin::g_running && getline(cin, line)) {
         if(line.empty()) {
             continue;
         }
@@ -132,4 +134,5 @@ RsyslogPlugin::RsyslogPlugin(string moduleName, string regexPath) {
     m_parser = unique_ptr<SyslogParser>(new SyslogParser());
     m_moduleName = moduleName;
     m_regexPath = regexPath;
+    RsyslogPlugin::g_running = true;
 }

--- a/src/sonic-eventd/rsyslog_plugin/rsyslog_plugin.h
+++ b/src/sonic-eventd/rsyslog_plugin/rsyslog_plugin.h
@@ -9,6 +9,7 @@ extern "C"
 }
 #include <string>
 #include <memory>
+#include <csignal>
 #include "syslog_parser.h"
 #include "events.h"
 #include "logger.h"
@@ -24,10 +25,17 @@ using namespace swss;
 
 class RsyslogPlugin {
 public:
+    static std::atomic<bool> g_running;
     int onInit();
     bool onMessage(string msg, lua_State* luaState);
     void run();
     RsyslogPlugin(string moduleName, string regexPath);
+    static void signalHandler(int signum) {
+        if (signum == SIGTERM) {
+            SWSS_LOG_INFO("Rsyslog plugin received SIGTERM, shutting down");
+	    RsyslogPlugin::g_running = false;
+        }
+    }
 private:
     unique_ptr<SyslogParser> m_parser;
     event_handle_t m_eventHandle;

--- a/src/sonic-eventd/rsyslog_plugin_tests/rsyslog_plugin_ut.cpp
+++ b/src/sonic-eventd/rsyslog_plugin_tests/rsyslog_plugin_ut.cpp
@@ -8,6 +8,7 @@ extern "C"
 #include <fstream>
 #include <memory>
 #include <regex>
+#include <thread>
 #include "gtest/gtest.h"
 #include <nlohmann/json.hpp>
 #include "events.h"
@@ -251,6 +252,31 @@ TEST(rsyslog_plugin, onMessage_noParams) {
     }
     lua_close(luaState);
     infile.close();
+}
+
+TEST(rsyslog_plugin, run) {
+    unique_ptr<RsyslogPlugin> plugin(new RsyslogPlugin("test_mod_name", "./rsyslog_plugin_tests/test_regex_5.rc.json"));
+    EXPECT_EQ(0, plugin->onInit());
+    istringstream ss("");
+    streambuf* cinbuf = cin.rdbuf();
+    cin.rdbuf(ss.rdbuf());
+    plugin->run();
+    cin.rdbuf(cinbuf);
+}
+
+TEST(rsyslog_plugin, run_SIGTERM) {
+    unique_ptr<RsyslogPlugin> plugin(new RsyslogPlugin("test_mod_name", "./rsyslog_plugin_tests/test_regex_5.rc.json"));
+    EXPECT_EQ(0, plugin->onInit());
+    EXPECT_TRUE(RsyslogPlugin::g_running);
+    thread pluginThread([&]() {
+        plugin->run();
+    });
+
+    RsyslogPlugin::signalHandler(SIGTERM);
+
+    pluginThread.join();
+
+    EXPECT_FALSE(RsyslogPlugin::g_running);
 }
 
 TEST(timestampFormatter, changeTimestampFormat) {


### PR DESCRIPTION
cherry-pick PR : https://github.com/sonic-net/sonic-buildimage/pull/19035

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When you restart rsyslog, the rsyslog plugin will run in an infinite loop, which causes the CPU usage to 100% inside Docker.
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

