### PR TITLE
Fix the libsnmp library using 5.9+dfsg-4+deb11u1 on bullseye.

### DIFF
--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -141,7 +141,10 @@ RUN apt-get update && apt-get install -y eatmydata && eatmydata apt-get install 
         chrpath \
 # For frr build
         libc-ares-dev \
-        libsnmp-dev \
+        libsnmp40=5.9+dfsg-4+deb11u1 \
+        libnetsnmptrapd40=5.9+dfsg-4+deb11u1 \
+        libsnmp-base=5.9+dfsg-4+deb11u1 \
+        libsnmp-dev=5.9+dfsg-4+deb11u1 \
         libjson-c-dev \
         libsystemd-dev \
         python3-ipaddr \


### PR DESCRIPTION
Fix the libsnmp library using 5.9+dfsg-4+deb11u1 on bullseye.