### PR TITLE
Fix the issue causing crashes in protodown.

### DIFF
--- a/src/sonic-frr/patch/0041-zebra-Check-if-ifp-is-not-NULL-in-zebra_if_update_ct.patch
+++ b/src/sonic-frr/patch/0041-zebra-Check-if-ifp-is-not-NULL-in-zebra_if_update_ct.patch
@@ -1,0 +1,44 @@
+From f283fa3386bd5feb77191ef754fc6099a181c4d9 Mon Sep 17 00:00:00 2001
+From: Eric Yang <eric_yang@edge-core.com>
+Date: Thu, 10 Apr 2025 03:29:55 +0000
+Subject: [PATCH] zebra: Check if ifp is not NULL in zebra_if_update_ctx() and
+ Prevent protodown_rc from going Bzonkas
+
+---
+ zebra/interface.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/zebra/interface.c b/zebra/interface.c
+index bfe7a0689..9fa386329 100644
+--- a/zebra/interface.c
++++ b/zebra/interface.c
+@@ -1189,6 +1189,12 @@ static bool if_ignore_set_protodown(const struct interface *ifp, bool new_down,
+ 
+ 	zif = ifp->info;
+ 
++	/*
++	 * FRR does not have enough data to make this request
++	 */
++	 if (ifp->ifindex == IFINDEX_INTERNAL)
++	 	return true;
++
+ 	/* Current state as we know it */
+ 	old_down = !!(ZEBRA_IF_IS_PROTODOWN(zif));
+ 	old_set_down = !!CHECK_FLAG(zif->flags, ZIF_FLAG_SET_PROTODOWN);
+@@ -1372,6 +1378,13 @@ static void zebra_if_update_ctx(struct zebra_dplane_ctx *ctx,
+ 	bool pd_reason_val;
+ 	bool down;
+ 
++	if (!ifp) {
++		if (IS_ZEBRA_DEBUG_KERNEL)
++			zlog_debug("%s: Can't find ifp", __func__);
++
++		return;
++	}
++
+ 	dp_res = dplane_ctx_get_status(ctx);
+ 	pd_reason_val = dplane_ctx_get_intf_pd_reason_val(ctx);
+ 	down = dplane_ctx_intf_is_protodown(ctx);
+-- 
+2.17.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -36,3 +36,4 @@ cross-compile-changes.patch
 0037-set-ZEBRA_DEFAULT_NHG_KEEP_TIMER-from-180s-to-1s.patch
 0038-PATCH-yang-route-distinguisher-typedef-for-route-map.patch
 0039-Let-it-return-the-first-matched-route-in-mibII-ipforward-in-zebra_snmp.patch
+0041-zebra-Check-if-ifp-is-not-NULL-in-zebra_if_update_ct.patch


### PR DESCRIPTION
1. Check if ifp is NULL to avoid VRRP or other functionality errors.
2. Check ifindex within protodown, and if ifindex is 0, do not process.

see original commit:
zebra: Check if ifp is not NULL in zebra_if_update_ctx() https://github.com/FRRouting/frr/commit/f5fee8dd54e7e17d759ebe608b81af01dbd476b2

zebra: Prevent protodown_rc from going Bzonkas
https://github.com/FRRouting/frr/commit/c937582491565d84e40bbd34a9371a3839a0a646

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

