### PR TITLE
Change the go URL of slave container.

### DIFF
--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -478,7 +478,7 @@ RUN export VERSION=1.15.15 \
  && wget https://storage.googleapis.com/golang/go$VERSION.linux-arm64.tar.gz \
  && tar -C /usr/local -xzf go$VERSION.linux-arm64.tar.gz \
 {%- else %}
- && wget https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz \
+ && wget https://dl.google.com/go/go$VERSION.linux-amd64.tar.gz \
  && tar -C /usr/local -xzf go$VERSION.linux-amd64.tar.gz \
 {%- endif %}
  && echo 'export GOROOT=/usr/local/go' >> /etc/bash.bashrc \


### PR DESCRIPTION
- What I did: 
Change the URL to https://dl.google.com/go/go1.16.3.linux-amd64.tar.gz.

- Why I did: 
The original URL cannot download go package.

