### PR TITLE
[docker-stp] restart rsyslogd after changing the rate-limit configuration

### DIFF
--- a/dockers/docker-stp/supervisord.conf
+++ b/dockers/docker-stp/supervisord.conf
@@ -3,6 +3,14 @@ logfile_maxbytes=1MB
 logfile_backups=2
 nodaemon=true
 
+[eventlistener:dependent-startup]
+command=python -m supervisord_dependent_startup
+autostart=true
+autorestart=unexpected
+startretries=0
+exitcodes=0,3
+events=PROCESS_STATE
+
 [eventlistener:supervisor-proc-exit-listener]
 command=/usr/bin/supervisor-proc-exit-listener --container-name stp
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
@@ -15,16 +23,20 @@ command=/usr/bin/start.sh
 priority=1
 autostart=true
 autorestart=false
+startsecs=0
 stdout_logfile=syslog
 stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=rsyslogd:running
 
 [program:rsyslogd]
-command=/usr/sbin/rsyslogd -n
+command=/usr/sbin/rsyslogd -n -iNONE
 priority=2
 autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
+dependent_startup=true
 
 [program:stpd]
 command=/usr/bin/stpd
@@ -33,6 +45,8 @@ autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=start:exited
 
 [program:stpmgrd]
 command=/usr/bin/stpmgrd
@@ -41,3 +55,5 @@ autostart=false
 autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
+dependent_startup=true
+dependent_startup_wait_for=start:exited


### PR DESCRIPTION
#### Why I did it
The rsyslogd process inside the docker-stp container does not restart properly after executing a config reload or performing a device reboot.

#### How I did it
The issue was resolved by updating the supervisor.conf within the docker-stp — adding an eventlistener:dependent-startup section

#### How to verify it
Make sure the pid of rsyslogd on docker-stp is changed.

