### PR TITLE
update submodule sonic-host-service URL, because community branch cannot download PyGObject correctly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -114,8 +114,8 @@
 	branch = 202311
 [submodule "src/sonic-host-services"]
 	path = src/sonic-host-services
-	url = https://github.com/sonic-net/sonic-host-services
-	branch = 202311
+	url = https://github.com/edge-core/sonic-host-services.git
+	branch = 202311.0
 [submodule "src/sonic-gnmi"]
 	path = src/sonic-gnmi
 	url = https://github.com/sonic-net/sonic-gnmi.git


### PR DESCRIPTION
update submodule sonic-host-service URL, because community branch cannot download PyGObject correctly
