### PR TITLE
BGP should delay its startup until the port initialization is complete

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -108,7 +108,7 @@ function preStartAction()
     fi
 {%- elif docker_container_name == "snmp" %}
     $SONIC_DB_CLI STATE_DB HSET 'DEVICE_METADATA|localhost' chassis_serial_number $(decode-syseeprom -s)
-{%- elif docker_container_name == "dhcp_relay" or docker_container_name == "iccpd" %}
+{%- elif docker_container_name == "dhcp_relay" or docker_container_name == "iccpd" or docker_container_name == "bgp" %}
     until [[ $($SONIC_DB_CLI APPL_DB EXISTS "PORT_TABLE:PortInitDone" | grep -c 1) -gt 0 ]]; do
         sleep 1;
     done


### PR DESCRIPTION
#### Why did it
If BGP startup without waiting port initialization to be complete.
The FRR configuration might disappered.
Also it may cause route inconsistent issue between app and asic db.

#### How I did
Delay BGP startup until the port initialization is complete.

#### How to verify it
Observe the syslog

