### PR TITLE
Remove unnecessary redis key check

### DIFF
--- a/src/sonic-py-common/sonic_py_common/port_util.py
+++ b/src/sonic-py-common/sonic_py_common/port_util.py
@@ -134,8 +134,8 @@ def get_vlan_id_from_bvid(db, bvid):
         Get the Vlan Id from Bridge Vlan Object
     """
     db.connect('ASIC_DB')
-    vlan_obj = db.keys('ASIC_DB', str("ASIC_STATE:SAI_OBJECT_TYPE_VLAN:" + bvid))
-    vlan_entry = db.get_all('ASIC_DB', vlan_obj[0], blocking=True)
+    vlan_obj = str("ASIC_STATE:SAI_OBJECT_TYPE_VLAN:" + bvid)
+    vlan_entry = db.get_all('ASIC_DB', vlan_obj, blocking=False)
     vlan_id = None
     # TODO: remove the first branch after all SonicV2Connector are migrated to decode_responses
     if isinstance(db, swsscommon.SonicV2Connector) == False and db.dbintf.redis_kwargs.get('decode_responses', False) == False:


### PR DESCRIPTION
#### Why I did it
1. When the DUT learns a large number of FDB entries, executing the "show arp" command takes a long time.

#### How I did it
1. Remove unnecessary redis key check

#### How to verify it
1. https://accton-group.atlassian.net/browse/SONIC-12488
