### PR TITLE
Disable build sonic-platform-nokia-chassis

### DIFF
--- a/platform/broadcom/rules.mk
+++ b/platform/broadcom/rules.mk
@@ -1,6 +1,6 @@
 include $(PLATFORM_PATH)/sai-modules.mk
 include $(PLATFORM_PATH)/sai.mk
-include $(PLATFORM_PATH)/platform-modules-nokia.mk
+# include $(PLATFORM_PATH)/platform-modules-nokia.mk
 include $(PLATFORM_PATH)/platform-modules-dell.mk
 include $(PLATFORM_PATH)/platform-modules-arista.mk
 #include $(PLATFORM_PATH)/platform-modules-ingrasys.mk


### PR DESCRIPTION
#### Why I did it
Disable build sonic-platform-nokia-chassis

#### Why I did it
The required library, 'sonic-platform-nokia-chassis', is out of date, which causes a build failure.
The Edge-corE product does not need to build the Nokia platform.