### PR TITLE
change /tmp/cache as 777 after warm-reboot restore

### DIFF
--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -131,6 +131,7 @@ function restore_counters_folder()
     if [[ -d $cache_counters_folder ]]; then
         mv $cache_counters_folder /tmp/cache
         chown -R admin:admin /tmp/cache
+	chmod 777 /tmp/cache
     fi
 }
 

--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -131,7 +131,7 @@ function restore_counters_folder()
     if [[ -d $cache_counters_folder ]]; then
         mv $cache_counters_folder /tmp/cache
         chown -R admin:admin /tmp/cache
-	chmod 777 /tmp/cache
+        chmod 777 /tmp/cache
     fi
 }
 


### PR DESCRIPTION
If the mode is 755, then guest would failed to create file below /tmp/cache