### PR TITLE
Support BIOS version v51.01.11.01 on AIS800-64 platforms.

### DIFF
--- a/device/accton/x86_64-accton_as9817_64d-r0/pcie.yaml.ais800_v51.01.11.01
+++ b/device/accton/x86_64-accton_as9817_64d-r0/pcie.yaml.ais800_v51.01.11.01
@@ -1,0 +1,434 @@
+- bus: '00'
+  dev: '00'
+  fn: '0'
+  id: 09a2
+  name: 'System peripheral: Intel Corporation Device 09a2 (rev 04)'
+- bus: '00'
+  dev: '00'
+  fn: '1'
+  id: 09a4
+  name: 'System peripheral: Intel Corporation Device 09a4 (rev 04)'
+- bus: '00'
+  dev: '00'
+  fn: '2'
+  id: 09a3
+  name: 'System peripheral: Intel Corporation Device 09a3 (rev 04)'
+- bus: '00'
+  dev: '00'
+  fn: '3'
+  id: 09a5
+  name: 'System peripheral: Intel Corporation Device 09a5 (rev 04)'
+- bus: '00'
+  dev: '00'
+  fn: '4'
+  id: 0998
+  name: 'Host bridge: Intel Corporation Device 0998'
+- bus: '00'
+  dev: '01'
+  fn: '0'
+  id: '0b00'
+  name: 'System peripheral: Intel Corporation Device 0b00'
+- bus: '00'
+  dev: '01'
+  fn: '1'
+  id: '0b00'
+  name: 'System peripheral: Intel Corporation Device 0b00'
+- bus: '00'
+  dev: '01'
+  fn: '2'
+  id: '0b00'
+  name: 'System peripheral: Intel Corporation Device 0b00'
+- bus: '00'
+  dev: '01'
+  fn: '3'
+  id: '0b00'
+  name: 'System peripheral: Intel Corporation Device 0b00'
+- bus: '00'
+  dev: '01'
+  fn: '4'
+  id: '0b00'
+  name: 'System peripheral: Intel Corporation Device 0b00'
+- bus: '00'
+  dev: '01'
+  fn: '5'
+  id: '0b00'
+  name: 'System peripheral: Intel Corporation Device 0b00'
+- bus: '00'
+  dev: '01'
+  fn: '6'
+  id: '0b00'
+  name: 'System peripheral: Intel Corporation Device 0b00'
+- bus: '00'
+  dev: '01'
+  fn: '7'
+  id: '0b00'
+  name: 'System peripheral: Intel Corporation Device 0b00'
+- bus: '00'
+  dev: '02'
+  fn: '0'
+  id: 09a6
+  name: 'System peripheral: Intel Corporation Device 09a6'
+- bus: '00'
+  dev: '02'
+  fn: '1'
+  id: 09a7
+  name: 'System peripheral: Intel Corporation Device 09a7'
+- bus: '00'
+  dev: '02'
+  fn: '4'
+  id: '3456'
+  name: 'Non-Essential Instrumentation [1300]: Intel Corporation Device 3456 (rev
+    01)'
+- bus: '00'
+  dev: '06'
+  fn: '0'
+  id: 18da
+  name: 'PCI bridge: Intel Corporation Device 18da (rev 11)'
+- bus: '00'
+  dev: 09
+  fn: '0'
+  id: 18a4
+  name: 'PCI bridge: Intel Corporation Device 18a4 (rev 11)'
+- bus: '00'
+  dev: 0b
+  fn: '0'
+  id: 18a6
+  name: 'PCI bridge: Intel Corporation Device 18a6 (rev 11)'
+- bus: '00'
+  dev: 0e
+  fn: '0'
+  id: 18f2
+  name: 'SATA controller: Intel Corporation Device 18f2 (rev 11)'
+- bus: '00'
+  dev: 0f
+  fn: '0'
+  id: 18ac
+  name: 'System peripheral: Intel Corporation Device 18ac (rev 11)'
+- bus: '00'
+  dev: '10'
+  fn: '0'
+  id: 18a8
+  name: 'PCI bridge: Intel Corporation Device 18a8 (rev 11)'
+- bus: '00'
+  dev: '14'
+  fn: '0'
+  id: 18ad
+  name: 'PCI bridge: Intel Corporation Device 18ad (rev 11)'
+- bus: '00'
+  dev: '18'
+  fn: '0'
+  id: 18d3
+  name: 'Communication controller: Intel Corporation Device 18d3 (rev 11)'
+- bus: '00'
+  dev: '18'
+  fn: '4'
+  id: 18d6
+  name: 'Communication controller: Intel Corporation Device 18d6 (rev 11)'
+- bus: '00'
+  dev: 1a
+  fn: '0'
+  id: 18d8
+  name: 'Serial controller: Intel Corporation Device 18d8 (rev 11)'
+- bus: '00'
+  dev: 1a
+  fn: '1'
+  id: 18d8
+  name: 'Serial controller: Intel Corporation Device 18d8 (rev 11)'
+- bus: '00'
+  dev: 1a
+  fn: '2'
+  id: 18d8
+  name: 'Serial controller: Intel Corporation Device 18d8 (rev 11)'
+- bus: '00'
+  dev: 1a
+  fn: '3'
+  id: 18d9
+  name: 'Unassigned class [ff00]: Intel Corporation Device 18d9 (rev 11)'
+- bus: '00'
+  dev: 1d
+  fn: '0'
+  id: 0998
+  name: 'Host bridge: Intel Corporation Device 0998'
+- bus: '00'
+  dev: 1e
+  fn: '0'
+  id: 18d0
+  name: 'USB controller: Intel Corporation Device 18d0 (rev 11)'
+- bus: '00'
+  dev: 1f
+  fn: '0'
+  id: 18dc
+  name: 'ISA bridge: Intel Corporation Device 18dc (rev 11)'
+- bus: '00'
+  dev: 1f
+  fn: '4'
+  id: 18df
+  name: 'SMBus: Intel Corporation Device 18df (rev 11)'
+- bus: '00'
+  dev: 1f
+  fn: '5'
+  id: 18e0
+  name: 'Serial bus controller [0c80]: Intel Corporation Device 18e0 (rev 11)'
+- bus: '01'
+  dev: '00'
+  fn: '0'
+  id: 18ee
+  name: 'Co-processor: Intel Corporation Device 18ee (rev 11)'
+- bus: '02'
+  dev: '00'
+  fn: '0'
+  id: '7021'
+  name: 'Memory controller: Xilinx Corporation Device 7021'
+- bus: '03'
+  dev: '00'
+  fn: '0'
+  id: '1533'
+  name: 'Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev
+    03)'
+- bus: '04'
+  dev: '00'
+  fn: '0'
+  id: '1150'
+  name: 'PCI bridge: ASPEED Technology, Inc. AST1150 PCI-to-PCI Bridge (rev 06)'
+- bus: '06'
+  dev: '00'
+  fn: '0'
+  id: '1533'
+  name: 'Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev
+    03)'
+- bus: '14'
+  dev: '00'
+  fn: '0'
+  id: 09a2
+  name: 'System peripheral: Intel Corporation Device 09a2 (rev 04)'
+- bus: '14'
+  dev: '00'
+  fn: '1'
+  id: 09a4
+  name: 'System peripheral: Intel Corporation Device 09a4 (rev 04)'
+- bus: '14'
+  dev: '00'
+  fn: '2'
+  id: 09a3
+  name: 'System peripheral: Intel Corporation Device 09a3 (rev 04)'
+- bus: '14'
+  dev: '00'
+  fn: '3'
+  id: 09a5
+  name: 'System peripheral: Intel Corporation Device 09a5 (rev 04)'
+- bus: '14'
+  dev: '00'
+  fn: '4'
+  id: 0998
+  name: 'Host bridge: Intel Corporation Device 0998'
+- bus: '14'
+  dev: '02'
+  fn: '0'
+  id: 347a
+  name: 'PCI bridge: Intel Corporation Device 347a (rev 06)'
+- bus: '14'
+  dev: '03'
+  fn: '0'
+  id: 347b
+  name: 'PCI bridge: Intel Corporation Device 347b (rev 06)'
+- bus: '15'
+  dev: '00'
+  fn: '0'
+  id: f900
+  name: 'Ethernet controller: Broadcom Inc. and subsidiaries Device f900 (rev 11)'
+- bus: '16'
+  dev: '00'
+  fn: '0'
+  id: '5013'
+  name: 'Non-Volatile memory controller: Phison Electronics Corporation PS5013 E13
+    NVMe Controller (rev 01)'
+- bus: f3
+  dev: '00'
+  fn: '0'
+  id: 09a2
+  name: 'System peripheral: Intel Corporation Device 09a2 (rev 04)'
+- bus: f3
+  dev: '00'
+  fn: '1'
+  id: 09a4
+  name: 'System peripheral: Intel Corporation Device 09a4 (rev 04)'
+- bus: f3
+  dev: '00'
+  fn: '2'
+  id: 09a3
+  name: 'System peripheral: Intel Corporation Device 09a3 (rev 04)'
+- bus: f3
+  dev: '00'
+  fn: '3'
+  id: 09a5
+  name: 'System peripheral: Intel Corporation Device 09a5 (rev 04)'
+- bus: f3
+  dev: '00'
+  fn: '4'
+  id: 0998
+  name: 'Host bridge: Intel Corporation Device 0998'
+- bus: f3
+  dev: '04'
+  fn: '0'
+  id: 18d1
+  name: 'PCI bridge: Intel Corporation Device 18d1'
+- bus: f4
+  dev: '00'
+  fn: '0'
+  id: 124c
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection E823-L for backplane'
+- bus: f4
+  dev: '00'
+  fn: '1'
+  id: 124c
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection E823-L for backplane'
+- bus: f4
+  dev: '00'
+  fn: '2'
+  id: 124c
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection E823-L for backplane'
+- bus: f4
+  dev: '00'
+  fn: '3'
+  id: 124c
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection E823-L for backplane'
+- bus: fe
+  dev: '00'
+  fn: '0'
+  id: '3450'
+  name: 'System peripheral: Intel Corporation Device 3450'
+- bus: fe
+  dev: '00'
+  fn: '1'
+  id: '3451'
+  name: 'System peripheral: Intel Corporation Device 3451'
+- bus: fe
+  dev: '00'
+  fn: '2'
+  id: '3452'
+  name: 'System peripheral: Intel Corporation Device 3452'
+- bus: fe
+  dev: '00'
+  fn: '3'
+  id: 0998
+  name: 'Host bridge: Intel Corporation Device 0998'
+- bus: fe
+  dev: '00'
+  fn: '5'
+  id: '3455'
+  name: 'System peripheral: Intel Corporation Device 3455'
+- bus: fe
+  dev: 0b
+  fn: '0'
+  id: '3448'
+  name: 'System peripheral: Intel Corporation Device 3448'
+- bus: fe
+  dev: 0b
+  fn: '1'
+  id: '3448'
+  name: 'System peripheral: Intel Corporation Device 3448'
+- bus: fe
+  dev: 0b
+  fn: '2'
+  id: 344b
+  name: 'System peripheral: Intel Corporation Device 344b'
+- bus: fe
+  dev: 0c
+  fn: '0'
+  id: 344a
+  name: 'Performance counters: Intel Corporation Device 344a'
+- bus: fe
+  dev: 1a
+  fn: '0'
+  id: '2880'
+  name: 'Performance counters: Intel Corporation Device 2880'
+- bus: ff
+  dev: '00'
+  fn: '0'
+  id: 344c
+  name: 'System peripheral: Intel Corporation Device 344c'
+- bus: ff
+  dev: '00'
+  fn: '1'
+  id: 344c
+  name: 'System peripheral: Intel Corporation Device 344c'
+- bus: ff
+  dev: '00'
+  fn: '2'
+  id: 344c
+  name: 'System peripheral: Intel Corporation Device 344c'
+- bus: ff
+  dev: '00'
+  fn: '3'
+  id: 344c
+  name: 'System peripheral: Intel Corporation Device 344c'
+- bus: ff
+  dev: 0a
+  fn: '0'
+  id: 344d
+  name: 'System peripheral: Intel Corporation Device 344d'
+- bus: ff
+  dev: 0a
+  fn: '1'
+  id: 344d
+  name: 'System peripheral: Intel Corporation Device 344d'
+- bus: ff
+  dev: 0a
+  fn: '2'
+  id: 344d
+  name: 'System peripheral: Intel Corporation Device 344d'
+- bus: ff
+  dev: 0a
+  fn: '3'
+  id: 344d
+  name: 'System peripheral: Intel Corporation Device 344d'
+- bus: ff
+  dev: 1d
+  fn: '0'
+  id: 344f
+  name: 'System peripheral: Intel Corporation Device 344f'
+- bus: ff
+  dev: 1d
+  fn: '1'
+  id: '3457'
+  name: 'System peripheral: Intel Corporation Device 3457'
+- bus: ff
+  dev: 1e
+  fn: '0'
+  id: '3458'
+  name: 'System peripheral: Intel Corporation Device 3458 (rev 01)'
+- bus: ff
+  dev: 1e
+  fn: '1'
+  id: '3459'
+  name: 'System peripheral: Intel Corporation Device 3459 (rev 01)'
+- bus: ff
+  dev: 1e
+  fn: '2'
+  id: 345a
+  name: 'System peripheral: Intel Corporation Device 345a (rev 01)'
+- bus: ff
+  dev: 1e
+  fn: '3'
+  id: 345b
+  name: 'System peripheral: Intel Corporation Device 345b (rev 01)'
+- bus: ff
+  dev: 1e
+  fn: '4'
+  id: 345c
+  name: 'System peripheral: Intel Corporation Device 345c (rev 01)'
+- bus: ff
+  dev: 1e
+  fn: '5'
+  id: 345d
+  name: 'System peripheral: Intel Corporation Device 345d (rev 01)'
+- bus: ff
+  dev: 1e
+  fn: '6'
+  id: 345e
+  name: 'System peripheral: Intel Corporation Device 345e (rev 01)'
+- bus: ff
+  dev: 1e
+  fn: '7'
+  id: 345f
+  name: 'System peripheral: Intel Corporation Device 345f (rev 01)'

--- a/device/accton/x86_64-accton_as9817_64o-r0/pcie.yaml.ais800_v51.01.11.01
+++ b/device/accton/x86_64-accton_as9817_64o-r0/pcie.yaml.ais800_v51.01.11.01
@@ -1,0 +1,434 @@
+- bus: '00'
+  dev: '00'
+  fn: '0'
+  id: 09a2
+  name: 'System peripheral: Intel Corporation Device 09a2 (rev 04)'
+- bus: '00'
+  dev: '00'
+  fn: '1'
+  id: 09a4
+  name: 'System peripheral: Intel Corporation Device 09a4 (rev 04)'
+- bus: '00'
+  dev: '00'
+  fn: '2'
+  id: 09a3
+  name: 'System peripheral: Intel Corporation Device 09a3 (rev 04)'
+- bus: '00'
+  dev: '00'
+  fn: '3'
+  id: 09a5
+  name: 'System peripheral: Intel Corporation Device 09a5 (rev 04)'
+- bus: '00'
+  dev: '00'
+  fn: '4'
+  id: 0998
+  name: 'Host bridge: Intel Corporation Device 0998'
+- bus: '00'
+  dev: '01'
+  fn: '0'
+  id: '0b00'
+  name: 'System peripheral: Intel Corporation Device 0b00'
+- bus: '00'
+  dev: '01'
+  fn: '1'
+  id: '0b00'
+  name: 'System peripheral: Intel Corporation Device 0b00'
+- bus: '00'
+  dev: '01'
+  fn: '2'
+  id: '0b00'
+  name: 'System peripheral: Intel Corporation Device 0b00'
+- bus: '00'
+  dev: '01'
+  fn: '3'
+  id: '0b00'
+  name: 'System peripheral: Intel Corporation Device 0b00'
+- bus: '00'
+  dev: '01'
+  fn: '4'
+  id: '0b00'
+  name: 'System peripheral: Intel Corporation Device 0b00'
+- bus: '00'
+  dev: '01'
+  fn: '5'
+  id: '0b00'
+  name: 'System peripheral: Intel Corporation Device 0b00'
+- bus: '00'
+  dev: '01'
+  fn: '6'
+  id: '0b00'
+  name: 'System peripheral: Intel Corporation Device 0b00'
+- bus: '00'
+  dev: '01'
+  fn: '7'
+  id: '0b00'
+  name: 'System peripheral: Intel Corporation Device 0b00'
+- bus: '00'
+  dev: '02'
+  fn: '0'
+  id: 09a6
+  name: 'System peripheral: Intel Corporation Device 09a6'
+- bus: '00'
+  dev: '02'
+  fn: '1'
+  id: 09a7
+  name: 'System peripheral: Intel Corporation Device 09a7'
+- bus: '00'
+  dev: '02'
+  fn: '4'
+  id: '3456'
+  name: 'Non-Essential Instrumentation [1300]: Intel Corporation Device 3456 (rev
+    01)'
+- bus: '00'
+  dev: '06'
+  fn: '0'
+  id: 18da
+  name: 'PCI bridge: Intel Corporation Device 18da (rev 11)'
+- bus: '00'
+  dev: 09
+  fn: '0'
+  id: 18a4
+  name: 'PCI bridge: Intel Corporation Device 18a4 (rev 11)'
+- bus: '00'
+  dev: 0b
+  fn: '0'
+  id: 18a6
+  name: 'PCI bridge: Intel Corporation Device 18a6 (rev 11)'
+- bus: '00'
+  dev: 0e
+  fn: '0'
+  id: 18f2
+  name: 'SATA controller: Intel Corporation Device 18f2 (rev 11)'
+- bus: '00'
+  dev: 0f
+  fn: '0'
+  id: 18ac
+  name: 'System peripheral: Intel Corporation Device 18ac (rev 11)'
+- bus: '00'
+  dev: '10'
+  fn: '0'
+  id: 18a8
+  name: 'PCI bridge: Intel Corporation Device 18a8 (rev 11)'
+- bus: '00'
+  dev: '14'
+  fn: '0'
+  id: 18ad
+  name: 'PCI bridge: Intel Corporation Device 18ad (rev 11)'
+- bus: '00'
+  dev: '18'
+  fn: '0'
+  id: 18d3
+  name: 'Communication controller: Intel Corporation Device 18d3 (rev 11)'
+- bus: '00'
+  dev: '18'
+  fn: '4'
+  id: 18d6
+  name: 'Communication controller: Intel Corporation Device 18d6 (rev 11)'
+- bus: '00'
+  dev: 1a
+  fn: '0'
+  id: 18d8
+  name: 'Serial controller: Intel Corporation Device 18d8 (rev 11)'
+- bus: '00'
+  dev: 1a
+  fn: '1'
+  id: 18d8
+  name: 'Serial controller: Intel Corporation Device 18d8 (rev 11)'
+- bus: '00'
+  dev: 1a
+  fn: '2'
+  id: 18d8
+  name: 'Serial controller: Intel Corporation Device 18d8 (rev 11)'
+- bus: '00'
+  dev: 1a
+  fn: '3'
+  id: 18d9
+  name: 'Unassigned class [ff00]: Intel Corporation Device 18d9 (rev 11)'
+- bus: '00'
+  dev: 1d
+  fn: '0'
+  id: 0998
+  name: 'Host bridge: Intel Corporation Device 0998'
+- bus: '00'
+  dev: 1e
+  fn: '0'
+  id: 18d0
+  name: 'USB controller: Intel Corporation Device 18d0 (rev 11)'
+- bus: '00'
+  dev: 1f
+  fn: '0'
+  id: 18dc
+  name: 'ISA bridge: Intel Corporation Device 18dc (rev 11)'
+- bus: '00'
+  dev: 1f
+  fn: '4'
+  id: 18df
+  name: 'SMBus: Intel Corporation Device 18df (rev 11)'
+- bus: '00'
+  dev: 1f
+  fn: '5'
+  id: 18e0
+  name: 'Serial bus controller [0c80]: Intel Corporation Device 18e0 (rev 11)'
+- bus: '01'
+  dev: '00'
+  fn: '0'
+  id: 18ee
+  name: 'Co-processor: Intel Corporation Device 18ee (rev 11)'
+- bus: '02'
+  dev: '00'
+  fn: '0'
+  id: '7021'
+  name: 'Memory controller: Xilinx Corporation Device 7021'
+- bus: '03'
+  dev: '00'
+  fn: '0'
+  id: '1533'
+  name: 'Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev
+    03)'
+- bus: '04'
+  dev: '00'
+  fn: '0'
+  id: '1150'
+  name: 'PCI bridge: ASPEED Technology, Inc. AST1150 PCI-to-PCI Bridge (rev 06)'
+- bus: '06'
+  dev: '00'
+  fn: '0'
+  id: '1533'
+  name: 'Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev
+    03)'
+- bus: '14'
+  dev: '00'
+  fn: '0'
+  id: 09a2
+  name: 'System peripheral: Intel Corporation Device 09a2 (rev 04)'
+- bus: '14'
+  dev: '00'
+  fn: '1'
+  id: 09a4
+  name: 'System peripheral: Intel Corporation Device 09a4 (rev 04)'
+- bus: '14'
+  dev: '00'
+  fn: '2'
+  id: 09a3
+  name: 'System peripheral: Intel Corporation Device 09a3 (rev 04)'
+- bus: '14'
+  dev: '00'
+  fn: '3'
+  id: 09a5
+  name: 'System peripheral: Intel Corporation Device 09a5 (rev 04)'
+- bus: '14'
+  dev: '00'
+  fn: '4'
+  id: 0998
+  name: 'Host bridge: Intel Corporation Device 0998'
+- bus: '14'
+  dev: '02'
+  fn: '0'
+  id: 347a
+  name: 'PCI bridge: Intel Corporation Device 347a (rev 06)'
+- bus: '14'
+  dev: '03'
+  fn: '0'
+  id: 347b
+  name: 'PCI bridge: Intel Corporation Device 347b (rev 06)'
+- bus: '15'
+  dev: '00'
+  fn: '0'
+  id: f900
+  name: 'Ethernet controller: Broadcom Inc. and subsidiaries Device f900 (rev 11)'
+- bus: '16'
+  dev: '00'
+  fn: '0'
+  id: '5013'
+  name: 'Non-Volatile memory controller: Phison Electronics Corporation PS5013 E13
+    NVMe Controller (rev 01)'
+- bus: f3
+  dev: '00'
+  fn: '0'
+  id: 09a2
+  name: 'System peripheral: Intel Corporation Device 09a2 (rev 04)'
+- bus: f3
+  dev: '00'
+  fn: '1'
+  id: 09a4
+  name: 'System peripheral: Intel Corporation Device 09a4 (rev 04)'
+- bus: f3
+  dev: '00'
+  fn: '2'
+  id: 09a3
+  name: 'System peripheral: Intel Corporation Device 09a3 (rev 04)'
+- bus: f3
+  dev: '00'
+  fn: '3'
+  id: 09a5
+  name: 'System peripheral: Intel Corporation Device 09a5 (rev 04)'
+- bus: f3
+  dev: '00'
+  fn: '4'
+  id: 0998
+  name: 'Host bridge: Intel Corporation Device 0998'
+- bus: f3
+  dev: '04'
+  fn: '0'
+  id: 18d1
+  name: 'PCI bridge: Intel Corporation Device 18d1'
+- bus: f4
+  dev: '00'
+  fn: '0'
+  id: 124c
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection E823-L for backplane'
+- bus: f4
+  dev: '00'
+  fn: '1'
+  id: 124c
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection E823-L for backplane'
+- bus: f4
+  dev: '00'
+  fn: '2'
+  id: 124c
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection E823-L for backplane'
+- bus: f4
+  dev: '00'
+  fn: '3'
+  id: 124c
+  name: 'Ethernet controller: Intel Corporation Ethernet Connection E823-L for backplane'
+- bus: fe
+  dev: '00'
+  fn: '0'
+  id: '3450'
+  name: 'System peripheral: Intel Corporation Device 3450'
+- bus: fe
+  dev: '00'
+  fn: '1'
+  id: '3451'
+  name: 'System peripheral: Intel Corporation Device 3451'
+- bus: fe
+  dev: '00'
+  fn: '2'
+  id: '3452'
+  name: 'System peripheral: Intel Corporation Device 3452'
+- bus: fe
+  dev: '00'
+  fn: '3'
+  id: 0998
+  name: 'Host bridge: Intel Corporation Device 0998'
+- bus: fe
+  dev: '00'
+  fn: '5'
+  id: '3455'
+  name: 'System peripheral: Intel Corporation Device 3455'
+- bus: fe
+  dev: 0b
+  fn: '0'
+  id: '3448'
+  name: 'System peripheral: Intel Corporation Device 3448'
+- bus: fe
+  dev: 0b
+  fn: '1'
+  id: '3448'
+  name: 'System peripheral: Intel Corporation Device 3448'
+- bus: fe
+  dev: 0b
+  fn: '2'
+  id: 344b
+  name: 'System peripheral: Intel Corporation Device 344b'
+- bus: fe
+  dev: 0c
+  fn: '0'
+  id: 344a
+  name: 'Performance counters: Intel Corporation Device 344a'
+- bus: fe
+  dev: 1a
+  fn: '0'
+  id: '2880'
+  name: 'Performance counters: Intel Corporation Device 2880'
+- bus: ff
+  dev: '00'
+  fn: '0'
+  id: 344c
+  name: 'System peripheral: Intel Corporation Device 344c'
+- bus: ff
+  dev: '00'
+  fn: '1'
+  id: 344c
+  name: 'System peripheral: Intel Corporation Device 344c'
+- bus: ff
+  dev: '00'
+  fn: '2'
+  id: 344c
+  name: 'System peripheral: Intel Corporation Device 344c'
+- bus: ff
+  dev: '00'
+  fn: '3'
+  id: 344c
+  name: 'System peripheral: Intel Corporation Device 344c'
+- bus: ff
+  dev: 0a
+  fn: '0'
+  id: 344d
+  name: 'System peripheral: Intel Corporation Device 344d'
+- bus: ff
+  dev: 0a
+  fn: '1'
+  id: 344d
+  name: 'System peripheral: Intel Corporation Device 344d'
+- bus: ff
+  dev: 0a
+  fn: '2'
+  id: 344d
+  name: 'System peripheral: Intel Corporation Device 344d'
+- bus: ff
+  dev: 0a
+  fn: '3'
+  id: 344d
+  name: 'System peripheral: Intel Corporation Device 344d'
+- bus: ff
+  dev: 1d
+  fn: '0'
+  id: 344f
+  name: 'System peripheral: Intel Corporation Device 344f'
+- bus: ff
+  dev: 1d
+  fn: '1'
+  id: '3457'
+  name: 'System peripheral: Intel Corporation Device 3457'
+- bus: ff
+  dev: 1e
+  fn: '0'
+  id: '3458'
+  name: 'System peripheral: Intel Corporation Device 3458 (rev 01)'
+- bus: ff
+  dev: 1e
+  fn: '1'
+  id: '3459'
+  name: 'System peripheral: Intel Corporation Device 3459 (rev 01)'
+- bus: ff
+  dev: 1e
+  fn: '2'
+  id: 345a
+  name: 'System peripheral: Intel Corporation Device 345a (rev 01)'
+- bus: ff
+  dev: 1e
+  fn: '3'
+  id: 345b
+  name: 'System peripheral: Intel Corporation Device 345b (rev 01)'
+- bus: ff
+  dev: 1e
+  fn: '4'
+  id: 345c
+  name: 'System peripheral: Intel Corporation Device 345c (rev 01)'
+- bus: ff
+  dev: 1e
+  fn: '5'
+  id: 345d
+  name: 'System peripheral: Intel Corporation Device 345d (rev 01)'
+- bus: ff
+  dev: 1e
+  fn: '6'
+  id: 345e
+  name: 'System peripheral: Intel Corporation Device 345e (rev 01)'
+- bus: ff
+  dev: 1e
+  fn: '7'
+  id: 345f
+  name: 'System peripheral: Intel Corporation Device 345f (rev 01)'

--- a/platform/broadcom/sonic-platform-modules-accton/as9817-64d/utils/accton_as9817_64d_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-64d/utils/accton_as9817_64d_util.py
@@ -52,6 +52,8 @@ FORCE = 0
 #logging.basicConfig(filename= PROJECT_NAME+'.log', filemode='w',level=logging.DEBUG)
 #logging.basicConfig(level=logging.INFO)
 
+BIOS_VERSION_PATH = "/sys/class/dmi/id/bios_version"
+PCIE_YAML_AIS800_64D = "pcie.yaml.ais800"
 
 if DEBUG == True:
     print(sys.argv[0])
@@ -438,24 +440,6 @@ def do_sonic_platform_clean():
 
     return
 
-device_path = f"{PLATFORM_ROOT_PATH}/x86_64-accton_{PROJECT_NAME}-r0"
-apply_ais800_cmds = [
-    f"cp -f {device_path}/platform.json.ais800 {device_path}/platform.json",
-    f"cp -f {device_path}/platform_components.json.ais800 {device_path}/platform_components.json",
-    f"cp -f {device_path}/pcie.yaml.ais800 {device_path}/pcie.yaml",
-]
-apply_as9817_cmds = [
-    f"cp -f {device_path}/platform.json.as9817 {device_path}/platform.json",
-    f"cp -f {device_path}/platform_components.json.as9817 {device_path}/platform_components.json",
-    f"cp -f {device_path}/pcie.yaml.as9817 {device_path}/pcie.yaml",
-]
-apply_cmd_sets = {
-    0x00 : apply_as9817_cmds, # OSFP
-    0x01 : apply_as9817_cmds, # QDD
-    0x02 : apply_ais800_cmds, # OSFP_ROT  ==> AIS800-64O
-    0x03 : apply_ais800_cmds  # QDD_ROT   ==> AIS800-64D
-}
-
 def get_pcb_id():
     id = None
     status, output = getstatusoutput_noshell("i2cget -f -y 0 0x60 0x00".split())
@@ -469,6 +453,33 @@ def get_pcb_id():
     return id
 
 def apply_product_conf():
+    pcie_yaml_ais800 = PCIE_YAML_AIS800_64D
+    cmd = ["cat", BIOS_VERSION_PATH]
+    status, bios_version = getstatusoutput_noshell(cmd)
+    if bios_version == "v51.01.11.01":
+        pcie_yaml_ais800 = pcie_yaml_ais800+"_"+bios_version
+        print(f"Using {pcie_yaml_ais800} for BIOS {bios_version}")
+    else:
+        print(f"Using default {pcie_yaml_ais800}")
+
+    device_path = f"{PLATFORM_ROOT_PATH}/x86_64-accton_{PROJECT_NAME}-r0"
+    apply_ais800_cmds = [
+        f"sed -i 's/\"name\":\ \"AS9817-64D\"/\"name\":\ \"AIS800-64D\"/g' {device_path}/platform.json",
+        f"cp -f {device_path}/platform_components.json.ais800 {device_path}/platform_components.json",
+        f"cp -f {device_path}/{pcie_yaml_ais800} {device_path}/pcie.yaml",
+    ]
+    apply_as9817_cmds = [
+        f"sed -i 's/\"name\":\ \"AIS800-64D\"/\"name\":\ \"AS9817-64D\"/g' {device_path}/platform.json",
+        f"cp -f {device_path}/platform_components.json.as9817 {device_path}/platform_components.json",
+        f"cp -f {device_path}/pcie.yaml.as9817 {device_path}/pcie.yaml",
+    ]
+    apply_cmd_sets = {
+        0x00 : apply_as9817_cmds, # OSFP
+        0x01 : apply_as9817_cmds, # QDD
+        0x02 : apply_ais800_cmds, # OSFP_ROT  ==> AIS800-64O
+        0x03 : apply_ais800_cmds  # QDD_ROT   ==> AIS800-64D
+    }
+
     pcb_id = get_pcb_id()
     if pcb_id is None:
         print("Invalid PCB ID.")
@@ -607,7 +618,7 @@ def restricted_float(x):
         raise argparse.ArgumentTypeError("%r not a floating-point literal" % (x,))
 
     if x < THRESHOLD_RANGE_LOW or x > THRESHOLD_RANGE_HIGH:
-        raise argparse.ArgumentTypeError("%r not in range [%.1f ~ %.1f]" % 
+        raise argparse.ArgumentTypeError("%r not in range [%.1f ~ %.1f]" %
                                          (x, THRESHOLD_RANGE_LOW, THRESHOLD_RANGE_HIGH))
 
     return x

--- a/platform/broadcom/sonic-platform-modules-accton/as9817-64o/utils/accton_as9817_64o_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-64o/utils/accton_as9817_64o_util.py
@@ -52,6 +52,8 @@ FORCE = 0
 #logging.basicConfig(filename= PROJECT_NAME+'.log', filemode='w',level=logging.DEBUG)
 #logging.basicConfig(level=logging.INFO)
 
+BIOS_VERSION_PATH = "/sys/class/dmi/id/bios_version"
+PCIE_YAML_AIS800_64O = "pcie.yaml.ais800"
 
 if DEBUG == True:
     print(sys.argv[0])
@@ -439,24 +441,6 @@ def do_sonic_platform_clean():
 
     return
 
-device_path = f"{PLATFORM_ROOT_PATH}/x86_64-accton_{PROJECT_NAME}-r0"
-apply_ais800_cmds = [
-    f"cp -f {device_path}/platform.json.ais800 {device_path}/platform.json",
-    f"cp -f {device_path}/platform_components.json.ais800 {device_path}/platform_components.json",
-    f"cp -f {device_path}/pcie.yaml.ais800 {device_path}/pcie.yaml",
-]
-apply_as9817_cmds = [
-    f"cp -f {device_path}/platform.json.as9817 {device_path}/platform.json",
-    f"cp -f {device_path}/platform_components.json.as9817 {device_path}/platform_components.json",
-    f"cp -f {device_path}/pcie.yaml.as9817 {device_path}/pcie.yaml",
-]
-apply_cmd_sets = {
-    0x00 : apply_as9817_cmds, # OSFP
-    0x01 : apply_as9817_cmds, # QDD
-    0x02 : apply_ais800_cmds, # OSFP_ROT  ==> AIS800-64O
-    0x03 : apply_ais800_cmds  # QDD_ROT   ==> AIS800-64D
-}
-
 def get_pcb_id():
     id = None
     status, output = getstatusoutput_noshell("i2cget -f -y 0 0x60 0x00".split())
@@ -470,6 +454,32 @@ def get_pcb_id():
     return id
 
 def apply_product_conf():
+    pcie_yaml_ais800 = PCIE_YAML_AIS800_64O
+    cmd = ["cat", BIOS_VERSION_PATH]
+    status, bios_version = getstatusoutput_noshell(cmd)
+    if bios_version == "v51.01.11.01":
+        pcie_yaml_ais800 = pcie_yaml_ais800+"_"+bios_version
+        print(f"Using {pcie_yaml_ais800} for BIOS {bios_version}")
+    else:
+        print(f"Using default {pcie_yaml_ais800}")
+
+    device_path = f"{PLATFORM_ROOT_PATH}/x86_64-accton_{PROJECT_NAME}-r0"
+    apply_ais800_cmds = [
+        f"sed -i 's/\"name\":\ \"AS9817-64O\"/\"name\":\ \"AIS800-64O\"/g' {device_path}/platform.json",
+        f"cp -f {device_path}/platform_components.json.ais800 {device_path}/platform_components.json",
+        f"cp -f {device_path}/{pcie_yaml_ais800} {device_path}/pcie.yaml",
+    ]
+    apply_as9817_cmds = [
+        f"sed -i 's/\"name\":\ \"AIS800-64O\"/\"name\":\ \"AS9817-64O\"/g' {device_path}/platform.json",
+        f"cp -f {device_path}/platform_components.json.as9817 {device_path}/platform_components.json",
+        f"cp -f {device_path}/pcie.yaml.as9817 {device_path}/pcie.yaml",
+    ]
+    apply_cmd_sets = {
+        0x00 : apply_as9817_cmds, # OSFP
+        0x01 : apply_as9817_cmds, # QDD
+        0x02 : apply_ais800_cmds, # OSFP_ROT  ==> AIS800-64O
+        0x03 : apply_ais800_cmds  # QDD_ROT   ==> AIS800-64D
+}
     pcb_id = get_pcb_id()
     if pcb_id is None:
         print("Invalid PCB ID.")


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support BIOS version v51.01.11.01 on AIS800-64 platforms.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

1. Generate new pcie.yaml for new version of bios.
2. Select pcie.yaml by bios version.
#### How to verify it
AIS800-64D Test Log:
root@ais800-64d-1:/home/admin# ./accton_as9817_64d_util.py install Checking system....
No driver, installing....
IPMI dev interface is ready.
Done driver_install
No device, installing....
Done device_install
Using pcie.yaml.ais800_v51.01.11.01 for BIOS v51.01.11.01 Apply AIS800 Configuration
Successfully installed sonic_platform-1.0-py3-none-any.whl package 
root@ais800-64d-1:/home/admin#

AIS800-64O Test Log:
root@ais800-64o-1:/home/admin# ./accton_as9817_64o_util.py install Checking system....
No driver, installing....
IPMI dev interface is ready.
Done driver_install
No device, installing....
Done device_install
Using pcie.yaml.ais800_v51.01.11.01 for BIOS v51.01.11.01 Apply AIS800 Configuration
Successfully installed sonic_platform-1.0-py3-none-any.whl package 
root@ais800-64o-1:/home/admin#
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

