### PR TITLE
[dhcp_relay] Change dhcp_relay feature to enable by default

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -39,10 +39,10 @@
                    ("pmon", "enabled", false, "enabled"),
                    ("snmp", "enabled", true, "enabled"),
                    ("swss", "enabled", false, "enabled"),
-                   ("syncd", "enabled", false, "enabled")] %}
+                   ("syncd", "enabled", false, "enabled"),
+                   ("dhcp_relay", "enabled", false, "enabled")] %}
 {%- if include_router_advertiser == "y" %}{% do features.append(("radv", "enabled", false, "enabled")) %}{% endif %}
 {%- if include_teamd == "y" %}{% do features.append(("teamd", "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] %}disabled{% else %}enabled{% endif %}", false, "enabled")) %}{% endif %}
-{% do features.append(("dhcp_relay", "{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] is not in ['ToRRouter', 'EPMS', 'MgmtTsToR', 'MgmtToRRouter', 'BmcMgmtToRRouter']) %}enabled{% else %}disabled{% endif %}", false, "enabled")) %}
 {%- if include_dhcp_server == "y" %}{% do features.append(("dhcp_server", "disabled", false, "enabled")) %}{% endif %}
 {%- if sonic_asic_platform == "vs" %}{% do features.append(("gbsyncd", "enabled", false, "enabled")) %}{% endif %}
 {%- if include_iccpd == "y" %}{% do features.append(("iccpd", "enabled", false, "enabled")) %}{% endif %}


### PR DESCRIPTION
#### Why I did it
- In the original design, dhcp_relay is automatically enabled only when the device type is ToRRouter.
- During ZTP, a LeafRouter device requires dhcp_relay to be manually enabled before the ZTP process can start.
- This manual step causes unnecessary friction and is inconsistent with automated provisioning goals.

#### How I did it
- Updated the default configuration logic to enable dhcp_relay by default, aligning it with ZTP requirements.
- This change overrides the community default to better support the LeafRouter scenario.

#### How I verified it

- Remove existing configuration:
rm /etc/sonic/config_db.json
- Reset to factory configuration:
config-setup factory
- Verify feature status:
show feature status

Confirm that dhcp_relay is listed with State = enabled.