### PR TITLE
Add supervisor-proc-exit-listener for stp docker.

### DIFF
--- a/dockers/docker-stp/Dockerfile.j2
+++ b/dockers/docker-stp/Dockerfile.j2
@@ -31,6 +31,7 @@ RUN apt-get clean -y      && \
 
 COPY ["start.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
+COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
 COPY ["critical_processes", "/etc/supervisor"]
 
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-stp/supervisord.conf
+++ b/dockers/docker-stp/supervisord.conf
@@ -3,6 +3,13 @@ logfile_maxbytes=1MB
 logfile_backups=2
 nodaemon=true
 
+[eventlistener:supervisor-proc-exit-listener]
+command=/usr/bin/supervisor-proc-exit-listener --container-name stp
+events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
+autostart=true
+autorestart=unexpected
+buffer_size=1024
+
 [program:start.sh]
 command=/usr/bin/start.sh
 priority=1

--- a/files/image_config/rsyslog/rsyslog.d/00-sonic.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.d/00-sonic.conf.j2
@@ -51,7 +51,7 @@ if $msg startswith  " telemetry" or ($msg startswith  " dialout" )then {
 }
 
 ## stpd rules
-if $programname contains "stp" then {
+if $programname contains "stp#" then {
     if not ($msg contains "STP_SYSLOG") then {
         /var/log/stpd.log
             stop


### PR DESCRIPTION
#### Why I did it
Don't get expected messages in critical_process_monitoring -- Process 'stpd' is not running in namespace 'host'. -- Process 'stpmgrd' is not running in namespace 'host'.

#### How I did it
1. Add supervisor-proc-exit-listener for stp docker.

2. Revise the stp rsyslog rule to check that program name contains "stp#". If sonic-mgmt pytest case name contains "stp", the log messages appended by logAnalyzer contains "stp" in the program name field and it matches the current rsyslog rule so the message will be directed to 'stp.log'. Revise the stp rsyslog rule so the log messages appended by logAnalyzer can be written to 'syslog'.

3. Will modify test_critical_process_monitoring.py in sonic-mgmt repository to check stpd.log, too.

#### How to verify it
Run test_critical_process_monitoring.py

