### PR TITLE
Add DPS400AB PSU model support for AS5835-54T/54X

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/modules/pddf_custom_psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/modules/pddf_custom_psu.c
@@ -156,12 +156,14 @@ static struct i2c_client *find_psu_eeprom_client(struct i2c_client *pmbus_client
 const char *fan_b2f_models[] = {
     "YM-2401H-DR",
     "YM-1401A-CR",
+    "DPS400AB-34A",
     NULL
 };
 
 const char *fan_f2b_models[] = {
     "YM-2401H-CR",
     "YM-1401A-BR",
+    "DPS400AB-33A",
     NULL
 };
 

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/modules/pddf_custom_psu.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/modules/pddf_custom_psu.c
@@ -155,12 +155,14 @@ static struct i2c_client *find_psu_eeprom_client(struct i2c_client *pmbus_client
 const char *fan_b2f_models[] = {
     "YM-2401H-DR",
     "YM-1401A-CR",
+    "DPS400AB-34A",
     NULL
 };
 
 const char *fan_f2b_models[] = {
     "YM-2401H-CR",
     "YM-1401A-BR",
+    "DPS400AB-33A",
     NULL
 };
 


### PR DESCRIPTION
#### Why I did it
Delta PSU can't display the correct fan direction

#### How I did it
Add DPS400AB-34A (B2F) and DPS400AB-33A (F2B) to fan direction model lists

#### How to verify it
Build and install image on device
