### PR TITLE
Enlarge Linux Kernel GC Thresholds for ARP Tables on AS4630

### DIFF
--- a/files/neighbor/91-gc-thresh-sysctl.conf.j2
+++ b/files/neighbor/91-gc-thresh-sysctl.conf.j2
@@ -40,6 +40,13 @@ net.ipv4.neigh.default.gc_thresh2=32768
 net.ipv6.neigh.default.gc_thresh2=16384
 net.ipv4.neigh.default.gc_thresh3=32768
 net.ipv6.neigh.default.gc_thresh3=16384
+{% elif DEVICE_METADATA.get('localhost', {}).get('hwsku', '') in ["Accton-AS4630-54NPE", "Accton-AS4630-54PE", "Accton-AS4630-54TE"] %}
+net.ipv4.neigh.default.gc_thresh1=24576
+net.ipv6.neigh.default.gc_thresh1=12288
+net.ipv4.neigh.default.gc_thresh2=24576
+net.ipv6.neigh.default.gc_thresh2=12288
+net.ipv4.neigh.default.gc_thresh3=24576
+net.ipv6.neigh.default.gc_thresh3=12288
 {% else %}
 net.ipv4.neigh.default.gc_thresh1=16384
 net.ipv6.neigh.default.gc_thresh1=8192


### PR DESCRIPTION
#### Why I did it
The previous thresholds were lower than the ASIC capacity, which could lead to premature deletion of neighbor entries and ARP table limitations. Enlarging the thresholds ensures full utilization of the ASIC’s ARP/NDP table.

#### How I did it
Increased the Linux kernel neighbor table garbage collection thresholds (gc_thresh1, gc_thresh2, gc_thresh3) for IPv4 and IPv6 on AS4630 devices to match the ASIC maximum of 24,576 ARP entries.

#### How to verify it
Applied the new thresholds on AS4630 devices and confirmed that the ARP/NDP tables can grow up to the maximum capacity without losing entries or impacting stability.