### PR TITLE
Revert the change of community YAML file.

### DIFF
--- a/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D-100G/td4-as9726-32x100G.config.yml
+++ b/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D-100G/td4-as9726-32x100G.config.yml
@@ -790,9 +790,7 @@ device:
 device:
     0:
         TM_THD_CONFIG:
-            THRESHOLD_MODE: LOSSY
-        TM_SCHEDULER_CONFIG:
-            DYNAMIC_VOQ: 0
+            THRESHOLD_MODE: LOSSLESS
 ...
 ---
 device:

--- a/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D/td4-as9726-32x400G.config.yml
+++ b/device/accton/x86_64-accton_as9726_32d-r0/Accton-AS9726-32D/td4-as9726-32x400G.config.yml
@@ -662,9 +662,7 @@ device:
 device:
     0:
         TM_THD_CONFIG:
-            THRESHOLD_MODE: LOSSY
-        TM_SCHEDULER_CONFIG:
-            DYNAMIC_VOQ: 0
+            THRESHOLD_MODE: LOSSLESS
 ...
 ---
 device:


### PR DESCRIPTION
#### Why I did it
Community SAI does not support DYNAMIC_VOQ defined in the community yaml file, causing the syncd container to crash.

#### What I did it
Since the community SAI and ecSAI has differnt yaml file, and community SAI does not support the DYNAMIC_VOQ, the solution is to revert the change of community YAML file.

#### How to verify it
Revert change of community yaml file and reboot device, the syncd container will not crash when running an image with community SAI.
