### PR TITLE
[device] Accton AS5712-54x: fix Python script errors preventing platform monitor startup

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as5712-54x/classes/fanutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5712-54x/classes/fanutil.py
@@ -122,7 +122,7 @@ class FanUtil(object):
             return None
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None
@@ -153,7 +153,7 @@ class FanUtil(object):
         val_file.write(content)
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None

--- a/platform/broadcom/sonic-platform-modules-accton/as5712-54x/classes/thermalutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5712-54x/classes/thermalutil.py
@@ -80,7 +80,7 @@ class ThermalUtil(object):
             return None
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None

--- a/platform/broadcom/sonic-platform-modules-accton/as5712-54x/utils/accton_as5712_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5712-54x/utils/accton_as5712_monitor.py
@@ -28,6 +28,7 @@ try:
     import logging.config
     import time  # this is only being used as part of the example
     import signal
+    import sys
     from as5712_54x.fanutil import FanUtil
     from as5712_54x.thermalutil import ThermalUtil
 except ImportError as e:


### PR DESCRIPTION
#### Why I did it

The as5712-platform-monitor.service was failing to start in my lab
This change fixes python script issues so the platform monitoring service can start

#### How I did it

Update the platform monitoring python sources:
- fixed inconsistent tab/space indentation in:
  - platform/broadcom/sonic-platform-modules-accton/as5712-54x/classes/fanutil.py
  - platform/broadcom/sonic-platform-modules-accton/as5712-54x/classes/thermalutil.py
- added missing "import sys" in:
  - platform/broadcom/sonic-platform-modules-accton/as5712-54x/utils/accton_as5712_monitor.py

#### How to verify it

1. Build and install a image with this change on my AS5712-54X
2. Start/Checked the platform monitor service after boot


---

Small step, i am currently working on full working version (best effort) and adding support for qsfp+ breakout