### PR TITLE
Correct indent issue of patch file

### DIFF
--- a/src/sonic-frr/patch/0043-bfdd-Fix_malformed-session-with-vrf.patch
+++ b/src/sonic-frr/patch/0043-bfdd-Fix_malformed-session-with-vrf.patch
@@ -1,7 +1,7 @@
 From b17c179664da7331a4669a1cf548e4e9c48a5477 Mon Sep 17 00:00:00 2001
 From: anlan_cs <vic.lan@pica8.com>
 Date: Wed, 10 May 2023 22:04:33 +0800
-Subject: [PATCH 06972/10000] bfdd: Fix malformed session with vrf
+Subject: [PATCH] bfdd: Fix malformed session with vrf
 
 With this configuration:
 
@@ -32,17 +32,15 @@ Signed-off-by: anlan_cs <vic.lan@pica8.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/bfdd/bfd_packet.c b/bfdd/bfd_packet.c
-index 311ce4d37..ea7a1038a 100644
+index 311ce4d37905..ea7a1038ae6b 100644
 --- a/bfdd/bfd_packet.c
 +++ b/bfdd/bfd_packet.c
 @@ -878,7 +878,7 @@ void bfd_recv_cb(struct event *t)
-        /*
-         * We may have a situation where received packet is on wrong vrf
-         */
--       if (bfd && bfd->vrf && bfd->vrf != bvrf->vrf) {
-+       if (bfd && bfd->vrf && bfd->vrf->vrf_id != vrfid) {
-                cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
-                         "wrong vrfid.");
-                return;
--- 
-2.38.1
+ 	/*
+ 	 * We may have a situation where received packet is on wrong vrf
+ 	 */
+-	if (bfd && bfd->vrf && bfd->vrf != bvrf->vrf) {
++	if (bfd && bfd->vrf && bfd->vrf->vrf_id != vrfid) {
+ 		cp_debug(is_mhop, &peer, &local, ifindex, vrfid,
+ 			 "wrong vrfid.");
+ 		return;


### PR DESCRIPTION
#### Why I did it
Fix https://github.com/edge-core/sonic-buildimage/pull/631

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

