### PR TITLE
Correct download URL of debian package rsyslog_8.2302.0-1~bpo11+1

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -416,7 +416,7 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
 # default rsyslog version is 8.2110.0 which has a bug on log rate limit,
 # use backport version rsyslog_8.2302.0-1~bpo11+1
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT curl -o /tmp/rsyslog.deb -fsSL \
-        http://ftp.de.debian.org/debian/pool/main/r/rsyslog/rsyslog_8.2302.0-1~bpo11+1_${CONFIGURED_ARCH}.deb
+        http://ftp.debian.org/debian/pool/main/r/rsyslog/rsyslog_8.2302.0-1~bpo11+1_${CONFIGURED_ARCH}.deb
 sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install -f /tmp/rsyslog.deb
 sudo LANG=C chroot $FILESYSTEM_ROOT rm -f /tmp/rsyslog.deb
 

--- a/dockers/docker-base-bullseye/Dockerfile.j2
+++ b/dockers/docker-base-bullseye/Dockerfile.j2
@@ -63,15 +63,15 @@ RUN apt-get update &&        \
 # default rsyslog version is 8.2110.0 which has a bug on log rate limit,
 # use backport version rsyslog_8.2302.0-1~bpo11+1
 {% if CONFIGURED_ARCH == "armhf" %}
-    RUN curl -o rsyslog_8.2302.0-1~bpo11+1_armhf.deb "http://ftp.de.debian.org/debian/pool/main/r/rsyslog/rsyslog_8.2302.0-1~bpo11+1_armhf.deb"
+    RUN curl -o rsyslog_8.2302.0-1~bpo11+1_armhf.deb "http://ftp.debian.org/debian/pool/main/r/rsyslog/rsyslog_8.2302.0-1~bpo11+1_armhf.deb"
     RUN dpkg -i rsyslog_8.2302.0-1~bpo11+1_armhf.deb || apt-get install -f -y
     RUN rm rsyslog_8.2302.0-1~bpo11+1_armhf.deb
 {% elif CONFIGURED_ARCH == "arm64" %}
-    RUN curl -o rsyslog_8.2302.0-1~bpo11+1_arm64.deb  "http://ftp.de.debian.org/debian/pool/main/r/rsyslog/rsyslog_8.2302.0-1~bpo11+1_arm64.deb"
+    RUN curl -o rsyslog_8.2302.0-1~bpo11+1_arm64.deb  "http://ftp.debian.org/debian/pool/main/r/rsyslog/rsyslog_8.2302.0-1~bpo11+1_arm64.deb"
     RUN dpkg -i rsyslog_8.2302.0-1~bpo11+1_arm64.deb || apt-get install -f -y
     RUN rm rsyslog_8.2302.0-1~bpo11+1_arm64.deb
 {% else %}
-    RUN curl -o rsyslog_8.2302.0-1~bpo11+1_amd64.deb "http://ftp.de.debian.org/debian/pool/main/r/rsyslog/rsyslog_8.2302.0-1~bpo11+1_amd64.deb"
+    RUN curl -o rsyslog_8.2302.0-1~bpo11+1_amd64.deb "http://ftp.debian.org/debian/pool/main/r/rsyslog/rsyslog_8.2302.0-1~bpo11+1_amd64.deb"
     RUN dpkg -i rsyslog_8.2302.0-1~bpo11+1_amd64.deb || apt-get install -f -y
     RUN rm rsyslog_8.2302.0-1~bpo11+1_amd64.deb
 {% endif %}


### PR DESCRIPTION
#### Why I did it
Correct download URL of debian package rsyslog_8.2302.0-1~bpo11+1


