### PR TITLE
JIRA-ONSBUSWI-3560: Fix fan speed check disabled issue by refining duty cycle conversion

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as4625-54p/modules/x86-64-accton-as4625-54p-fan.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as4625-54p/modules/x86-64-accton-as4625-54p-fan.c
@@ -185,19 +185,20 @@ static int as4625_fan_write_value(u8 reg, u8 value)
 static u32 reg_val_to_duty_cycle(u8 reg_val)
 {
 	reg_val &= FAN_DUTY_CYCLE_REG_MASK;
-	return (u32)(reg_val+1) * 625 / 100;
+    if (reg_val < 4)
+        return ((u32)(reg_val) * 625 + 50) / 100;
+    else
+        return ((u32)(reg_val+1) * 625 + 50) / 100;
 }
 
 static u8 duty_cycle_to_reg_val(u8 duty_cycle)
 {
-    if (duty_cycle == 0) {
-        return 0;
-    }
-	else if (duty_cycle > FAN_MAX_DUTY_CYCLE) {
-		duty_cycle = FAN_MAX_DUTY_CYCLE;
-	}
-
-    return ((u32)duty_cycle * 100 / 625) - 1;
+    if (duty_cycle <= 21)
+        return (((u32)duty_cycle * 100 + 312) / 625);
+    else if(duty_cycle <= 29)
+        return (duty_cycle <= 25) ? 3 : 4;
+    else
+        return (((u32)duty_cycle * 100 + 312) / 625) - 1;
 }
 
 static u32 reg_val_to_speed_rpm(u8 reg_val)

--- a/platform/broadcom/sonic-platform-modules-accton/as4625-54t/utils/accton_as4625_54t_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4625-54t/utils/accton_as4625_54t_monitor.py
@@ -32,7 +32,7 @@ FUNCTION_NAME = '/usr/local/bin/accton_as4625_54t_monitor'
 I2C_PATH = "/sys/bus/i2c/devices/{}-00{}/"
 
 FAN_SPEED_DEFAULT_F2B = 38
-FAN_SPEED_DEFAULT_B2F = 25
+FAN_SPEED_DEFAULT_B2F = 31
 FAN_SPEED_MAX = 100
 
 ERROR_CONFIG_LOGGING = 1

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/modules/x86-64-accton-as4630-54pe-cpld.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/modules/x86-64-accton-as4630-54pe-cpld.c
@@ -532,12 +532,12 @@ static ssize_t show_version(struct device *dev, struct device_attribute *attr, c
 static u32 reg_val_to_duty_cycle(u8 reg_val)
 {
     reg_val &= FAN_DUTY_CYCLE_REG_MASK;
-    return ((u32)(reg_val) * 625)/ 100;
+    return ((u32)(reg_val) * 625 + 50)/ 100;
 }
 
 static u8 duty_cycle_to_reg_val(u8 duty_cycle)
 {
-    return ((u32)duty_cycle * 100 / 625);
+    return (((u32)duty_cycle * 100 + 312) / 625);
 }
 
 static u32 reg_val_to_speed_rpm(u8 reg_val)

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/accton_as4630_54pe_monitor.py
@@ -165,7 +165,7 @@ class device_monitor(object):
         LEVEL_TEMP_CRITICAL=4
         fan_policy = {
            LEVEL_FAN_MIN:       [50,   8, 0,      140000],
-           LEVEL_FAN_NORMAL:    [62,  10, 140000, 150000],
+           LEVEL_FAN_NORMAL:    [63,  10, 140000, 150000],
            LEVEL_FAN_MID:       [75,  12, 150000, 160000],
            LEVEL_FAN_HIGH:      [88,  14, 160000, 240000],
            LEVEL_TEMP_CRITICAL: [100, 16, 240000, 300000],

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54te/modules/x86-64-accton-as4630-54te-cpld.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54te/modules/x86-64-accton-as4630-54te-cpld.c
@@ -535,12 +535,12 @@ static ssize_t show_version(struct device *dev, struct device_attribute *attr, c
 static u32 reg_val_to_duty_cycle(u8 reg_val)
 {
     reg_val &= FAN_DUTY_CYCLE_REG_MASK;
-    return ((u32)(reg_val) * 625)/ 100;
+    return ((u32)(reg_val) * 625 + 50)/ 100;
 }
 
 static u8 duty_cycle_to_reg_val(u8 duty_cycle)
 {
-    return ((u32)duty_cycle * 100 / 625);
+    return (((u32)duty_cycle * 100 + 312) / 625);
 }
 
 static u32 reg_val_to_speed_rpm(u8 reg_val)

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54te/utils/accton_as4630_54te_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54te/utils/accton_as4630_54te_monitor.py
@@ -163,10 +163,10 @@ class device_monitor(object):
         LEVEL_FAN_HIGH = 3
         LEVEL_TEMP_CRITICAL = 4
         fan_policy = {
-            LEVEL_FAN_MIN: [50, 8, 0, 140000],
-            LEVEL_FAN_NORMAL: [62, 10, 140000, 150000],
-            LEVEL_FAN_MID: [75, 12, 150000, 160000],
-            LEVEL_FAN_HIGH: [88, 14, 160000, 240000],
+            LEVEL_FAN_MIN:       [50,   8, 0,      140000],
+            LEVEL_FAN_NORMAL:    [63,  10, 140000, 150000],
+            LEVEL_FAN_MID:       [75,  12, 150000, 160000],
+            LEVEL_FAN_HIGH:      [88,  14, 160000, 240000],
             LEVEL_TEMP_CRITICAL: [100, 16, 240000, 300000],
         }
         temp = [0, 0, 0]


### PR DESCRIPTION
Summary:
- Implement linear interpolation for fan speed calculation on AS4630.
- Fix duty cycle to register value conversion formulas to improve precision.
- Adjust default fan speed and monitoring policies for specific platforms.

Description:
1. AS4625/AS4630 (C drivers):
   - Update `reg_val_to_duty_cycle` and `duty_cycle_to_reg_val` with rounding offsets (e.g., +50, +312) to ensure more accurate integer math conversion between percentage (0-100) and CPLD register values.
   - Handle specific non-linear cases for AS4625-54P duty cycle ranges.

2. Monitor Utilities:
   - AS4625-54T: Update `FAN_SPEED_DEFAULT_B2F` from 25% to 31%.
   - AS4630-54PE/TE: Adjust `LEVEL_FAN_NORMAL` target speed from 62% to 63% in fan policy.