### PR TITLE
JIRA-SONIC-11986: [oobe][nous][ec202311.x][nat] code sync of NAT

### DIFF
--- a/dockers/docker-nat/Dockerfile.j2
+++ b/dockers/docker-nat/Dockerfile.j2
@@ -34,4 +34,7 @@ COPY ["critical_processes", "/etc/supervisor"]
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
 RUN rm -rf /debs
 
+RUN ln -s /usr/sbin/iptables /sbin/iptables && \
+    ln -s /usr/sbin/ip6tables /sbin/ip6tables
+
 ENTRYPOINT ["/usr/local/bin/supervisord"]


### PR DESCRIPTION
What I did:
Sync following commit.
(1e573560) JIRA-SONIC-11238: [ec202311.1][Code sync] NAT
Add symbolic links for iptables and ip6tables in the NAT container to be used by the natmgr.

Why I did it:
Fix the issue where the NAT function is not working.

How I verified it:
Run the NAT test cases, and ensure no error messages related to the iptables command are logged in the syslog.