### PR TITLE
Fix build failure for bookworm snmpd dependency issue (=5.9.3+dfsg-2+deb12u1)

### DIFF
--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -141,7 +141,10 @@ RUN apt-get update && apt-get install -y eatmydata && eatmydata apt-get install 
         chrpath \
 # For frr build
         libc-ares-dev \
-        libsnmp-dev \
+        libsnmp40=5.9.3+dfsg-2+deb12u1 \
+        libnetsnmptrapd40=5.9.3+dfsg-2+deb12u1 \
+        libsnmp-base=5.9.3+dfsg-2+deb12u1 \
+        libsnmp-dev=5.9.3+dfsg-2+deb12u1 \
         libjson-c-dev \
         libsystemd-dev \
         libcmocka-dev \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The bookworm slave container installs the incorrect version of snmpd dependent packages

#### How I did it
Specify dependent package versions for snmpd (=5.9.3+dfsg-2+deb12u1)


