### PR TITLE
Nexthop compare function include vxlan encap info.

### DIFF
--- a/src/sonic-frr/patch/0042-Nexthop-compare-function-include-vxlan-encap-info.patch
+++ b/src/sonic-frr/patch/0042-Nexthop-compare-function-include-vxlan-encap-info.patch
@@ -1,0 +1,32 @@
+From 7d9878ba6eefdc7ad1bf3934381df1a911f9ad19 Mon Sep 17 00:00:00 2001
+From: "minkang_tsai@edge-core.com" <ubuntu@contoso.com>
+Date: Tue, 1 Jul 2025 03:45:53 +0000
+Subject: [PATCH] Nexthop compare function include vxlan encap info.
+
+
+diff --git a/lib/nexthop.c b/lib/nexthop.c
+index fe42b9f86..ab7eb64b6 100644
+--- a/lib/nexthop.c
++++ b/lib/nexthop.c
+@@ -196,6 +196,18 @@ static int _nexthop_cmp_no_labels(const struct nexthop *next1,
+ 	if (ret != 0)
+ 		goto done;
+ 
++	if (next1->nh_encap_type < next2->nh_encap_type)
++		return -1;
++	if (next1->nh_encap_type > next2->nh_encap_type)
++		return 1;
++	if (next1->nh_encap.encap_data.vni < next2->nh_encap.encap_data.vni)
++		return -1;
++	if (next1->nh_encap.encap_data.vni > next2->nh_encap.encap_data.vni)
++		return 1;
++	ret = memcmp(next1->nh_encap.encap_data.rmac.octet, next2->nh_encap.encap_data.rmac.octet, ETH_ALEN);
++	if (ret != 0)
++		return ret;
++
+ 	if (!CHECK_FLAG(next1->flags, NEXTHOP_FLAG_HAS_BACKUP) &&
+ 	    !CHECK_FLAG(next2->flags, NEXTHOP_FLAG_HAS_BACKUP))
+ 		return 0;
+-- 
+2.30.2
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -38,3 +38,4 @@ cross-compile-changes.patch
 0039-Let-it-return-the-first-matched-route-in-mibII-ipforward-in-zebra_snmp.patch
 0040-bgpd-some-safi-s-do-not-mix-with-bgp-suppress-fib.patch
 0041-zebra-Check-if-ifp-is-not-NULL-in-zebra_if_update_ct.patch
+0042-Nexthop-compare-function-include-vxlan-encap-info.patch


### PR DESCRIPTION
#### Why I did it
The type 5 route must check for additional information in the nexthop, which is about encap data. This helps prevent l3 egress from using the wrong RMAC. 



