### PR TITLE
frr: Added a patch to fix malformed session with vrf

### DIFF
--- a/src/sonic-frr/patch/0043-bfdd-Fix_malformed-session-with-vrf.patch
+++ b/src/sonic-frr/patch/0043-bfdd-Fix_malformed-session-with-vrf.patch
@@ -1,0 +1,48 @@
+From b17c179664da7331a4669a1cf548e4e9c48a5477 Mon Sep 17 00:00:00 2001
+From: anlan_cs <vic.lan@pica8.com>
+Date: Wed, 10 May 2023 22:04:33 +0800
+Subject: [PATCH 06972/10000] bfdd: Fix malformed session with vrf
+
+With this configuration:
+
+```
+bfd
+ peer 33:33::66 local-address 33:33::88 vrf vrf8 interface enp1s0
+ exit
+ !
+exit
+```
+
+The bfd session can't be established with error:
+
+```
+bfdd[18663]: [YA0Q5-C0BPV] control-packet: wrong vrfid. [mhop:no peer:33:33::66 local:33:33::88 port:2 vrf:61]
+```
+
+The vrf check should use the carefully adjusted `vrfid`, which is
+based on globally/reliable interface.  We can't believe the
+`bvrf->vrf->vrf_id` because the `/proc/sys/net/ipv4/udp_l3mdev_accept`
+maybe is set "1" in VRF-lite backend even with security drawback.
+
+Just correct the vrf check.
+
+Signed-off-by: anlan_cs <vic.lan@pica8.com>
+---
+ bfdd/bfd_packet.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bfdd/bfd_packet.c b/bfdd/bfd_packet.c
+index 311ce4d37..ea7a1038a 100644
+--- a/bfdd/bfd_packet.c
++++ b/bfdd/bfd_packet.c
+@@ -878,7 +878,7 @@ void bfd_recv_cb(struct event *t)
+        /*
+         * We may have a situation where received packet is on wrong vrf
+         */
+-       if (bfd && bfd->vrf && bfd->vrf != bvrf->vrf) {
++       if (bfd && bfd->vrf && bfd->vrf->vrf_id != vrfid) {
+                cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
+                         "wrong vrfid.");
+                return;
+-- 
+2.38.1

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -39,3 +39,4 @@ cross-compile-changes.patch
 0040-bgpd-some-safi-s-do-not-mix-with-bgp-suppress-fib.patch
 0041-zebra-Check-if-ifp-is-not-NULL-in-zebra_if_update_ct.patch
 0042-Nexthop-compare-function-include-vxlan-encap-info.patch
+0043-bfdd-Fix_malformed-session-with-vrf.patch


### PR DESCRIPTION
Patch picked from https://github.com/sonic-net/sonic-buildimage/pull/20207

(cherry picked from commit 58d5896d832faa30db836bd1e828bd51633f7b6f)

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Currently establishing a bfd session with a bgp unnumbered peer inside of a Vrf will fail with the message "wrong vrfid" since it compares more than the vrfid, see https://github.com/FRRouting/frr/pull/13506 for more details

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
Enable bfd for a bgp unnumbered peer in non-default vrf:
```
edgecore202311-x-02# show bfd peers
BFD Peers:
        peer fe80::e42:46ff:fe94:0 local-address fe80::e97:b7ff:fee2:0 vrf Vrf_main interface Ethernet124.900
                ID: 613719910
                Remote ID: 1406160404
                Active mode
                Status: up
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 202311.4

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 202311.X (61d23c15784380c8dfcd123a085132978acf0fbf)
-->

- [x] 202311.X (61d23c15784380c8dfcd123a085132978acf0fbf)

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

