### PR TITLE
Configure buffer lossy mode and disable VOQ of scheduling.

### DIFF
--- a/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D-100G/td4-as9726-32x100G.config.yml
+++ b/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D-100G/td4-as9726-32x100G.config.yml
@@ -790,7 +790,9 @@ device:
 device:
     0:
         TM_THD_CONFIG:
-            THRESHOLD_MODE: LOSSLESS
+            THRESHOLD_MODE: LOSSY
+        TM_SCHEDULER_CONFIG:
+            DYNAMIC_VOQ: 0
 ...
 ---
 device:

--- a/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D-100G/td4-as9726-32x100G_ec.config.yml
+++ b/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D-100G/td4-as9726-32x100G_ec.config.yml
@@ -787,7 +787,9 @@ device:
 device:
     0:
         TM_THD_CONFIG:
-            THRESHOLD_MODE: LOSSLESS
+            THRESHOLD_MODE: LOSSY
+        TM_SCHEDULER_CONFIG:
+            DYNAMIC_VOQ: 0
 ...
 ---
 device:

--- a/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D/td4-as9726-32x400G.config.yml
+++ b/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D/td4-as9726-32x400G.config.yml
@@ -662,7 +662,9 @@ device:
 device:
     0:
         TM_THD_CONFIG:
-            THRESHOLD_MODE: LOSSLESS
+            THRESHOLD_MODE: LOSSY
+        TM_SCHEDULER_CONFIG:
+            DYNAMIC_VOQ: 0
 ...
 ---
 device:

--- a/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D/td4-as9726-32x400G_ec.config.yml
+++ b/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D/td4-as9726-32x400G_ec.config.yml
@@ -659,7 +659,9 @@ device:
 device:
     0:
         TM_THD_CONFIG:
-            THRESHOLD_MODE: LOSSLESS
+            THRESHOLD_MODE: LOSSY
+        TM_SCHEDULER_CONFIG:
+            DYNAMIC_VOQ: 0
 ...
 ---
 device:


### PR DESCRIPTION
#### What I did it
* Configure the lossy mode for the MMU to support PFC configuration.
* Disable VOQ scheduling to support queue shaping. The syncd container will crash if queue shaping is applied while VOQ is enabled.

#### How to verify it
* Dump the registers to confirm that the MMU is configured in lossy mode.
* Bind shaping to the queue and send traffic to verify that queue shaping is working correctly and the syncd container do not crash.


