### PR TITLE
RS/RA packets must be dropped at software dataplane to prevent the BUM looping.

### DIFF
--- a/files/build_templates/nftables.conf.j2
+++ b/files/build_templates/nftables.conf.j2
@@ -12,8 +12,8 @@ table bridge filter {
                 iifname "PortChannel*" counter packets 0 bytes 0 jump MCLAG_PORT_ISOLATION
                 iifname "Ethernet*" counter packets 0 bytes 0 jump MCLAG_PORT_ISOLATION
                 iifname "VTTNL*" counter packets 0 bytes 0 jump MCLAG_PORT_ISOLATION
-                ether type ip6 icmpv6 type 135-136 icmpv6 code 0  counter packets 0 bytes 0 jump ND_LIST
-                ether type vlan vlan type ip6 icmpv6 type 135-136 icmpv6 code 0 counter packets 0 bytes 0 jump ND_LIST
+                ether type ip6 icmpv6 type 133-136 icmpv6 code 0  counter packets 0 bytes 0 jump ND_LIST
+                ether type vlan vlan type ip6 icmpv6 type 133-136 icmpv6 code 0 counter packets 0 bytes 0 jump ND_LIST
                 ether type vlan vlan type 0x0806  counter packets 0 bytes 0 jump VLAN_ARP_LIST
                 ether type arp counter packets 0 bytes 0 jump ARP_LIST
                 ether type ip ip daddr 255.255.255.255 udp sport 68 udp dport 67  counter packets 0 bytes 0 jump VLAN_UNTAG_PORT_LIST
@@ -21,8 +21,8 @@ table bridge filter {
                 ether daddr 01:80:c2:00:00:00 counter packets 0 bytes 0 drop
                 ether type arp counter packets 0 bytes 0 drop
                 ether type vlan vlan type 0x0806  counter packets 0 bytes 0 drop
-                ether type ip6 icmpv6 type 135-136 icmpv6 code 0  counter packets 0 bytes 0 drop
-                ether type vlan vlan type ip6 icmpv6 type 135-136 icmpv6 code 0 counter packets 0 bytes 0 drop
+                ether type ip6 icmpv6 type 133-136 icmpv6 code 0  counter packets 0 bytes 0 drop
+                ether type vlan vlan type ip6 icmpv6 type 133-136 icmpv6 code 0 counter packets 0 bytes 0 drop
                 ether type vlan vlan type 0x8100  counter packets 0 bytes 0 drop
 {%- endif %}
         }


### PR DESCRIPTION
The original rules in the bridge forward chain of the nft table have been expanded to drop RS/RA types.