### PR TITLE
JIRA-ONSBUSWI-3584: Fix incorrect indexing of per-fan threshold attributes

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as9817-32o/modules/accton_as9817_32_fan.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-32o/modules/accton_as9817_32_fan.c
@@ -165,7 +165,9 @@ enum as9817_32_fan_sysfs_attrs {
     FAN_RPM_THRESHOLD_ATTR(11),
     FAN_RPM_THRESHOLD_ATTR(12),
     FAN_RPM_THRESHOLD_ATTR(13),
-    FAN_RPM_THRESHOLD_ATTR(14)
+    FAN_RPM_THRESHOLD_ATTR(14),
+    NUM_OF_FAN_RPM_THRESHOLD_ATTR,
+    NUM_OF_PER_FAN_RPM_THRESHOLD_ATTR = ((NUM_OF_FAN_RPM_THRESHOLD_ATTR-NUM_OF_PER_FAN_ATTR)/NUM_OF_FAN),
 };
 
 /* fan attributes */
@@ -522,7 +524,9 @@ static ssize_t show_threshold(struct device *dev, struct device_attribute *da,
             char *buf)
 {
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+    unsigned char fid;
     int value = 0;
+    int index = 0;
     int error = 0;
 
     mutex_lock(&data->update_lock);
@@ -548,8 +552,10 @@ static ssize_t show_threshold(struct device *dev, struct device_attribute *da,
     case FAN12_TARGET:
     case FAN13_TARGET:
     case FAN14_TARGET:
-        value = (int)data->ipmi_resp_speed[FAN_TARGET_SPEED0] |
-                (int)data->ipmi_resp_speed[FAN_TARGET_SPEED1] << 8;
+        fid = (attr->index - FAN1_TARGET) / NUM_OF_PER_FAN_RPM_THRESHOLD_ATTR;
+        index = fid * FAN_SPEED_DATA_COUNT;
+        value = (int)data->ipmi_resp_speed[index + FAN_TARGET_SPEED0] |
+                (int)data->ipmi_resp_speed[index + FAN_TARGET_SPEED1] << 8;
         break;
     case FAN1_TOLERANCE:
     case FAN2_TOLERANCE:
@@ -565,7 +571,9 @@ static ssize_t show_threshold(struct device *dev, struct device_attribute *da,
     case FAN12_TOLERANCE:
     case FAN13_TOLERANCE:
     case FAN14_TOLERANCE:
-        value = (int)data->ipmi_resp_speed[FAN_SPEED_TOLERANCE];
+        fid = (attr->index - FAN1_TOLERANCE) / NUM_OF_PER_FAN_RPM_THRESHOLD_ATTR;
+        index = fid * FAN_SPEED_DATA_COUNT;
+        value = (int)data->ipmi_resp_speed[index + FAN_SPEED_TOLERANCE];
         break;
     default:
         error = -EINVAL;

--- a/platform/broadcom/sonic-platform-modules-accton/as9817-64o/modules/accton_as9817_64_fan.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-64o/modules/accton_as9817_64_fan.c
@@ -165,7 +165,9 @@ enum as9817_64_fan_sysfs_attrs {
     FAN_RPM_THRESHOLD_ATTR(5),
     FAN_RPM_THRESHOLD_ATTR(6),
     FAN_RPM_THRESHOLD_ATTR(7),
-    FAN_RPM_THRESHOLD_ATTR(8)
+    FAN_RPM_THRESHOLD_ATTR(8),
+    NUM_OF_FAN_RPM_THRESHOLD_ATTR,
+    NUM_OF_PER_FAN_RPM_THRESHOLD_ATTR = ((NUM_OF_FAN_RPM_THRESHOLD_ATTR-NUM_OF_PER_FAN_ATTR)/NUM_OF_FAN),
 };
 
 /* fan attributes */
@@ -619,7 +621,9 @@ static ssize_t show_threshold(struct device *dev, struct device_attribute *da,
             char *buf)
 {
     struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+    unsigned char fid;
     int value = 0;
+    int index = 0;
     int error = 0;
 
     mutex_lock(&data->update_lock);
@@ -639,8 +643,10 @@ static ssize_t show_threshold(struct device *dev, struct device_attribute *da,
     case FAN6_TARGET:
     case FAN7_TARGET:
     case FAN8_TARGET:
-        value = (int)data->ipmi_resp_speed[FAN_TARGET_SPEED0] |
-                (int)data->ipmi_resp_speed[FAN_TARGET_SPEED1] << 8;
+        fid = (attr->index - FAN1_TARGET) / NUM_OF_PER_FAN_RPM_THRESHOLD_ATTR;
+        index = fid * FAN_SPEED_DATA_COUNT;
+        value = (int)data->ipmi_resp_speed[index + FAN_TARGET_SPEED0] |
+                (int)data->ipmi_resp_speed[index + FAN_TARGET_SPEED1] << 8;
         break;
     case FAN1_TOLERANCE:
     case FAN2_TOLERANCE:
@@ -650,7 +656,9 @@ static ssize_t show_threshold(struct device *dev, struct device_attribute *da,
     case FAN6_TOLERANCE:
     case FAN7_TOLERANCE:
     case FAN8_TOLERANCE:
-        value = (int)data->ipmi_resp_speed[FAN_SPEED_TOLERANCE];
+        fid = (attr->index - FAN1_TOLERANCE) / NUM_OF_PER_FAN_RPM_THRESHOLD_ATTR;
+        index = fid * FAN_SPEED_DATA_COUNT;
+        value = (int)data->ipmi_resp_speed[index + FAN_SPEED_TOLERANCE];
         break;
     default:
         error = -EINVAL;


### PR DESCRIPTION
- Corrected the `fid` and `index` calculation logic in the `show_threshold` function for AS9817-32d/o and AS9817-64d/o platforms.
- Introduced `NUM_OF_FAN_RPM_THRESHOLD_ATTR` and `NUM_OF_PER_FAN_RPM_THRESHOLD_ATTR` to dynamically calculate  per-fan threshold attributes.
- Updated the logic for `FAN_TARGET` and `FAN_TOLERANCE` cases to properly index `ipmi_resp_speed` based on the fan ID.

This fix resolves indexing errors when handling per-fan thresholds .