### PR TITLE
JIRA-SONIC-13998: [FRR][zebra] EVPN check l3vni vxlan intf exist in rmac install Apply FRR PR#20494

### DIFF
--- a/src/sonic-frr/patch/0044-zebra-EVPN-check-l3vni-vxlan-intf-exist-in-rmac-install.patch
+++ b/src/sonic-frr/patch/0044-zebra-EVPN-check-l3vni-vxlan-intf-exist-in-rmac-install.patch
@@ -1,0 +1,40 @@
+From 2db879a05cdef85ba4230a9d0793539d3e62f541 Mon Sep 17 00:00:00 2001
+From: Chirag Shah <chiragshah6@gmail.com>
+Date: Wed, 16 Jan 2026 10:00:00 +0000
+Subject: [PATCH 1/2] zebra: EVPN check l3vni vxlan intf exist in rmac install
+
+When a VXLAN interface goes down, the L3VNI may be cleaned up while
+associated routes are still being processed. During RMAC uninstallation,
+the code attempts to access the VXLAN interface pointer without verifying
+it still exists, causing a null pointer dereference.
+
+Add a check to verify the VXLAN interface exists before proceeding with
+RMAC operations.
+
+(cherry picked from FRR PR #20494, backported for sonic-buildimage 8.5.1-sonic)
+
+---
+ zebra/zebra_vxlan.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/zebra/zebra_vxlan.c b/zebra/zebra_vxlan.c
+index c6ff5089ca..a1aaa2b0e8 100644
+--- a/zebra/zebra_vxlan.c
++++ b/zebra/zebra_vxlan.c
+@@ -1229,6 +1229,14 @@ static int zl3vni_rmac_install(struct zebra_l3vni *zl3vni,
+ 	    || !(CHECK_FLAG(zrmac->flags, ZEBRA_MAC_REMOTE_RMAC)))
+ 		return 0;
+ 
++	if (!zl3vni->vxlan_if) {
++		if (IS_ZEBRA_DEBUG_VXLAN)
++			zlog_debug(
++				"RMAC %pEA on L3-VNI %u hash %p couldn't be installed - no vxlan_if",
++				&zrmac->macaddr, zl3vni->vni, zl3vni);
++		return -1;
++	}
++
+ 	zif = zl3vni->vxlan_if->info;
+ 	if (!zif)
+ 		return -1;
+-- 
+2.17.1

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -40,3 +40,4 @@ cross-compile-changes.patch
 0041-zebra-Check-if-ifp-is-not-NULL-in-zebra_if_update_ct.patch
 0042-Nexthop-compare-function-include-vxlan-encap-info.patch
 0043-bfdd-Fix_malformed-session-with-vrf.patch
+0044-zebra-EVPN-check-l3vni-vxlan-intf-exist-in-rmac-install.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
When a VXLAN interface goes down, the L3VNI may be cleaned up while associated
routes are still being processed. During RMAC install/uninstall, the code in
`zl3vni_rmac_install()` dereferences `zl3vni->vxlan_if` without verifying it is
still valid, which leads to a null pointer dereference and can crash zebra.

This change backports the upstream FRR fix (FRR PR #20494) to the
sonic-buildimage 202311 branch.
#### How to verify it
Added a new FRR patch `0044-zebra-EVPN-check-l3vni-vxlan-intf-exist-in-rmac-install.patch`
under `src/sonic-frr/patch/` and registered it in `src/sonic-frr/patch/series`.

The patch modifies `zebra/zebra_vxlan.c::zl3vni_rmac_install()` so that before
touching `zl3vni->vxlan_if->info`, it first checks whether `zl3vni->vxlan_if`
is non-NULL. If the vxlan interface no longer exists, the function logs a debug
message (under `IS_ZEBRA_DEBUG_VXLAN`) and returns `-1` instead of crashing.

```c
if (!zl3vni->vxlan_if) {
    if (IS_ZEBRA_DEBUG_VXLAN)
        zlog_debug(
            "RMAC %pEA on L3-VNI %u hash %p couldn't be installed - no vxlan_if",
            &zrmac->macaddr, zl3vni->vni, zl3vni);
    return -1;
}
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

