### PR TITLE
Fix the issue: Breakout Ethernet144 to 2x400G[200G], the subport can’…

### DIFF
--- a/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D-100G/th5-as9817-32d-32x100G.config.yml
+++ b/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D-100G/th5-as9817-32d-32x100G.config.yml
@@ -38,7 +38,7 @@ bcm_device:
   0:
     global:
       dport_map_direct: 1
-      dport_map_enable: 1
+      dport_map_enable: 0
       dport_map_indexed: 1
     port:
       "264":

--- a/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D-100G/th5-as9817-32d-32x100G_ec.config.yml
+++ b/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D-100G/th5-as9817-32d-32x100G_ec.config.yml
@@ -19,7 +19,7 @@ bcm_device:
   0:
     global:
       dport_map_direct: 1
-      dport_map_enable: 1
+      dport_map_enable: 0
       dport_map_indexed: 1
     port:
       "264":

--- a/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D/th5-as9817-32d-32x800G.config.yml
+++ b/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D/th5-as9817-32d-32x800G.config.yml
@@ -38,7 +38,7 @@ bcm_device:
   0:
     global:
       dport_map_direct: 1
-      dport_map_enable: 1
+      dport_map_enable: 0
       dport_map_indexed: 1
     port:
       "264":

--- a/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D/th5-as9817-32d-32x800G_ec.config.yml
+++ b/device/accton/x86_64-accton_as9817_32d-r0/Accton-AS9817-32D/th5-as9817-32d-32x800G_ec.config.yml
@@ -19,7 +19,7 @@ bcm_device:
   0:
     global:
       dport_map_direct: 1
-      dport_map_enable: 1
+      dport_map_enable: 0
       dport_map_indexed: 1
     port:
       "264":

--- a/device/accton/x86_64-accton_as9817_32o-r0/Accton-AS9817-32O-100G/th5-as9817-32o-32x100G.config.yml
+++ b/device/accton/x86_64-accton_as9817_32o-r0/Accton-AS9817-32O-100G/th5-as9817-32o-32x100G.config.yml
@@ -38,7 +38,7 @@ bcm_device:
   0:
     global:
       dport_map_direct: 1
-      dport_map_enable: 1
+      dport_map_enable: 0
       dport_map_indexed: 1
     port:
       "264":

--- a/device/accton/x86_64-accton_as9817_32o-r0/Accton-AS9817-32O-100G/th5-as9817-32o-32x100G_ec.config.yml
+++ b/device/accton/x86_64-accton_as9817_32o-r0/Accton-AS9817-32O-100G/th5-as9817-32o-32x100G_ec.config.yml
@@ -19,7 +19,7 @@ bcm_device:
   0:
     global:
       dport_map_direct: 1
-      dport_map_enable: 1
+      dport_map_enable: 0
       dport_map_indexed: 1
     port:
       "264":

--- a/device/accton/x86_64-accton_as9817_32o-r0/Accton-AS9817-32O/th5-as9817-32o-32x800G.config.yml
+++ b/device/accton/x86_64-accton_as9817_32o-r0/Accton-AS9817-32O/th5-as9817-32o-32x800G.config.yml
@@ -38,7 +38,7 @@ bcm_device:
   0:
     global:
       dport_map_direct: 1
-      dport_map_enable: 1
+      dport_map_enable: 0
       dport_map_indexed: 1
     port:
       "264":

--- a/device/accton/x86_64-accton_as9817_32o-r0/Accton-AS9817-32O/th5-as9817-32o-32x800G_ec.config.yml
+++ b/device/accton/x86_64-accton_as9817_32o-r0/Accton-AS9817-32O/th5-as9817-32o-32x800G_ec.config.yml
@@ -19,7 +19,7 @@ bcm_device:
   0:
     global:
       dport_map_direct: 1
-      dport_map_enable: 1
+      dport_map_enable: 0
       dport_map_indexed: 1
     port:
       "264":


### PR DESCRIPTION
…t be created.

Root Cause:
dport_map_enable=1

When enabled, port names will be assigned in diag shell port order, and the BCM shell will list multiple ports in diag shell port order regardless of the logical port numbering. If there are no dport_map_port directives in the configuration file, ports will be listed in logical port order.

IMPORTANT: If dport mapping is used, it is important to map all logical ports to ensure that ports will be listed correctly after port flex operations..

Solution:
Modify dport_map_enable from 1 to 0.

Regression log:

admin@sonic:~$ sudo bash
root@sonic:/home/admin#
root@sonic:/home/admin# show boot
Current: SONiC-OS-Edgecore-SONiC_202311.3_ec202311_331 Next: SONiC-OS-Edgecore-SONiC_202311.3_ec202311_331 Available:
SONiC-OS-Edgecore-SONiC_202311.3_ec202311_331
SONiC-OS-Edgecore-SONiC_202311.3_ec202311_281

root@sonic:/home/admin#
root@sonic:/home/admin# show int sta Ethernet144
  Interface                    Lanes    Speed    MTU    FEC          Alias    Vlan    Oper    Admin    ProtoDown    Eff Admin    Type    Asym PFC
-----------  -----------------------  -------  -----  -----  -------------  ------  ------  -------  -----------  -----------  ------  ----------
Ethernet144  17,18,19,20,21,22,23,24     800G   9100    N/A  Eth19(Port19)  routed    down       up        False           up     N/A         N/A
root@sonic:/home/admin#                                                        y
root@sonic:/home/admin# config interface breakout Ethernet144 2x400G[200G] -f -y
Running Breakout Mode : 1x800G
Target Breakout Mode : 2x400G[200G]

Ports to be deleted :
 {
    "Ethernet144": "800000"
}
Ports to be added :
 {
    "Ethernet144": "400000",
    "Ethernet148": "400000"
}
sonic_yang(6):Note: Below table(s) have no YANG models: REST_SERVER Breakout process got successfully completed.
Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`. root@sonic:/home/admin#
root@sonic:/home/admin# bcmcmd 'ps cd'
ps cd
              ena/        speed/ link auto    STP                  lrn             max    cut                 loop
        port  link  Lns   duplex scan neg?   state   pause  discrd ops   medium  frame   thru            FEC  back
    cd0( 11)  !ena   4  400G  FD   SW  No   Forward          None   FA Backplane  9122   No        RS544-2xN
    cd1( 13)  !ena   4  400G  FD   SW  No   Forward          None   FA Backplane  9122   No        RS544-2xN

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

