### PR TITLE
[PLATFORM][5835-54X/T] make eth1(06:00.0) init  after eth0(05:00.0)

### DIFF
--- a/device/accton/x86_64-accton_as5835_54t-r0/installer.conf
+++ b/device/accton/x86_64-accton_as5835_54t-r0/installer.conf
@@ -1,4 +1,4 @@
 CONSOLE_PORT=0x3f8
 CONSOLE_DEV=0
 CONSOLE_SPEED=115200
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="pcie_aspm=off intel_iommu=off modprobe.blacklist=i2c-ismt,i2c_ismt,i2c-i801,i2c_i801"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="pcie_aspm=off intel_iommu=off modprobe.blacklist=i2c-ismt,i2c_ismt,i2c-i801,i2c_i801,ixgbe"

--- a/device/accton/x86_64-accton_as5835_54t-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as5835_54t-r0/pddf/pddf-device.json
@@ -30,6 +30,7 @@
         },
         "std_kos":
         [
+	    "ixgbe",
             "i2c-i801",
             "i2c-ismt",
             "i2c_dev",

--- a/device/accton/x86_64-accton_as5835_54x-r0/installer.conf
+++ b/device/accton/x86_64-accton_as5835_54x-r0/installer.conf
@@ -1,4 +1,4 @@
 CONSOLE_PORT=0x3f8
 CONSOLE_DEV=0
 CONSOLE_SPEED=115200
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="pcie_aspm=off intel_iommu=off modprobe.blacklist=i2c-ismt,i2c_ismt,i2c-i801,i2c_i801"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="pcie_aspm=off intel_iommu=off modprobe.blacklist=i2c-ismt,i2c_ismt,i2c-i801,i2c_i801,ixgbe"

--- a/device/accton/x86_64-accton_as5835_54x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as5835_54x-r0/pddf/pddf-device.json
@@ -30,6 +30,7 @@
         },
         "std_kos":
         [
+	    "ixgbe",
             "i2c-i801",
             "i2c-ismt",
             "i2c_dev",

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/utils/accton_as5835_54t_util.py
@@ -155,6 +155,7 @@ def driver_check():
 
 
 kos = [
+'modprobe ixgbe',
 'modprobe i2c_dev',
 'modprobe i2c_mux_pca954x force_deselect_on_exit=1',
 'modprobe accton_as5835_54t_cpld'  ,
@@ -162,7 +163,8 @@ kos = [
 'modprobe accton_as5835_54t_fan'     ,
 'modprobe optoe'      ,
 'modprobe accton_as5835_54t_leds'      ,
-'modprobe accton_as5835_54t_psu' ]
+'modprobe accton_as5835_54t_psu'
+]
 
 def driver_install():
     global FORCE

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/utils/accton_as5835_54x_util.py
@@ -127,6 +127,7 @@ def driver_check():
 
 
 kos = [
+'modprobe ixgbe', 
 'modprobe i2c_dev',
 'modprobe i2c_i801',
 'modprobe i2c_ismt',
@@ -136,7 +137,8 @@ kos = [
 'modprobe accton_as5835_54x_fan'     ,
 'modprobe optoe'      ,
 'modprobe accton_as5835_54x_leds'      ,
-'modprobe accton_as5835_54x_psu' ]
+'modprobe accton_as5835_54x_psu' ,
+]
 
 def driver_install():
     global FORCE


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Load eth1 kernel driver after eth0 to avoid the chance make eth1 device occupy the 'eth0' name

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

