### PR TITLE
[AS9817/AIS800] Support hardware reboot cause via BMC using ipmitool.

### DIFF
--- a/device/accton/x86_64-accton_as9817_64o-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as9817_64o-r0/sonic_platform/chassis.py
@@ -22,10 +22,6 @@ NUM_THERMAL = 13
 NUM_PORT = 66
 NUM_COMPONENT = 5
 
-HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
-PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
-REBOOT_CAUSE_FILE = "reboot-cause.txt"
-PREV_REBOOT_CAUSE_FILE = "previous-reboot-cause.txt"
 SYSLED_FNODE= "/sys/devices/platform/as9817_64_led/led_alarm"
 SYSLED_MODES = {
     "0" : "STATUS_LED_COLOR_OFF",
@@ -177,38 +173,21 @@ class Chassis(ChassisBase):
             to pass a description of the reboot cause.
         """
         description = 'None'
+        reboot_cause = self.REBOOT_CAUSE_NON_HARDWARE
+        try:
+            err, res = getstatusoutput_noshell(['ipmitool', 'raw', '0x34', '0x22', '0x21', '0x30'])
+            if err != 0 or res is None:
+                return (reboot_cause, description)
 
-        reboot_cause_path = (HOST_REBOOT_CAUSE_PATH + REBOOT_CAUSE_FILE) \
-            if self.is_host \
-            else (PMON_REBOOT_CAUSE_PATH + REBOOT_CAUSE_FILE)
-        prev_reboot_cause_path = (HOST_REBOOT_CAUSE_PATH + PREV_REBOOT_CAUSE_FILE) \
-            if self.is_host \
-            else (PMON_REBOOT_CAUSE_PATH + PREV_REBOOT_CAUSE_FILE)
+            code = int(res.strip(), 16)
+            for (key, value) in self.CPU_RESET_REASON.items():
+                if code & key:
+                    reboot_cause = value[0]
+                    description = value[1]
+                    break
 
-        sw_reboot_cause      = self._api_helper.read_txt_file(reboot_cause_path) or "Unknown"
-        prev_sw_reboot_cause = self._api_helper.read_txt_file(prev_reboot_cause_path) or "Unknown"
-
-        if sw_reboot_cause != "Unknown":
-            reboot_cause = self.REBOOT_CAUSE_NON_HARDWARE
-            description = sw_reboot_cause
-        elif prev_sw_reboot_cause != "Unknown":
-            reboot_cause = self.REBOOT_CAUSE_NON_HARDWARE
-            description = prev_sw_reboot_cause
-        else: # Try to get reboot cause from BMC
-            reboot_cause = self.REBOOT_CAUSE_NON_HARDWARE
-            description = 'Unknown'
-            try:
-                err, res = getstatusoutput_noshell(['ipmitool', 'raw', '0x34', '0x22', '0x21', '0x30'])
-                if err != 0 or res is None:
-                    return (reboot_cause, description)
-
-                code = int(res.strip(), 16)
-                for (key, value) in self.CPU_RESET_REASON.items():
-                    if code & key:
-                        reboot_cause = value[0]
-                        description = value[1]
-            except Exception:
-                pass
+        except Exception:
+            pass
 
         return (reboot_cause, description)
 

--- a/device/accton/x86_64-accton_as9817_64o-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as9817_64o-r0/sonic_platform/chassis.py
@@ -12,6 +12,7 @@ try:
     from sonic_platform_base.chassis_base import ChassisBase
     from .helper import APIHelper
     from .event import SfpEvent
+    from sonic_py_common.general import getstatusoutput_noshell
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -40,6 +41,17 @@ class Chassis(ChassisBase):
         self.is_host = self._api_helper.is_host()
 
         self.config_data = {}
+
+        self.CPU_RESET_REASON = {
+            0x80 : [self.REBOOT_CAUSE_THERMAL_OVERLOAD_ASIC,"EC_DIMM CRITICAL RESET"] ,
+            0x40 : [self.REBOOT_CAUSE_WATCHDOG, "CPU WDT RESET" ],
+            0x20 : [self.REBOOT_CAUSE_HARDWARE_OTHER, "CPU COLD RESET"],
+            0x10 : [self.REBOOT_CAUSE_NON_HARDWARE, "CPU WARM RESET"],
+            0x8  : [self.REBOOT_CAUSE_HARDWARE_OTHER, "RESET_BUTTON RESET"],
+            0x4  : [self.REBOOT_CAUSE_HARDWARE_OTHER, "POWER_BUTTON RESET"],
+            0x2  : [self.REBOOT_CAUSE_WATCHDOG, "EC WDT RESET"],
+            0x1  : [self.REBOOT_CAUSE_HARDWARE_OTHER, "POWER_ON RESET"]
+        }
 
         self.__initialize_fan()
         self.__initialize_psu()
@@ -179,9 +191,24 @@ class Chassis(ChassisBase):
         if sw_reboot_cause != "Unknown":
             reboot_cause = self.REBOOT_CAUSE_NON_HARDWARE
             description = sw_reboot_cause
-        elif prev_reboot_cause_path != "Unknown":
+        elif prev_sw_reboot_cause != "Unknown":
             reboot_cause = self.REBOOT_CAUSE_NON_HARDWARE
             description = prev_sw_reboot_cause
+        else: # Try to get reboot cause from BMC
+            reboot_cause = self.REBOOT_CAUSE_NON_HARDWARE
+            description = 'Unknown'
+            try:
+                err, res = getstatusoutput_noshell(['ipmitool', 'raw', '0x34', '0x22', '0x21', '0x30'])
+                if err != 0 or res is None:
+                    return (reboot_cause, description)
+
+                code = int(res.strip(), 16)
+                for (key, value) in self.CPU_RESET_REASON.items():
+                    if code & key:
+                        reboot_cause = value[0]
+                        description = value[1]
+            except Exception:
+                pass
 
         return (reboot_cause, description)
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The software reboot cause check in `chassis.py` was redundant because it's already handled by `determine-reboot-cause`. Also, hardware reboot causes should be retrieved from the BMC.

#### How I did it
- Removed software reboot cause logic and related file dependencies from `chassis.py`.
- Now using `ipmitool` to get the hardware reboot cause from the BMC.
- Cleaned up redundant code.
- 
#### How to verify it
- Trigger hardware reboots (e.g., power button, power loss) on AS9817/AIS800 and verify `show reboot-cause` shows correct info.
- Confirm software reboot causes are still handled properly by `determine-reboot-cause`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202311.X 

#### Description for the changelog
[Platform] [AS9817/AIS800] Support hardware reboot cause via BMC using ipmitool.



#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

