### PR TITLE
SON-2291: [Xsight] Restore ASIC_SENSOR poller parameters in config_db.json

### DIFF
--- a/platform/xsight/files/xlx/start.sh
+++ b/platform/xsight/files/xlx/start.sh
@@ -32,7 +32,7 @@ if [ "false" = "$ASIC_POLLER_SECTION" ]; then
         echo "Merging $CUSTOM_JSON into config_db.json ..."
         sonic-cfggen --from-db -j "$CUSTOM_JSON" --print-data > "$TMP_CONFIG"
         mv "$TMP_CONFIG" /etc/sonic/config_db.json
-        config reload -y
+        sonic-cfggen -j "$CUSTOM_JSON" --write-to-db
     else
         echo "custom.json not found for platform $PLATFORM" >&2
     fi

--- a/platform/xsight/files/xlx/start.sh
+++ b/platform/xsight/files/xlx/start.sh
@@ -18,15 +18,23 @@ XPLT_UTL="/opt/xplt/utils"
 XSIGHT_PCI_SIG="1e6c"
 XSIGHT_PCI_ID=""
 XSIGHT_DEVICE=""
-FIRSTBOOT="/tmp/notify_firstboot_to_platform"
 
-if [ -f $FIRSTBOOT ]; then
-    PLATFORM=$(sed -n 's/onie_platform=\(.*\)/\1/p' /host/machine.conf)
-
-    # update default config from custom.json
-    if [ -f /usr/share/sonic/device/$PLATFORM/custom.json ]; then
-        sonic-cfggen --from-db -j /usr/share/sonic/device/$PLATFORM/custom.json --print-data > /etc/sonic/config_db.json
-        sonic-cfggen -j /usr/share/sonic/device/$PLATFORM/custom.json --write-to-db
+# Adding the custom.json content at runtime is a workaround introduced in the 202311 code.
+# Ideally, this should be handled via platform.json, but the necessary infrastructure
+# was added later in 202411 (PR #20826: "[asic_sensors] Generate the ASIC sensor polling
+# configuration based on platform.json").
+ASIC_POLLER_SECTION=$(sonic-cfggen --from-db -j /etc/sonic/config_db.json --print-data | jq 'has("ASIC_SENSORS")')
+PLATFORM=$(sed -n 's/onie_platform=\(.*\)/\1/p' /host/machine.conf)
+CUSTOM_JSON="/usr/share/sonic/device/$PLATFORM/custom.json"
+TMP_CONFIG="/etc/sonic/config_db.json.tmp"
+if [ "false" = "$ASIC_POLLER_SECTION" ]; then
+    if [ -f "$CUSTOM_JSON" ]; then
+        echo "Merging $CUSTOM_JSON into config_db.json ..."
+        sonic-cfggen --from-db -j "$CUSTOM_JSON" --print-data > "$TMP_CONFIG"
+        mv "$TMP_CONFIG" /etc/sonic/config_db.json
+        config reload -y
+    else
+        echo "custom.json not found for platform $PLATFORM" >&2
     fi
 fi
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The sonic-config update process clears the ASIC_SENSOR section in config_db.json.
This change restores the poller parameters automatically during the next boot
to ensure proper monitoring.



##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

