### PR TITLE
[ICCPD] Remove MAC from RB tree if it exists before freeing it to prevent crashes

### DIFF
--- a/src/iccpd/src/mlacp_fsm.c
+++ b/src/iccpd/src/mlacp_fsm.c
@@ -68,7 +68,11 @@
             mac_msg = TAILQ_FIRST(&(list)); \
             TAILQ_REMOVE(&(list), mac_msg, tail); \
             if (mac_msg->op_type == MAC_SYNC_DEL) \
+            { \
+                if (RB_FIND(mac_rb_tree, &MLACP(csm).mac_rb , mac_msg)) \
+                    MAC_RB_REMOVE(mac_rb_tree, &MLACP(csm).mac_rb, mac_msg);\
                 free(mac_msg); \
+            } \
         } \
         TAILQ_INIT(&(list)); \
     }


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
It’s probably the MLACP_MAC_MSG_QUEUE_REINIT macro causing ICCPD crash if the op_type of mac_msg is MAC_SYNC_DEL . This is because mac_msg will be freed. After that, mac_rb_tree will access the invalid memory address during the search.

#### How I did it
Remove MAC from RB tree if it exists before freeing it to prevent crashes.

#### How to verify it
N/A

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

