### PR TITLE
SON-2344: set pfcwd_sw_enable to 3,4 to match pfc_enable

### DIFF
--- a/device/accton/x86_64-accton_es9618xx-r0/Accton-ES9618XX-O16x400G/qos.json.j2
+++ b/device/accton/x86_64-accton_es9618xx-r0/Accton-ES9618XX-O16x400G/qos.json.j2
@@ -180,7 +180,7 @@
             "tc_to_queue_map": "AZURE",
             "dscp_to_tc_map": "AZURE",
             "pfc_to_queue_map": "AZURE",
-            "pfcwd_sw_enable" : "0,1,2,3",
+            "pfcwd_sw_enable" : "3,4",
             "pfc_enable": "3,4"
         }{% if not loop.last %},{% endif %}
 

--- a/platform/xsight/xsight-sai.mk
+++ b/platform/xsight/xsight-sai.mk
@@ -1,6 +1,6 @@
 # XSight SAI
 
-XSIGHT_LIBSAI_VERSION = 1.13.3-10
+XSIGHT_LIBSAI_VERSION = 1.13.3-11
 XSIGHT_LIBSAI_URL_PREFIX = "https://github.com/Xsight-Labs/SONiC/raw/refs/heads/main/amd64/sai-plugin/202311"
 
 XSIGHT_LIBSAI = xsai-main_$(XSIGHT_LIBSAI_VERSION)_amd64.deb


### PR DESCRIPTION
Align PFC watchdog enabled queues with PFC-enabled queues (3,4)

#### Why I did it
To align PFC WD TCs in Xsight's QoS template with default SONiC's lossless TCs

#### How I did it
Updated Xsight's QoS template

#### How to verify it
Build fresh SONiC image and check opened issues
