### PR TITLE
[BGP][workaround] Fix build failure of update-delay for sonic_config_engine

### DIFF
--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
@@ -55,6 +55,7 @@ router bgp 65100
   bgp log-neighbor-changes
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
+  update-delay 1
 !
   bgp bestpath as-path multipath-relax
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
@@ -55,6 +55,7 @@ router bgp 65100
   bgp log-neighbor-changes
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
+  update-delay 1
 !
   bgp bestpath as-path multipath-relax
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
@@ -55,6 +55,7 @@ router bgp 65100
   bgp log-neighbor-changes
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
+  update-delay 1
 !
   bgp bestpath as-path multipath-relax
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
@@ -55,6 +55,7 @@ router bgp 65100
   bgp log-neighbor-changes
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
+  update-delay 1
 !
   bgp bestpath as-path multipath-relax
 !


### PR DESCRIPTION
- Why I did it
  Fix
14:38:30    File "/sonic/src/sonic-config-engine/tests/test_multinpu_cfggen.py", line 545, in test_bgpd_frr_backendasic
14:38:30      self.assertTrue(*self.run_frr_asic_case('bgpd/bgpd.conf.j2', 'bgpd_frr_backend_asic.conf', "asic3", self.port_config[3]))

- How I did it
  Updated several files in sonic-config-engine/tests/sample_output

- How I verified it
  make sonic-config-engine-1.0 again