### PR TITLE
Correct AS7726-32X System Health LED configuration

### DIFF
--- a/device/accton/x86_64-accton_as7726_32x-r0/system_health_monitoring_config.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/system_health_monitoring_config.json
@@ -6,7 +6,7 @@
     "user_defined_checkers": [],
     "polling_interval": 60,
     "led_color": {
-        "fault": "amber",
+        "fault": "red",
         "normal": "green",
         "booting": "off"
     }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Refer to sonic-buildimage_ec/device/accton/x86_64-accton_as7726_32x-r0/pddf /pddf-device.json, the green/red/off are defined for DIAG LED.

#### How I did it
Revised the fault color from amber to red in AS7727-32X system_health_monitoring_config.json.
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

