### PR TITLE
Correct AS9737-32DB status led

### DIFF
--- a/device/accton/x86_64-accton_as9737_32db-r0/platform.json
+++ b/device/accton/x86_64-accton_as9737_32db-r0/platform.json
@@ -3,8 +3,7 @@
         "name": "AS9737-32DB",
         "thermal_manager":false,
         "status_led": {
-            "controllable": true,
-            "colors": ["STATUS_LED_COLOR_RED", "STATUS_LED_COLOR_OFF"]
+            "controllable": false
         },
         "components": [
             {

--- a/device/accton/x86_64-accton_as9737_32db-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as9737_32db-r0/sonic_platform/chassis.py
@@ -28,12 +28,6 @@ PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
 REBOOT_CAUSE_FILE = "reboot-cause.txt"
 PREV_REBOOT_CAUSE_FILE = "previous-reboot-cause.txt"
 
-SYSLED_FNODE= "/sys/devices/platform/as9737_32db_led/led_alarm"
-SYSLED_MODES = {
-    "0" : "STATUS_LED_COLOR_OFF",
-    "10" : "STATUS_LED_COLOR_RED",
-}
-
 class Chassis(ChassisBase):
     """Platform-specific Chassis class"""
 
@@ -291,18 +285,7 @@ class Chassis(ChassisBase):
         return True
 
     def get_status_led(self):
-        val = self._api_helper.read_txt_file(SYSLED_FNODE)
-        return SYSLED_MODES[val] if val in SYSLED_MODES else "UNKNOWN"
+        return "ControlledByBMC"
 
     def set_status_led(self, color):
-        mode = None
-        for key, val in SYSLED_MODES.items():
-            if val == color:
-                mode = key
-                break
-        if mode is None:
-            return False
-        else:
-            return self._api_helper.write_txt_file(SYSLED_FNODE, mode)
-
-
+        return True

--- a/device/accton/x86_64-accton_as9737_32db-r0/system_health_monitoring_config.json
+++ b/device/accton/x86_64-accton_as9737_32db-r0/system_health_monitoring_config.json
@@ -6,8 +6,8 @@
     "user_defined_checkers": [],
     "polling_interval": 60,
     "led_color": {
-        "fault": "STATUS_LED_COLOR_RED",
-        "normal": "STATUS_LED_COLOR_OFF",
-        "booting": "STATUS_LED_COLOR_OFF"
+        "fault": "ControlledByBMC",
+        "normal": "ControlledByBMC",
+        "booting": "ControlledByBMC"
     }
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To address the status LED issue due to hardware limitations:
The status LED is controlled by the BMC instead of the NOS, as in the AS9737-32DB model.
#### How I did it
Correct AS9737-32DB status led
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

