### PR TITLE
[build] bullseye-backports is invalid for APT::Default-Release

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -414,8 +414,11 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     nftables
 
 # default rsyslog version is 8.2110.0 which has a bug on log rate limit,
-# use backport version
-sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -t bullseye-backports -y install rsyslog
+# use backport version rsyslog_8.2302.0-1~bpo11+1
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT curl -o /tmp/rsyslog.deb -fsSL \
+        http://ftp.de.debian.org/debian/pool/main/r/rsyslog/rsyslog_8.2302.0-1~bpo11+1_${CONFIGURED_ARCH}.deb
+sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install -f /tmp/rsyslog.deb
+sudo LANG=C chroot $FILESYSTEM_ROOT rm -f /tmp/rsyslog.deb
 
 # Have systemd create the auditd log directory
 sudo mkdir -p ${FILESYSTEM_ROOT}/etc/systemd/system/auditd.service.d

--- a/dockers/docker-base-bullseye/Dockerfile.j2
+++ b/dockers/docker-base-bullseye/Dockerfile.j2
@@ -61,8 +61,20 @@ RUN apt-get update &&        \
         libwrap0
 
 # default rsyslog version is 8.2110.0 which has a bug on log rate limit,
-# use backport version 8.2206.0-1~bpo11+1
-RUN apt-get -t bullseye-backports -y install rsyslog
+# use backport version rsyslog_8.2302.0-1~bpo11+1
+{% if CONFIGURED_ARCH == "armhf" %}
+    RUN curl -o rsyslog_8.2302.0-1~bpo11+1_armhf.deb "http://ftp.de.debian.org/debian/pool/main/r/rsyslog/rsyslog_8.2302.0-1~bpo11+1_armhf.deb"
+    RUN dpkg -i rsyslog_8.2302.0-1~bpo11+1_armhf.deb || apt-get install -f -y
+    RUN rm rsyslog_8.2302.0-1~bpo11+1_armhf.deb
+{% elif CONFIGURED_ARCH == "arm64" %}
+    RUN curl -o rsyslog_8.2302.0-1~bpo11+1_arm64.deb  "http://ftp.de.debian.org/debian/pool/main/r/rsyslog/rsyslog_8.2302.0-1~bpo11+1_arm64.deb"
+    RUN dpkg -i rsyslog_8.2302.0-1~bpo11+1_arm64.deb || apt-get install -f -y
+    RUN rm rsyslog_8.2302.0-1~bpo11+1_arm64.deb
+{% else %}
+    RUN curl -o rsyslog_8.2302.0-1~bpo11+1_amd64.deb "http://ftp.de.debian.org/debian/pool/main/r/rsyslog/rsyslog_8.2302.0-1~bpo11+1_amd64.deb"
+    RUN dpkg -i rsyslog_8.2302.0-1~bpo11+1_amd64.deb || apt-get install -f -y
+    RUN rm rsyslog_8.2302.0-1~bpo11+1_amd64.deb
+{% endif %}
 
 # Upgrade pip via PyPI and uninstall the Debian version
 RUN pip3 install --upgrade pip


### PR DESCRIPTION
apt-get failed for bullseye-backports.
Download and install rsyslog.deb manually

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

