### PR TITLE
Correct the RFS_DEP_FILES

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -361,7 +361,7 @@ endef
 
 RFS_DEP_FILES := $(wildcard \
 	$(addprefix scripts/, build_debian_base_system.sh prepare_debian_image_buildinfo.sh build_mirror_config.sh) \
-	$(addprefix $(IMAGE_DISTRO_DEBS_PATH)/,$(INITRAMFS_TOOLS) $(LINUX_HEADERS)) \
+	$(addprefix $(IMAGE_DISTRO_DEBS_PATH)/,$(INITRAMFS_TOOLS) $(LINUX_HEADERS_COMMON)) \
 	$(shell git ls-files files/initramfs-tools) \
 	$(shell git ls-files files/image_config) \
 	$(shell git ls-files files/apparmor) \

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -361,7 +361,7 @@ endef
 
 RFS_DEP_FILES := $(wildcard \
 	$(addprefix scripts/, build_debian_base_system.sh prepare_debian_image_buildinfo.sh build_mirror_config.sh) \
-	$(addprefix $(IMAGE_DISTRO_DEBS_PATH)/,$(INITRAMFS_TOOLS) $(LINUX_KERNEL)) \
+	$(addprefix $(IMAGE_DISTRO_DEBS_PATH)/,$(INITRAMFS_TOOLS) $(LINUX_HEADERS)) \
 	$(shell git ls-files files/initramfs-tools) \
 	$(shell git ls-files files/image_config) \
 	$(shell git ls-files files/apparmor) \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
LINUX_KERNEL would not create related files for cache build, Use LINUX_HEADERS_COMMON instead.

```
ubuntu@ip-10-5-1-141:~/workspace/SONiC-Harden/SONiC-GITHUB-Build-202311.X_xsai/sonic-buildimage$ ls -l target/debs/bullseye/linux-*
-rw-r--r-- 1 ubuntu ubuntu  1117260 Sep 25 08:15 target/debs/bullseye/linux-headers-5.10.0-23-2-amd64_5.10.179-3_amd64.deb
-rw-r--r-- 1 ubuntu ubuntu      568 Sep 25 08:34 target/debs/bullseye/linux-headers-5.10.0-23-2-amd64_5.10.179-3_amd64.deb-install.log
-rw-r--r-- 1 ubuntu ubuntu  9106596 Sep 25 07:02 target/debs/bullseye/linux-headers-5.10.0-23-2-common_5.10.179-3_all.deb
-rw-r--r-- 1 ubuntu ubuntu      463 Sep 25 08:34 target/debs/bullseye/linux-headers-5.10.0-23-2-common_5.10.179-3_all.deb-install.log
-rw-r--r-- 1 ubuntu ubuntu       45 Sep 25 06:55 target/debs/bullseye/linux-headers-5.10.0-23-2-common_5.10.179-3_all.deb.dep
-rw-r--r-- 1 ubuntu ubuntu       82 Sep 25 06:55 target/debs/bullseye/linux-headers-5.10.0-23-2-common_5.10.179-3_all.deb.dep.sha
-rw-r--r-- 1 ubuntu ubuntu       45 Sep 25 06:55 target/debs/bullseye/linux-headers-5.10.0-23-2-common_5.10.179-3_all.deb.flags
-rw-r--r-- 1 ubuntu ubuntu 91040017 Sep 25 08:34 target/debs/bullseye/linux-headers-5.10.0-23-2-common_5.10.179-3_all.deb.log
-rw-r--r-- 1 ubuntu ubuntu    17127 Sep 25 06:55 target/debs/bullseye/linux-headers-5.10.0-23-2-common_5.10.179-3_all.deb.smdep
-rw-r--r-- 1 ubuntu ubuntu    11726 Sep 25 06:55 target/debs/bullseye/linux-headers-5.10.0-23-2-common_5.10.179-3_all.deb.smdep.smsha
-rw-r--r-- 1 ubuntu ubuntu 54856168 Sep 25 08:22 target/debs/bullseye/linux-image-5.10.0-23-2-amd64-unsigned_5.10.179-3_amd64.deb
```
#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

