### PR TITLE
ICCPD container will restart when the process of iccpd or mclagsyncd crashes.

### DIFF
--- a/dockers/docker-iccpd/Dockerfile.j2
+++ b/dockers/docker-iccpd/Dockerfile.j2
@@ -27,6 +27,8 @@ debs/{{ deb }}{{' '}}
 COPY ["start.sh", "iccpd.sh", "/usr/bin/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["iccpd.j2", "/usr/share/sonic/templates/"]
+COPY ["files/supervisor-proc-exit-listener", "/usr/bin"]
+COPY ["critical_processes", "/etc/supervisor"]
 
 RUN chmod +x /usr/bin/start.sh /usr/bin/iccpd.sh
 RUN apt-get clean -y      && \

--- a/dockers/docker-iccpd/critical_processes
+++ b/dockers/docker-iccpd/critical_processes
@@ -1,0 +1,2 @@
+program:mclagsyncd
+program:iccpd

--- a/dockers/docker-iccpd/iccpd.sh
+++ b/dockers/docker-iccpd/iccpd.sh
@@ -4,8 +4,6 @@ export platform=$(sonic-cfggen -d -y /etc/sonic/sonic_version.yml --var asic_typ
 
 function start_app {
     rm -f /var/run/iccpd/*
-    mclagsyncd &
-    iccpd
 }
 
 function clean_up {

--- a/dockers/docker-iccpd/supervisord.conf
+++ b/dockers/docker-iccpd/supervisord.conf
@@ -12,6 +12,13 @@ exitcodes=0,3
 events=PROCESS_STATE
 buffer_size=1024
 
+[eventlistener:supervisor-proc-exit-listener]
+command=/usr/bin/supervisor-proc-exit-listener --container-name iccpd
+events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
+autostart=true
+autorestart=unexpected
+buffer_size=1024
+
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE
 priority=1
@@ -32,7 +39,7 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 
-[program:iccpd]
+[program:iccpd_setup]
 command=/usr/bin/iccpd.sh
 priority=3
 autostart=false
@@ -41,3 +48,23 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=start:exited
+
+[program:mclagsyncd]
+command=/usr/bin/mclagsyncd
+priority=4
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=iccpd_setup:running
+
+[program:iccpd]
+command=/usr/bin/iccpd
+priority=5
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=mclagsyncd:running


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add a mechanism to restart the ICCPD container when the iccpd or mclagsyncd crashes

#### How I did it
N/A

#### How to verify it
N/A

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

