### PR TITLE
flashrom build fix: incorrect tag name (#21473)

### DIFF
--- a/src/flashrom/Makefile
+++ b/src/flashrom/Makefile
@@ -12,7 +12,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	pushd ./flashrom-$(FLASHROM_VERSION_FULL)
 
 	# Check out tag: tags/0.9.7
-	git checkout -b flashrom-src tags/$(FLASHROM_VERSION_FULL)
+	git checkout -b flashrom-src v$(FLASHROM_VERSION_FULL)
 
 	# Apply patch series
 	stg init


### PR DESCRIPTION
flashrom recently started failing to build with the below error:
```
Cloning into 'flashrom-0.9.7'...
/sonic/src/flashrom/flashrom-0.9.7 /sonic/src/flashrom
fatal: 'tags/0.9.7' is not a commit and a branch 'flashrom-src' cannot be created from it
```
Nothing in sonic-buildimage has changed in relation to this so presumably flashrom upstream renamed their tags.

This commit just fixes the formatting of the tag name to use the new format.

Signed-off-by: Brad House (@bradh352)