### PR TITLE
[PDDF] Add get_lpmode() to set lpmode default is disable

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/sonic_platform/sfp.py
@@ -208,3 +208,38 @@ class Sfp(PddfSfp):
             pass
         return self.__get_error_description()
 
+    def get_lpmode(self):
+
+        lpmode = False
+
+        if self.get_presence()==False:
+            return False
+
+        device = 'PORT{}'.format(self.port_index)
+        output = self.pddf_obj.get_attr_name_output(device, 'xcvr_lpmode')
+
+        if output:
+            status = int(output['status'].rstrip())
+
+            if status == 1:
+                lpmode = True
+            else:
+                lpmode = False
+        else:
+            xcvr_id = self._xcvr_api_factory._get_id()
+
+            if xcvr_id is not None:
+                if xcvr_id == 0x18 or xcvr_id == 0x19 or xcvr_id == 0x1e:
+                    # QSFP-DD or OSFP
+                    # Use common SfpOptoeBase implementation for get_lpmode
+                    lpmode = super().get_lpmode()
+                elif xcvr_id == 0x11 or xcvr_id == 0x0d or xcvr_id == 0x0c:
+                    # QSFP28, QSFP+, QSFP
+                    # get_power_set() is not defined in the optoe_base class
+                    api = self.get_xcvr_api()
+                    power_set = api.get_power_set()
+                    power_override = self.get_power_override()
+                    
+                    return power_set if power_override else False
+
+        return lpmode

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/sonic_platform/sfp.py
@@ -218,3 +218,39 @@ class Sfp(PddfSfp):
         if self.sfp_type == "QSFP28":
             return super().reset()
         return False
+
+    def get_lpmode(self):
+
+        lpmode = False
+
+        if self.get_presence()==False:
+            return False
+
+        device = 'PORT{}'.format(self.port_index)
+        output = self.pddf_obj.get_attr_name_output(device, 'xcvr_lpmode')
+
+        if output:
+            status = int(output['status'].rstrip())
+
+            if status == 1:
+                lpmode = True
+            else:
+                lpmode = False
+        else:
+            xcvr_id = self._xcvr_api_factory._get_id()
+
+            if xcvr_id is not None:
+                if xcvr_id == 0x18 or xcvr_id == 0x19 or xcvr_id == 0x1e:
+                    # QSFP-DD or OSFP
+                    # Use common SfpOptoeBase implementation for get_lpmode
+                    lpmode = super().get_lpmode()
+                elif xcvr_id == 0x11 or xcvr_id == 0x0d or xcvr_id == 0x0c:
+                    # QSFP28, QSFP+, QSFP
+                    # get_power_set() is not defined in the optoe_base class
+                    api = self.get_xcvr_api()
+                    power_set = api.get_power_set()
+                    power_override = self.get_power_override()
+                    
+                    return power_set if power_override else False
+
+        return lpmode

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/sonic_platform/sfp.py
@@ -18,3 +18,39 @@ class Sfp(PddfSfp):
     def get_position_in_parent(self):
         """Retrieves 1-based relative physical position in parent device."""
         return self.port_index
+
+    def get_lpmode(self):
+
+        lpmode = False
+
+        if self.get_presence()==False:
+            return False
+
+        device = 'PORT{}'.format(self.port_index)
+        output = self.pddf_obj.get_attr_name_output(device, 'xcvr_lpmode')
+
+        if output:
+            status = int(output['status'].rstrip())
+
+            if status == 1:
+                lpmode = True
+            else:
+                lpmode = False
+        else:
+            xcvr_id = self._xcvr_api_factory._get_id()
+
+            if xcvr_id is not None:
+                if xcvr_id == 0x18 or xcvr_id == 0x19 or xcvr_id == 0x1e:
+                    # QSFP-DD or OSFP
+                    # Use common SfpOptoeBase implementation for get_lpmode
+                    lpmode = super().get_lpmode()
+                elif xcvr_id == 0x11 or xcvr_id == 0x0d or xcvr_id == 0x0c:
+                    # QSFP28, QSFP+, QSFP
+                    # get_power_set() is not defined in the optoe_base class
+                    api = self.get_xcvr_api()
+                    power_set = api.get_power_set()
+                    power_override = self.get_power_override()
+                    
+                    return power_set if power_override else False
+
+        return lpmode

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/sonic_platform/sfp.py
@@ -191,3 +191,39 @@ class Sfp(PddfSfp):
         except NotImplementedError:
             pass
         return self.__get_error_description()
+    
+    def get_lpmode(self):
+
+        lpmode = False
+
+        if self.get_presence()==False:
+            return False
+
+        device = 'PORT{}'.format(self.port_index)
+        output = self.pddf_obj.get_attr_name_output(device, 'xcvr_lpmode')
+
+        if output:
+            status = int(output['status'].rstrip())
+
+            if status == 1:
+                lpmode = True
+            else:
+                lpmode = False
+        else:
+            xcvr_id = self._xcvr_api_factory._get_id()
+
+            if xcvr_id is not None:
+                if xcvr_id == 0x18 or xcvr_id == 0x19 or xcvr_id == 0x1e:
+                    # QSFP-DD or OSFP
+                    # Use common SfpOptoeBase implementation for get_lpmode
+                    lpmode = super().get_lpmode()
+                elif xcvr_id == 0x11 or xcvr_id == 0x0d or xcvr_id == 0x0c:
+                    # QSFP28, QSFP+, QSFP
+                    # get_power_set() is not defined in the optoe_base class
+                    api = self.get_xcvr_api()
+                    power_set = api.get_power_set()
+                    power_override = self.get_power_override()
+                    
+                    return power_set if power_override else False
+
+        return lpmode

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/sonic_platform/sfp.py
@@ -15,3 +15,39 @@ class Sfp(PddfSfp):
         PddfSfp.__init__(self, index, pddf_data, pddf_plugin_data)
 
     # Provide the functions/variables below for which implementation is to be overwritten
+
+    def get_lpmode(self):
+
+        lpmode = False
+
+        if self.get_presence()==False:
+            return False
+
+        device = 'PORT{}'.format(self.port_index)
+        output = self.pddf_obj.get_attr_name_output(device, 'xcvr_lpmode')
+
+        if output:
+            status = int(output['status'].rstrip())
+
+            if status == 1:
+                lpmode = True
+            else:
+                lpmode = False
+        else:
+            xcvr_id = self._xcvr_api_factory._get_id()
+
+            if xcvr_id is not None:
+                if xcvr_id == 0x18 or xcvr_id == 0x19 or xcvr_id == 0x1e:
+                    # QSFP-DD or OSFP
+                    # Use common SfpOptoeBase implementation for get_lpmode
+                    lpmode = super().get_lpmode()
+                elif xcvr_id == 0x11 or xcvr_id == 0x0d or xcvr_id == 0x0c:
+                    # QSFP28, QSFP+, QSFP
+                    # get_power_set() is not defined in the optoe_base class
+                    api = self.get_xcvr_api()
+                    power_set = api.get_power_set()
+                    power_override = self.get_power_override()
+                    
+                    return power_set if power_override else False
+
+        return lpmode

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/sonic_platform/sfp.py
@@ -259,3 +259,39 @@ class Sfp(PddfSfp):
         except NotImplementedError:
             pass
         return self.__get_error_description()
+
+    def get_lpmode(self):
+
+        lpmode = False
+
+        if self.get_presence()==False:
+            return False
+
+        device = 'PORT{}'.format(self.port_index)
+        output = self.pddf_obj.get_attr_name_output(device, 'xcvr_lpmode')
+
+        if output:
+            status = int(output['status'].rstrip())
+
+            if status == 1:
+                lpmode = True
+            else:
+                lpmode = False
+        else:
+            xcvr_id = self._xcvr_api_factory._get_id()
+
+            if xcvr_id is not None:
+                if xcvr_id == 0x18 or xcvr_id == 0x19 or xcvr_id == 0x1e:
+                    # QSFP-DD or OSFP
+                    # Use common SfpOptoeBase implementation for get_lpmode
+                    lpmode = super().get_lpmode()
+                elif xcvr_id == 0x11 or xcvr_id == 0x0d or xcvr_id == 0x0c:
+                    # QSFP28, QSFP+, QSFP
+                    # get_power_set() is not defined in the optoe_base class
+                    api = self.get_xcvr_api()
+                    power_set = api.get_power_set()
+                    power_override = self.get_power_override()
+                    
+                    return power_set if power_override else False
+
+        return lpmode


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
PDDF framework set lpmode default setting to enable.
#### How I did it
Add get_lpmode to override pddf_sfp,py api, so accton platform will get default value=False.
Modify below plaform, 
as4630-54pe
as7326
as7726
as7712
as9716
as7816
#### How to verify it
root@sonic:~# sfputil show presence
Port         Presence
-----------  -----------
Ethernet0    Not present
Ethernet8    Not present
Ethernet16   Not present
Ethernet24   Not present
Ethernet32   Not present
Ethernet40   Present
Ethernet48   Not present
Ethernet56   Present


Port         Low-power Mode
-----------  ----------------
Ethernet40   Off
Ethernet56   Off
root@sonic:~#

root@sonic:~# sfputil lpmode on Ethernet40
Enabling low-power mode for port Ethernet40 ... OK
Port         Low-power Mode
-----------  ----------------
Ethernet40   On

root@sonic:~# sfputil lpmode off Ethernet40
Disabling low-power mode for port Ethernet40 ...


root@sonic:/home/admin# sfputil show lpmode

Port         Low-power Mode
-----------  ----------------
Ethernet40   Off
Ethernet56   Off
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

