### PR TITLE
upgrade XSAI version to 1.13.3-7

### DIFF
--- a/platform/xsight/xsight-sai.mk
+++ b/platform/xsight/xsight-sai.mk
@@ -1,6 +1,6 @@
 # XSight SAI
 
-XSIGHT_LIBSAI_VERSION = 1.13.3-6
+XSIGHT_LIBSAI_VERSION = 1.13.3-7
 XSIGHT_LIBSAI_URL_PREFIX = "https://github.com/Xsight-Labs/SONiC/raw/refs/heads/main/amd64/sai-plugin/202311"
 
 XSIGHT_LIBSAI = xsai-main_$(XSIGHT_LIBSAI_VERSION)_amd64.deb


### PR DESCRIPTION
upgrade XSAI version to 1.13.3-7

#### Why I did it
To provide latest changes requested by EC

#### How I did it
Release notes
Added support of mirroring configuration with an attached policer

#### How to verify it
Build fresh SONiC image and check opened issues
