### PR TITLE
Let cache build check the change of sonic-buildimage/device/accton/*/…

### DIFF
--- a/platform/broadcom/platform-modules-accton.dep
+++ b/platform/broadcom/platform-modules-accton.dep
@@ -3,6 +3,7 @@ MPATH       := $($(ACCTON_AS7712_32X_PLATFORM_MODULE)_SRC_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) platform/broadcom/platform-modules-accton.mk platform/broadcom/platform-modules-accton.dep   
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(MPATH))
+DEP_FILES   += $(shell git ls-files device/accton/*/sonic_platform)
 
 $(ACCTON_AS7712_32X_PLATFORM_MODULE)_CACHE_MODE  := GIT_CONTENT_SHA 
 $(ACCTON_AS7712_32X_PLATFORM_MODULE)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cache build does not check ec sonic_platform change
#### How I did it
Let cache build check ec sonic_platform change
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

