### PR TITLE
[monit] Add cleanup of stale pid and sock before start/restart

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -361,6 +361,18 @@ sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/memory_checker
 sudo cp $IMAGE_CONFIGS/monit/restart_service $FILESYSTEM_ROOT/usr/bin/
 sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/restart_service
 
+# Patch /etc/init.d/monit to remove stale pid/sock in start)
+sudo sed -i '/^\s*start)/a\
+    # Remove stale monit.pid and monit.sock before start\n\
+    if [ -e /var/run/monit.pid ]; then rm -f /var/run/monit.pid; fi\n\
+    if [ -e /var/run/monit.sock ]; then rm -f /var/run/monit.sock; fi' $FILESYSTEM_ROOT/etc/init.d/monit
+
+# Patch /etc/init.d/monit to remove stale pid/sock in restart|force-reload)
+sudo sed -i '/^\s*restart|force-reload)/a\
+    # Remove stale monit.pid and monit.sock before restart\n\
+    if [ -e /var/run/monit.pid ]; then rm -f /var/run/monit.pid; fi\n\
+    if [ -e /var/run/monit.sock ]; then rm -f /var/run/monit.sock; fi' $FILESYSTEM_ROOT/etc/init.d/monit
+
 # Installed smartmontools version should match installed smartmontools in docker-platform-monitor Dockerfile
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install smartmontools=7.2-1
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`monit` may fail to start or restart if stale files such as `/var/run/monit.pid` or `/var/run/monit.sock` are present, which can happen during an unclean shutdown, crash, or manual kill.

This can prevent `monit` from restarting properly on SONiC systems, especially when relying on init.d scripts instead of systemd units.
#### How I did it
- Use `sed` in `sonic_debian_extension.j2` to patch `/etc/init.d/monit`
- Inject logic in `start)` and `restart|force-reload)` blocks to remove:
  - `/var/run/monit.pid`
  - `/var/run/monit.sock`

This ensures a clean startup for `monit` in both normal and crash-recovery scenarios.

#### How to verify it
- Built image with modified `sonic_debian_extension.j2`
- Verified that monit can restart after killing its process manually
- Checked that pid/sock files are properly removed and recreated
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

