### PR TITLE
Add MGMT_PORT section into the generated default sonic config.

### DIFF
--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -18,6 +18,14 @@ def generate_common_config(data):
             'POLL_INTERVAL': '10000'
         }
     }
+    # use eth0 as default management port
+    data['MGMT_PORT'] = {
+        'eth0': {
+            'alias': 'eth0',
+            'admin_status': 'up',
+            'description': 'Management Port'
+        }
+    }
     return data
 
 # The following config generation methods exits:

--- a/src/sonic-config-engine/data/l1intf.j2
+++ b/src/sonic-config-engine/data/l1intf.j2
@@ -12,6 +12,13 @@
         }
     },
     {% set ns = {'firstPrinted': False} -%}
+    "MGMT_PORT": {
+        "eth0": {
+            "alias": "eth0",
+            "admin_status": "up",
+            "description": "Management Port"
+        }
+    },
     "PORT": {
         {%- for key, value in PORT.items() -%}
         {%- if ns.firstPrinted %},{% endif %}

--- a/src/sonic-config-engine/data/l2switch.j2
+++ b/src/sonic-config-engine/data/l2switch.j2
@@ -30,6 +30,13 @@
         }
     },
     {% set ns = {'firstPrinted': False} -%}
+    "MGMT_PORT": {
+        "eth0": {
+            "alias": "eth0",
+            "admin_status": "up",
+            "description": "Management Port"
+        }
+    },
     "VLAN_MEMBER": {
         {%- for port in PORT -%}
         {%- if ns.firstPrinted %},{% endif %}

--- a/src/sonic-config-engine/data/l3intf.j2
+++ b/src/sonic-config-engine/data/l3intf.j2
@@ -12,6 +12,13 @@
         }
     },
     {% set ns = {'firstPrinted': False} -%}
+    "MGMT_PORT": {
+        "eth0": {
+            "alias": "eth0",
+            "admin_status": "up",
+            "description": "Management Port"
+        }
+    },
     "PORT": {
         {%- for key, value in PORT.items() -%}
         {%- if ns.firstPrinted %},{% endif %}

--- a/src/sonic-config-engine/tests/sample_output/py2/l1_intfs.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/l1_intfs.json
@@ -1,5 +1,12 @@
 {
     "DEVICE_METADATA": {"localhost": {"hwsku": "32x1000Gb"}},
+    "MGMT_PORT": {
+        "eth0": {
+            "alias": "eth0",
+            "admin_status": "up",
+            "description": "Management Port"
+        }
+    },
     "PORT": {
         "Ethernet0": {
             "admin_status": "up",

--- a/src/sonic-config-engine/tests/sample_output/py2/l2switch.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/l2switch.json
@@ -1,5 +1,12 @@
 {
     "DEVICE_METADATA": {"localhost": {"hwsku": "Mellanox-SN2700"}},
+    "MGMT_PORT": {
+        "eth0": {
+            "alias": "eth0",
+            "admin_status": "up",
+            "description": "Management Port"
+        }
+    },
     "PORT": {
         "Ethernet8": {
             "alias": "fortyGigE0/8",

--- a/src/sonic-config-engine/tests/sample_output/py2/l2switch_dualtor.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/l2switch_dualtor.json
@@ -6,6 +6,13 @@
             "peer_switch": "peer_switch_hostname"
         }
     },
+    "MGMT_PORT": {
+        "eth0": {
+            "admin_status": "up",
+            "alias": "eth0",
+            "description": "Management Port"
+        }
+    },
     "PORT": {
         "Ethernet0": {
             "lanes": "1,2",

--- a/src/sonic-config-engine/tests/sample_output/py2/l3_intfs.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/l3_intfs.json
@@ -1,5 +1,12 @@
 {
     "DEVICE_METADATA": {"localhost": {"hwsku": "32x1000Gb"}},
+    "MGMT_PORT": {
+        "eth0": {
+            "admin_status": "up",
+            "alias": "eth0",
+            "description": "Management Port"
+        }
+    },
     "PORT": {
         "Ethernet0": {
             "admin_status": "up",

--- a/src/sonic-config-engine/tests/sample_output/py3/l1_intfs.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/l1_intfs.json
@@ -1,5 +1,12 @@
 {
     "DEVICE_METADATA": {"localhost": {"hwsku": "32x1000Gb"}},
+    "MGMT_PORT": {
+        "eth0": {
+            "admin_status": "up",
+            "alias": "eth0",
+            "description": "Management Port"
+        }
+    },
     "PORT": {
         "Ethernet0": {
             "admin_status": "up",

--- a/src/sonic-config-engine/tests/sample_output/py3/l2switch.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/l2switch.json
@@ -1,5 +1,12 @@
 {
     "DEVICE_METADATA": {"localhost": {"hwsku": "Mellanox-SN2700"}},
+    "MGMT_PORT": {
+        "eth0": {
+            "admin_status": "up",
+            "alias": "eth0",
+            "description": "Management Port"
+        }
+    },
     "PORT": {
         "Ethernet0": {
             "alias": "fortyGigE0/0",

--- a/src/sonic-config-engine/tests/sample_output/py3/l2switch_dualtor.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/l2switch_dualtor.json
@@ -6,6 +6,13 @@
             "peer_switch": "peer_switch_hostname"
         }
     },
+    "MGMT_PORT": {
+        "eth0": {
+            "admin_status": "up",
+            "alias": "eth0",
+            "description": "Management Port"
+        }
+    },
     "PORT": {
         "Ethernet0": {
             "lanes": "1,2",

--- a/src/sonic-config-engine/tests/sample_output/py3/l3_intfs.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/l3_intfs.json
@@ -1,5 +1,12 @@
 {
     "DEVICE_METADATA": {"localhost": {"hwsku": "32x1000Gb"}},
+    "MGMT_PORT": {
+        "eth0": {
+            "admin_status": "up",
+            "alias": "eth0",
+            "description": "Management Port"
+        }
+    },
     "PORT": {
         "Ethernet0": {
             "admin_status": "up",


### PR DESCRIPTION
The generated default sonic config does not contain "MGMT_PORT" section. When a static IP is configured on the management port and execute port breakout, the breakout command fails due to the yang file validation. The "MGMT_PORT" should be included in the generated default sonic config so the error will not happen.

Modify config_samples.py to add "MGMT_PORT" section, which will be added into the generated default sonic config.

```Before Fix
admin@sonic:~$ sudo config interface ip add eth0 192.168.3.30/24
192.168.3.254
admin@sonic:~$ sudo config interface breakout -f Ethernet0 "2x50G"
Do you want to Breakout the port, continue? [y/N]: y

Running Breakout Mode : 1x100G[40G]
Target Breakout Mode : 2x50G

Ports to be deleted :
 {
    "Ethernet0": "100000"
}
Ports to be added :
 {
    "Ethernet0": "50000",
    "Ethernet2": "50000"
}
libyang[0]: Leafref
"/sonic-mgmt_port:sonic-mgmt_port/sonic-mgmt_port:MGMT_PORT/sonic-mgmt_port:MGMT_PORT_LIST/sonic-mgmt_port:name"
of value "eth0" points to a non-existing leaf. (path:
/sonic-mgmt_interface:sonic-mgmt_interface/MGMT_INTERFACE/MGMT_INTERFACE_LIST[name='eth0'][ip_prefix='192.168.3.30/24']/name)
sonic_yang(3):Data Loading Failed:Leafref
"/sonic-mgmt_port:sonic-mgmt_port/sonic-mgmt_port:MGMT_PORT/sonic-mgmt_port:MGMT_PORT_LIST/sonic-mgmt_port:name"
of value "eth0" points to a non-existing leaf.
Data Loading Failed
Leafref
"/sonic-mgmt_port:sonic-mgmt_port/sonic-mgmt_port:MGMT_PORT/sonic-mgmt_port:MGMT_PORT_LIST/sonic-mgmt_port:name"
of value "eth0" points to a non-existing leaf.
ConfigMgmt Class creation failed
Failed to break out Port. Error: Failed to load the config. Error:
ConfigMgmtDPB Class creation failed
```

```After Fix

admin@sonic:~$ sudo config interface ip add eth0 192.168.3.30/24
192.168.3.254
admin@sonic:~$ sudo config interface breakout -f Ethernet0 "2x50G"
Do you want to Breakout the port, continue? [y/N]: y

Running Breakout Mode : 1x100G[40G]
Target Breakout Mode : 2x50G

Ports to be deleted :
 {
    "Ethernet0": "100000"
}
Ports to be added :
 {
    "Ethernet0": "50000",
    "Ethernet2": "50000"
}
```

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

