### PR TITLE
STP container failed the syslog rate limit test case.

### DIFF
--- a/files/image_config/rsyslog/rsyslog.d/00-sonic.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.d/00-sonic.conf.j2
@@ -51,7 +51,7 @@ if $msg startswith  " telemetry" or ($msg startswith  " dialout" )then {
 }
 
 ## stpd rules
-if $programname contains "stp#" then {
+if $programname contains "stpd" or ($programname contains "stpmgrd" ) then {
     if not ($msg contains "STP_SYSLOG") then {
         /var/log/stpd.log
             stop


### PR DESCRIPTION
What I did:

Modified the STP container's logging rules so that only stpd and stpmgr related logs are written to the separate log file (/var/log/stpd.log). All other logs, including those generated by the test case, are now directed to the standard syslog (/var/log/syslog).

Why I did it:
To fix the failure in the syslog_rate_limit test case, which only checks the standard syslog.

How I verified it:
Ran the test case test_syslog_rate_limit.py and confirmed that all test cases passed.