### PR TITLE
[docker-snmp] Install dependency packages - libpci3, libsensors5, libpcap0.8

### DIFF
--- a/dockers/docker-snmp/Dockerfile.j2
+++ b/dockers/docker-snmp/Dockerfile.j2
@@ -20,7 +20,10 @@ RUN apt-get update   && \
         python3-dev     \
         gcc             \
         make            \
-        ipmitool
+        ipmitool        \
+        libpci3         \
+        libsensors5     \
+        libpcap0.8
 
 {% if docker_snmp_debs.strip() -%}
 # Copy locally-built Debian package dependencies


### PR DESCRIPTION

#### Why I did it
snmpd fails to bind to the management VRF interface, causing the service to fail or become unreachable via the management IP.

The root cause is that the installed `libsnmp`/`snmpd` packages were inadvertently replaced by official Debian versions, which lack the necessary source code patches for management VRF binding (SO_BINDTODEVICE).

This occurred because the locally built Debian packages depended on libraries (`libpci3`, `libsensors5`) not present in the base image. The `dpkg -i` command failed due to these missing dependencies, triggering the fallback `apt-get -f install`. Since the upstream Debian repository contained a newer version of snmpd than the local build, apt upgraded the packages, effectively discarding the local SONiC patches.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Pre-install the required dependency packages (libpci3, libsensors5, libpcap0.8, etc.) in the Dockerfile. This ensures the initial installation of the custom SONiC packages succeeds, preventing apt from overriding them with upstream versions.

#### How to verify it
1. Build docker-snmp.gz image and upgrade docker image
2. Setup mgmt VRF and restart snmp.service to verify if snmpget work

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

