### PR TITLE
Stop platform init service to unload i2c device node before reboot

### DIFF
--- a/device/accton/x86_64-accton_as7326_56x-r0/fast-reboot_plugin
+++ b/device/accton/x86_64-accton_as7326_56x-r0/fast-reboot_plugin
@@ -1,0 +1,1 @@
+warm-reboot_plugin

--- a/device/accton/x86_64-accton_as7326_56x-r0/soft-reboot_plugin
+++ b/device/accton/x86_64-accton_as7326_56x-r0/soft-reboot_plugin
@@ -1,0 +1,1 @@
+warm-reboot_plugin

--- a/device/accton/x86_64-accton_as7326_56x-r0/warm-reboot_plugin
+++ b/device/accton/x86_64-accton_as7326_56x-r0/warm-reboot_plugin
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+systemctl stop pddf-platform-init.service

--- a/device/accton/x86_64-accton_as9726_32d-r0/soft-reboot_plugin
+++ b/device/accton/x86_64-accton_as9726_32d-r0/soft-reboot_plugin
@@ -1,0 +1,1 @@
+device/accton/x86_64-accton_as9726_32d-r0/warm-reboot_plugin

--- a/device/accton/x86_64-accton_as9736_64d-r0/fast-reboot_plugin
+++ b/device/accton/x86_64-accton_as9736_64d-r0/fast-reboot_plugin
@@ -1,0 +1,1 @@
+device/accton/x86_64-accton_as9736_64d-r0/warm-reboot_plugin


### PR DESCRIPTION
- Add for AS7326-56X
- Add the missing plugin for AS9726/9736