### PR TITLE
[SNMP] Change the default contact to Edgecore Open Networking Products team <support@edge-core.com>

### DIFF
--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -93,7 +93,7 @@ sysLocation    public
 {% if SNMP is defined and SNMP.CONTACT is defined %}
 sysContact     {{ SNMP.CONTACT.keys() | first }} {{ SNMP.CONTACT.values() | first }}
 {% else %}
-sysContact     Azure Cloud Switch vteam <linuxnetdev@microsoft.com>
+sysContact     Edgecore Open Networking Products team <support@edge-core.com>
 {% endif %}
 
                                                  # Application + End-to-End layers


### PR DESCRIPTION
#### What I did
Change the default contact to Edgecore Open Networking Products team <support@edge-core.com>

#### Why I did it
The product shall use the edgecore name for default contact.

#### How to verify it
Get the snmp value snmpwalk to check the contact value.