### PR TITLE
[bookworm] Fix docker gid mismatch with host  (#17158)

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -72,6 +72,7 @@ USER := $(shell id -un)
 PWD := $(shell pwd)
 USER_LC := $(shell echo $(USER) | tr A-Z a-z)
 DOCKER_MACHINE := $(shell docker run --rm debian:buster uname -m)
+HOST_DOCKERD_GID := $(shell getent group docker | cut -d : -f3)
 
 comma := ,
 
@@ -384,7 +385,7 @@ endif
 
 ifeq ($(SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD), y)
 ifneq ($(MULTIARCH_QEMU_ENVIRON), y)
-    DOCKER_RUN += -v /var/run/docker.sock:/var/run/docker.sock
+    DOCKER_RUN += -v /var/run/docker.sock:/var/run/docker.sock --group-add $(HOST_DOCKERD_GID)
 endif
 endif
 


### PR DESCRIPTION
* [bookworm] Fix docker gid mismatch with host
* Use group-add arg instead of update sonic-slave user

Original PR: https://github.com/sonic-net/sonic-buildimage/pull/17158