### PR TITLE
[AS9817-32O/AS9737-32DB] Remove software reboot cause logic from chas…

### DIFF
--- a/device/accton/x86_64-accton_as9737_32db-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as9737_32db-r0/sonic_platform/chassis.py
@@ -23,11 +23,6 @@ NUM_THERMAL = 10
 NUM_PORT = 33
 NUM_COMPONENT = 5
 
-HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
-PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
-REBOOT_CAUSE_FILE = "reboot-cause.txt"
-PREV_REBOOT_CAUSE_FILE = "previous-reboot-cause.txt"
-
 class Chassis(ChassisBase):
     """Platform-specific Chassis class"""
 
@@ -173,38 +168,21 @@ class Chassis(ChassisBase):
             to pass a description of the reboot cause.
         """
         description = 'None'
+        reboot_cause = self.REBOOT_CAUSE_NON_HARDWARE
+        try:
+            err, res = getstatusoutput_noshell(['ipmitool', 'raw', '0x34', '0x22', '0x21', '0x30'])
+            if err != 0 or res is None:
+                return (reboot_cause, description)
 
-        reboot_cause_path = (HOST_REBOOT_CAUSE_PATH + REBOOT_CAUSE_FILE) \
-            if self.is_host \
-            else (PMON_REBOOT_CAUSE_PATH + REBOOT_CAUSE_FILE)
-        prev_reboot_cause_path = (HOST_REBOOT_CAUSE_PATH + PREV_REBOOT_CAUSE_FILE) \
-            if self.is_host \
-            else (PMON_REBOOT_CAUSE_PATH + PREV_REBOOT_CAUSE_FILE)
+            code = int(res.strip(), 16)
+            for (key, value) in self.CPU_RESET_REASON.items():
+                if code & key:
+                    reboot_cause = value[0]
+                    description = value[1]
+                    break
 
-        sw_reboot_cause      = self._api_helper.read_txt_file(reboot_cause_path) or "Unknown"
-        prev_sw_reboot_cause = self._api_helper.read_txt_file(prev_reboot_cause_path) or "Unknown"
-
-        if sw_reboot_cause != "Unknown":
-            reboot_cause = self.REBOOT_CAUSE_NON_HARDWARE
-            description = sw_reboot_cause
-        elif prev_sw_reboot_cause != "Unknown":
-            reboot_cause = self.REBOOT_CAUSE_NON_HARDWARE
-            description = prev_sw_reboot_cause
-        else: # Try to get reboot cause from BMC
-            reboot_cause = self.REBOOT_CAUSE_NON_HARDWARE
-            description = 'Unknown'
-            try:
-                err, res = getstatusoutput_noshell(['ipmitool', 'raw', '0x34', '0x22', '0x21', '0x30'])
-                if err != 0 or res is None:
-                    return (reboot_cause, description)
-
-                code = int(res.strip(), 16)
-                for (key, value) in self.CPU_RESET_REASON.items():
-                    if code & key:
-                        reboot_cause = value[0]
-                        description = value[1]
-            except Exception:
-                pass
+        except Exception:
+            pass
 
         return (reboot_cause, description)
 
@@ -259,7 +237,7 @@ class Chassis(ChassisBase):
         from sonic_platform_base.sfp_base import SfpBase
 
         if index in range(1, 33):
-            return (SfpBase.SFP_PORT_TYPE_BIT_QSFP | SfpBase.SFP_PORT_TYPE_BIT_QSFP_PLUS | 
+            return (SfpBase.SFP_PORT_TYPE_BIT_QSFP | SfpBase.SFP_PORT_TYPE_BIT_QSFP_PLUS |
                     SfpBase.SFP_PORT_TYPE_BIT_QSFP28 | SfpBase.SFP_PORT_TYPE_BIT_QSFPDD)
         elif index == 33:
             return SfpBase.SFP_PORT_TYPE_BIT_SFP | SfpBase.SFP_PORT_TYPE_BIT_SFP_PLUS

--- a/device/accton/x86_64-accton_as9817_32o-r0/sonic_platform/chassis.py
+++ b/device/accton/x86_64-accton_as9817_32o-r0/sonic_platform/chassis.py
@@ -22,10 +22,6 @@ NUM_THERMAL = 13
 NUM_PORT = 34
 NUM_COMPONENT = 6
 
-HOST_REBOOT_CAUSE_PATH = "/host/reboot-cause/"
-PMON_REBOOT_CAUSE_PATH = "/usr/share/sonic/platform/api_files/reboot-cause/"
-REBOOT_CAUSE_FILE = "reboot-cause.txt"
-PREV_REBOOT_CAUSE_FILE = "previous-reboot-cause.txt"
 SYSLED_FNODE= "/sys/devices/platform/as9817_32_led/led_alarm"
 SYSLED_MODES = {
     "0" : "STATUS_LED_COLOR_OFF",
@@ -177,38 +173,21 @@ class Chassis(ChassisBase):
             to pass a description of the reboot cause.
         """
         description = 'None'
+        reboot_cause = self.REBOOT_CAUSE_NON_HARDWARE
+        try:
+            err, res = getstatusoutput_noshell(['ipmitool', 'raw', '0x34', '0x22', '0x21', '0x30'])
+            if err != 0 or res is None:
+                return (reboot_cause, description)
 
-        reboot_cause_path = (HOST_REBOOT_CAUSE_PATH + REBOOT_CAUSE_FILE) \
-            if self.is_host \
-            else (PMON_REBOOT_CAUSE_PATH + REBOOT_CAUSE_FILE)
-        prev_reboot_cause_path = (HOST_REBOOT_CAUSE_PATH + PREV_REBOOT_CAUSE_FILE) \
-            if self.is_host \
-            else (PMON_REBOOT_CAUSE_PATH + PREV_REBOOT_CAUSE_FILE)
+            code = int(res.strip(), 16)
+            for (key, value) in self.CPU_RESET_REASON.items():
+                if code & key:
+                    reboot_cause = value[0]
+                    description = value[1]
+                    break
 
-        sw_reboot_cause      = self._api_helper.read_txt_file(reboot_cause_path) or "Unknown"
-        prev_sw_reboot_cause = self._api_helper.read_txt_file(prev_reboot_cause_path) or "Unknown"
-
-        if sw_reboot_cause != "Unknown":
-            reboot_cause = self.REBOOT_CAUSE_NON_HARDWARE
-            description = sw_reboot_cause
-        elif prev_sw_reboot_cause != "Unknown":
-            reboot_cause = self.REBOOT_CAUSE_NON_HARDWARE
-            description = prev_sw_reboot_cause
-        else: # Try to get reboot cause from BMC
-            reboot_cause = self.REBOOT_CAUSE_NON_HARDWARE
-            description = 'Unknown'
-            try:
-                err, res = getstatusoutput_noshell(['ipmitool', 'raw', '0x34', '0x22', '0x21', '0x30'])
-                if err != 0 or res is None:
-                    return (reboot_cause, description)
-
-                code = int(res.strip(), 16)
-                for (key, value) in self.CPU_RESET_REASON.items():
-                    if code & key:
-                        reboot_cause = value[0]
-                        description = value[1]
-            except Exception:
-                pass
+        except Exception:
+            pass
 
         return (reboot_cause, description)
 
@@ -246,8 +225,8 @@ class Chassis(ChassisBase):
         from sonic_platform_base.sfp_base import SfpBase
 
         if index in range(1, 33):
-            return (SfpBase.SFP_PORT_TYPE_BIT_QSFP | SfpBase.SFP_PORT_TYPE_BIT_QSFP_PLUS | 
-                    SfpBase.SFP_PORT_TYPE_BIT_QSFP28 | SfpBase.SFP_PORT_TYPE_BIT_QSFPDD | 
+            return (SfpBase.SFP_PORT_TYPE_BIT_QSFP | SfpBase.SFP_PORT_TYPE_BIT_QSFP_PLUS |
+                    SfpBase.SFP_PORT_TYPE_BIT_QSFP28 | SfpBase.SFP_PORT_TYPE_BIT_QSFPDD |
                     SfpBase.SFP_PORT_TYPE_BIT_OSFP)
         else:
             return SfpBase.SFP_PORT_TYPE_BIT_SFP | SfpBase.SFP_PORT_TYPE_BIT_SFP_PLUS | SfpBase.SFP_PORT_TYPE_BIT_SFP28


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Since determine-reboot-cause already handles software-related reboot causes, chassis.py
no longer needs to perform this check. It now focuses solely on retrieving the hardware
reboot cause from the BMC using ipmitool.

    - Removed `previous-reboot-cause.txt` dependency.
    - Removed software reboot cause logic and related variables/paths.
    - Directly use `ipmitool` for hardware reboot cause retrieval.

This improves the accuracy and efficiency of hardware reboot cause reporting and avoids redundant checks.

Note:
The predefined reboot cause in chassis_base class:

REBOOT_CAUSE_POWER_LOSS = "Power Loss"
REBOOT_CAUSE_THERMAL_OVERLOAD_CPU = "Thermal Overload: CPU" REBOOT_CAUSE_THERMAL_OVERLOAD_ASIC = "Thermal Overload: ASIC" REBOOT_CAUSE_THERMAL_OVERLOAD_OTHER = "Thermal Overload: Other" REBOOT_CAUSE_INSUFFICIENT_FAN_SPEED = "Insufficient Fan Speed" REBOOT_CAUSE_WATCHDOG = "Watchdog"
REBOOT_CAUSE_HARDWARE_OTHER = "Hardware - Other"
REBOOT_CAUSE_HARDWARE_BIOS = "BIOS"
REBOOT_CAUSE_HARDWARE_CPU = "CPU"
REBOOT_CAUSE_HARDWARE_BUTTON = "Push button"
REBOOT_CAUSE_HARDWARE_RESET_FROM_ASIC = "Reset from ASIC" REBOOT_CAUSE_NON_HARDWARE = "Non-Hardware"
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
This commit removes the redundant software reboot cause check from chassis.py.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

