### PR TITLE
SON-2281: es9618xx: Align interface names in platform.json

### DIFF
--- a/device/accton/x86_64-accton_es9618xx-r0/platform.json
+++ b/device/accton/x86_64-accton_es9618xx-r0/platform.json
@@ -468,52 +468,52 @@
       ],
       "sfps": [
         {
-            "name": "osfp1"
+            "name": "Ethernet0"
         },
         {
-            "name": "osfp2"
+            "name": "Ethernet8"
         },
         {
-            "name": "osfp3"
+            "name": "Ethernet16"
         },
         {
-            "name": "osfp4"
+            "name": "Ethernet24"
         },
         {
-            "name": "osfp5"
+            "name": "Ethernet32"
         },
         {
-            "name": "osfp6"
+            "name": "Ethernet40"
         },
         {
-            "name": "osfp7"
+            "name": "Ethernet48"
         },
         {
-            "name": "osfp8"
+            "name": "Ethernet56"
         },
         {
-            "name": "osfp9"
+            "name": "Ethernet64"
         },
         {
-            "name": "osfp10"
+            "name": "Ethernet72"
         },
         {
-            "name": "osfp11"
+            "name": "Ethernet80"
         },
         {
-            "name": "osfp12"
+            "name": "Ethernet88"
         },
         {
-            "name": "osfp13"
+            "name": "Ethernet96"
         },
         {
-            "name": "osfp14"
+            "name": "Ethernet104"
         },
         {
-            "name": "osfp15"
+            "name": "Ethernet112"
         },
         {
-            "name": "osfp16"
+            "name": "Ethernet120"
         }
       ]
     },


### PR DESCRIPTION
The test `platform_tests/api/test_sfp.py::test_get_name()` retrieves OSFP interface names (e.g., "osfp1") from platform.json, while `sfp.get_name()` returns names in the "EthernetXX" format. This inconsistency between the platform API and platform.json causes the test to fail with errors such as:

Failed: Transceiver name 'Ethernet0' for PORT1 not found in platform.json; expected 'osfp1' at index 1.

This commit aligns the interface names in platform.json to ensure consistency between the platform API implementation and the test expectations.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

