### PR TITLE
Revert "enable ospf, vrrp, vrrp6, isis and bfd copp rule"

### DIFF
--- a/files/image_config/copp/copp_cfg.j2
+++ b/files/image_config/copp/copp_cfg.j2
@@ -43,28 +43,6 @@
 {% endif %}
 		    "red_action":"drop"
 	    },
-{% if asic_type in ["broadcom", "barefoot"] %}
-        "queue4_group4": {
-            "trap_action":"trap",
-            "trap_priority":"4",
-            "queue": "4",
-            "meter_type":"packets",
-            "mode":"sr_tcm",
-            "cir":"1000",
-            "cbs":"1000",
-            "red_action":"drop"
-        },
-        "queue4_group5": {
-            "trap_action":"trap",
-            "trap_priority":"4",
-            "queue": "4",
-            "meter_type":"packets",
-            "mode":"sr_tcm",
-            "cir":"1000",
-            "cbs":"1000",
-            "red_action":"drop"
-        },
-{% endif %}
 	    "queue1_group1": {
 		    "trap_action":"trap",
 		    "trap_priority":"1",
@@ -144,23 +122,5 @@
 		    "trap_group": "queue2_group1",
 		    "trap_ids": "sample_packet"
 	    }
-{% if asic_type in ["broadcom", "barefoot"] %}
-        ,
-        "ospf": {
-            "trap_ids": "ospf",
-            "trap_group": "queue4_group4",
-            "always_enabled": "true"
-        },
-        "vrrp": {
-            "trap_ids": "vrrp,vrrpv6",
-            "trap_group": "queue4_group4",
-            "always_enabled": "true"
-        },
-        "isis": {
-            "trap_ids": "isis",
-            "trap_group": "queue4_group5",
-            "always_enabled": "true"
-        }
-{% endif %}
     }
 }


### PR DESCRIPTION
This reverts commit f5602c529493c536883158bf32a16bae8fb548a0.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

