### PR TITLE
Correct AS7326-56X PDDf DIAG LED

### DIFF
--- a/device/accton/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json
@@ -2958,10 +2958,10 @@
              [
                 {"attr_name":"blue_blink", "descr": "" , "bits" : "5:0",  "value" : "0x27", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x24"},
                 {"attr_name":"green_blink", "descr": "" , "bits" : "5:0",  "value" : "0x17", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x24"},
-                {"attr_name":"amber_blink", "descr": "" , "bits" : "5:0",  "value" : "0xf", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x24"},
+                {"attr_name":"red_blink", "descr": "" , "bits" : "5:0",  "value" : "0xf", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x24"},
                 {"attr_name":"blue", "descr": "" , "bits" : "5:0",  "value" : "0x3", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x24"},
                 {"attr_name":"green", "descr": "" , "bits" : "5:0",  "value" : "0x5", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x24"},
-                {"attr_name":"amber", "descr": "" , "bits" : "5:0",  "value" : "0x6", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x24"},
+                {"attr_name":"red", "descr": "" , "bits" : "5:0",  "value" : "0x6", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x24"},
                 {"attr_name":"off", "descr": "" , "bits" : "5:0",  "value" : "0x7", "swpld_addr" : "0x60", "swpld_addr_offset" : "0x24"}
                 
              ]


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Correct AS7326-56X PDDf DIAG LED
#### How I did it
Revised the color from amber to red in AS7326-56X pddf-device.json.
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

