### PR TITLE
[BGP][workaround] Set update-delay for docker_routing_config_mode of separated

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -68,6 +68,9 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   bgp log-neighbor-changes
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
+{% if DEVICE_METADATA['localhost']['type'] == 'LeafRouter' %}
+  update-delay 1
+{% endif %}
 {% if (DEVICE_METADATA is defined) and ('localhost' in DEVICE_METADATA) and ('subtype' in DEVICE_METADATA['localhost']) and (DEVICE_METADATA['localhost']['subtype'].lower() == 'dualtor') %}
   coalesce-time 10000
 {% endif %}


### PR DESCRIPTION
- Why I did it
sonic-mgmt/tests/configlet/test_add_rack.py 
Some ECMP routes have fewer than expected nexthops after config reload.

- How I did it
It will delay the best path selection in BGP.
There is an issue that some paths of route is not selected as ECMP during test_add_rack in t1 topo. This will help to fix it.

- How I verified it
Use a script to verify each ECMP route has 16 nexthops.





