### PR TITLE
Change YANG schema for SNMP_USER_AUTH_TYPE

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
@@ -275,7 +275,7 @@
                        "SNMP_USER_TYPE": "AuthNoPriv",
                        "SNMP_USER_PERMISSION": "RW",
                        "SNMP_USER_AUTH_PASSWORD": "auth_pass",
-                       "SNMP_USER_AUTH_TYPE": "HMAC-SHA-2",
+                       "SNMP_USER_AUTH_TYPE": "SHA-512",
                        "SNMP_USER_ENCRYPTION_TYPE": "",
                        "SNMP_USER_ENCRYPTION_PASSWORD": ""
                     }

--- a/src/sonic-yang-models/yang-models/sonic-snmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-snmp.yang
@@ -117,10 +117,10 @@ module sonic-snmp {
           type string;
           must "(current()/../SNMP_USER_TYPE = 'noAuthNoPriv' and current() = '') or
                 ((current()/../SNMP_USER_TYPE = 'AuthNoPriv' or current()/../SNMP_USER_TYPE = 'Priv')
-                and (current() = 'SHA' or current() = 'MD5' or current() = 'HMAC-SHA-2'))";
+                and (current() = 'SHA' or current() = 'MD5' or current() = 'SHA-224' or current() = 'SHA-256' or current() = 'SHA-384' or current() = 'SHA-512'))";
           default "";
           description
-            "Specify authentication type used for user, can be MD5, SHA or HMAC-SHA-2";
+            "Specify authentication type used for user, can be MD5, SHA, SHA-224, SHA-256, SHA-384 or SHA-512";
         }
         leaf SNMP_USER_AUTH_PASSWORD {
           type string {


### PR DESCRIPTION
#### Why I did it
According to RFC 7630 (HMAC-SHA-2 Authentication in USM), HMAC-SHA-2 authentication is not a single protocol but consists of 4 different protocols:
 * usmHMAC128SHA224AuthProtocol
 * usmHMAC192SHA256AuthProtocol
 * usmHMAC256SHA384AuthProtocol
 * usmHMAC384SHA512AuthProtocol

#### How I did it
Following the syntax defined by Cisco, replace the "HMAC-SHA-2" with "SHA-224", "SHA-256", "SHA-384" and "SHA-512" in SNMP_USER_AUTH_TYPE
