### PR TITLE
JIRA-SONIC-12853: [SmartD] Disable root notifications on disk issues

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -375,6 +375,8 @@ sudo sed -i '/^\s*restart|force-reload)/a\
 
 # Installed smartmontools version should match installed smartmontools in docker-platform-monitor Dockerfile
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install smartmontools=7.2-1
+# Remove '-m root -M exec /usr/share/smartmontools/smartd-runner' from smartd.conf to disable notification to root
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT sed -E -i -e 's/\s*-m root//' -e 's#\s*-M exec /usr/share/smartmontools/smartd-runner##' /etc/smartd.conf
 
 # Install custom-built openssh sshd
 sudo dpkg --root=$FILESYSTEM_ROOT -i $debs_path/openssh-server_${OPENSSH_VERSION}_*.deb $debs_path/openssh-client_${OPENSSH_VERSION}_*.deb $debs_path/openssh-sftp-server_${OPENSSH_VERSION}_*.deb


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Issue: During the scaling_factory_vrf_reboot test, the following syslog entries were observed:

CORE2-AIS800-64O-6-26U smartd[545]: Warning via /usr/share/smartmontools/smartd-runner to root produced unexpected output (183 bytes) to STDOUT/STDERR:
CORE2-AIS800-64O-6-26U smartd[545]: /etc/smartmontools/run.d/10mail:
CORE2-AIS800-64O-6-26U smartd[545]: Your system does not have /usr/bin/mail.  Install the mailx or mailutils package
CORE2-AIS800-64O-6-26U smartd[545]: run-parts: /etc/smartmontools/run.d/10mail exited with return code 1
CORE2-AIS800-64O-6-26U smartd[545]: Warning via /usr/share/smartmontools/smartd-runner to root: failed (32-bit/8-bit exit status: 256/1)

Root Cause:
1. The smartd daemon detected a disk issue (e.g., SMART failure, temperature spike, etc.).
2. It attempted to execute the alert notification script via /usr/share/smartmontools/smartd-runner.
3. The script executed through /etc/smartmontools/run.d/, triggering alert scripts such as 10mail.
4. The 10mail script failed due to the absence of the mail utility on the system.
5. This resulted in a warning log, including the exit code from the script.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Solution:
Remove both '-m root' and '-M exec /usr/share/smartmontools/smartd-runner' from /etc/smartd.conf during build time. This prevents smartd configuration errors and properly disables notification emails to root.

Impact:
After this change, smartd will not send notifications, matching the intended behavior of disabling root email alerts.
#### How to verify it
Regression:
root@sonic:/# grep DEVICESCAN /etc/smartd.conf|grep -v '#' DEVICESCAN -d removable -n standby
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

