### PR TITLE
copp/copp_cfg.j2: Change the Broadcom ASIC devices to use dhcp_l2 and dhcpv6_l2 traps.

### DIFF
--- a/files/image_config/copp/copp-config.sh
+++ b/files/image_config/copp/copp-config.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-sonic-cfggen -d -t /usr/share/sonic/templates/copp_cfg.j2 > /etc/sonic/copp_cfg.json
+asic_type=$(sonic-cfggen -d -y /etc/sonic/sonic_version.yml --var asic_type)
+
+sonic-cfggen -d -a "{\"asic_type\": \"$asic_type\"}" \
+  -t /usr/share/sonic/templates/copp_cfg.j2 > /etc/sonic/copp_cfg.json

--- a/files/image_config/copp/copp_cfg.j2
+++ b/files/image_config/copp/copp_cfg.j2
@@ -121,7 +121,7 @@
 		    "trap_group": "queue4_group3"
 	    },
 	    "dhcp_relay": {
-		    "trap_ids": "dhcp,dhcpv6",
+		    "trap_ids": "{{ 'dhcp_l2,dhcpv6_l2' if asic_type == 'broadcom' else 'dhcp,dhcpv6' }}",
 		    "trap_group": "queue4_group3"
 	    },
 	    "udld": {


### PR DESCRIPTION
… dhcpv6_l2 traps.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Change the Broadcom ASIC devices to use dhcp_l2 and dhcpv6_l2 traps.

#### How I did it
Enhancement

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

