### PR TITLE
[build] bullseye-backports is invalid for APT::Default-Release

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -414,8 +414,11 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     nftables
 
 # default rsyslog version is 8.2110.0 which has a bug on log rate limit,
-# use backport version
-sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -t bullseye-backports -y install rsyslog
+# use backport version rsyslog_8.2302.0-1~bpo11+1
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT curl -o /tmp/rsyslog.deb -fsSL \
+        http://ftp.de.debian.org/debian/pool/main/r/rsyslog/rsyslog_8.2302.0-1~bpo11+1_${CONFIGURED_ARCH}.deb
+sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install -f /tmp/rsyslog.deb
+sudo LANG=C chroot $FILESYSTEM_ROOT rm -f /tmp/rsyslog.deb
 
 # Have systemd create the auditd log directory
 sudo mkdir -p ${FILESYSTEM_ROOT}/etc/systemd/system/auditd.service.d

--- a/dockers/docker-base-bullseye/Dockerfile.j2
+++ b/dockers/docker-base-bullseye/Dockerfile.j2
@@ -61,8 +61,20 @@ RUN apt-get update &&        \
         libwrap0
 
 # default rsyslog version is 8.2110.0 which has a bug on log rate limit,
-# use backport version 8.2206.0-1~bpo11+1
-RUN apt-get -t bullseye-backports -y install rsyslog
+# use backport version rsyslog_8.2302.0-1~bpo11+1
+{% if CONFIGURED_ARCH == "armhf" %}
+    RUN curl -o rsyslog_8.2302.0-1~bpo11+1_armhf.deb "http://ftp.de.debian.org/debian/pool/main/r/rsyslog/rsyslog_8.2302.0-1~bpo11+1_armhf.deb"
+    RUN dpkg -i rsyslog_8.2302.0-1~bpo11+1_armhf.deb || apt-get install -f -y
+    RUN rm rsyslog_8.2302.0-1~bpo11+1_armhf.deb
+{% elif CONFIGURED_ARCH == "arm64" %}
+    RUN curl -o rsyslog_8.2302.0-1~bpo11+1_arm64.deb  "http://ftp.de.debian.org/debian/pool/main/r/rsyslog/rsyslog_8.2302.0-1~bpo11+1_arm64.deb"
+    RUN dpkg -i rsyslog_8.2302.0-1~bpo11+1_arm64.deb || apt-get install -f -y
+    RUN rm rsyslog_8.2302.0-1~bpo11+1_arm64.deb
+{% else %}
+    RUN curl -o rsyslog_8.2302.0-1~bpo11+1_amd64.deb "http://ftp.de.debian.org/debian/pool/main/r/rsyslog/rsyslog_8.2302.0-1~bpo11+1_amd64.deb"
+    RUN dpkg -i rsyslog_8.2302.0-1~bpo11+1_amd64.deb || apt-get install -f -y
+    RUN rm rsyslog_8.2302.0-1~bpo11+1_amd64.deb
+{% endif %}
 
 # Upgrade pip via PyPI and uninstall the Debian version
 RUN pip3 install --upgrade pip


### PR DESCRIPTION
apt-get failed for bullseye-backports.
Download and install rsyslog.deb manually