### PR TITLE
Correct i2c-health message indexes

### DIFF
--- a/src/i2c-health/i2c_health_mgr/i2c_health_msgs.py
+++ b/src/i2c-health/i2c_health_mgr/i2c_health_msgs.py
@@ -29,7 +29,7 @@ i2c_health_msg_list = [
     "Failed to execute cmd to start i2c daemon: '{}'.", # 022(ERROR): i2c daemon service. Example "Failed to execute cmd to start i2c daemon: 'sudo systemctl start as9716-32d-platform-monitor-fan.service'."
     "Failed to add {}({}:{}) into the isolation list.", # 023(ERROR): device name, region id, device addr. Example: "Failed to add Ethernet1(77-2-72-1:25-0050) into the isolation list."
     "Failed to remove {}({}:{}) into the isolation list.", # 024(ERROR): device name, region id, device addr. Example: "Failed to remove Ethernet1(77-2-72-1:25-0050) into the isolation list."
-    "Abnormal condition in handling cached_data during the STATE DB restore operation. ", # 025(WARNING)
+    "Abnormal condition in handling cached_data during the STATE DB restore operation.", # 025(WARNING)
     "These devices are unfinished during the restoration: {}.", # 026(NOTICE): Uncleared cached device names, Example: "These devices are unfinished during the restoration: ['Ethernet24', 'Ethernet144', 'Ethernet64, ...]."
     "After reset mux, the I2C bus lock is still detected", # 027(ERROR)
     "After reset I2C master, the I2C bus lock is still detected", # 028(ERROR)

--- a/src/i2c-health/i2c_health_mgr/i2c_health_msgs.py
+++ b/src/i2c-health/i2c_health_mgr/i2c_health_msgs.py
@@ -30,9 +30,9 @@ i2c_health_msg_list = [
     "Failed to add {}({}:{}) into the isolation list.", # 023(ERROR): device name, region id, device addr. Example: "Failed to add Ethernet1(77-2-72-1:25-0050) into the isolation list."
     "Failed to remove {}({}:{}) into the isolation list.", # 024(ERROR): device name, region id, device addr. Example: "Failed to remove Ethernet1(77-2-72-1:25-0050) into the isolation list."
     "Abnormal condition in handling cached_data during the STATE DB restore operation. ", # 025(WARNING)
-    "These devices are unfinished during the restoration: {}.", # 025(NOTICE): Uncleared cached device names, Example: "These devices are unfinished during the restoration: ['Ethernet24', 'Ethernet144', 'Ethernet64, ...]."
-    "After reset mux, the I2C bus lock is still detected", # 026(ERROR)
-    "After reset I2C master, the I2C bus lock is still detected", # 027(ERROR)
+    "These devices are unfinished during the restoration: {}.", # 026(NOTICE): Uncleared cached device names, Example: "These devices are unfinished during the restoration: ['Ethernet24', 'Ethernet144', 'Ethernet64, ...]."
+    "After reset mux, the I2C bus lock is still detected", # 027(ERROR)
+    "After reset I2C master, the I2C bus lock is still detected", # 028(ERROR)
 ]
 
 def get_i2c_health_msg(msg_idx):

--- a/src/i2c-health/scripts/i2chealthd
+++ b/src/i2c-health/scripts/i2chealthd
@@ -84,7 +84,7 @@ class I2CHealthDaemon(daemon_base.DaemonBase):
                     # After resetting the mux, the I2C bus remains locked.
                     # This indicates the lock is on the master side.
                     # Proceed to reset the I2C master.
-                    msg = get_i2c_health_msg(26)
+                    msg = get_i2c_health_msg(27)
                     self.log_error(msg)
                     try:
                         i2c_mgr.reset_i2c_master()
@@ -98,7 +98,7 @@ class I2CHealthDaemon(daemon_base.DaemonBase):
                     # repeating it after reset_i2c_master() is unnecessary and unintended.
                     # Therefore, just check the I2C bus status here.
                     if i2c_mgr.is_bus_lock():
-                        msg = get_i2c_health_msg(27)
+                        msg = get_i2c_health_msg(28)
                         self.log_error(msg)
                         continue
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

