### PR TITLE
[build]: Use --no-build-isolation for python wheel builds

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -932,7 +932,7 @@ $(addprefix $(PYTHON_WHEELS_PATH)/, $(SONIC_PYTHON_WHEELS)) : $(PYTHON_WHEELS_PA
 		if [ -f ../$(notdir $($*_SRC_PATH)).patch/series ]; then ( quilt pop -a -f 1>/dev/null 2>&1 || true ) && QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; fi $(LOG)
 ifneq ($(CROSS_BUILD_ENVIRON),y)
 		# Use pip instead of later setup.py to install dependencies into user home, but uninstall self
-		pip$($*_PYTHON_VERSION) install . && pip$($*_PYTHON_VERSION) uninstall --yes `python$($*_PYTHON_VERSION) setup.py --name`
+		pip$($*_PYTHON_VERSION) install --no-build-isolation . && pip$($*_PYTHON_VERSION) uninstall --yes `python$($*_PYTHON_VERSION) setup.py --name`
 		if [ ! "$($*_TEST)" = "n" ]; then python$($*_PYTHON_VERSION) setup.py test $(LOG); fi
 		python$($*_PYTHON_VERSION) setup.py bdist_wheel $(LOG)
 else


### PR DESCRIPTION
### Why I did it

Python wheel builds fail on the bullseye slave during `Getting requirements to build wheel`:

```
ModuleNotFoundError: No module named 'pkg_resources'   # sonic-py-common, sonic-platform-common
ModuleNotFoundError: No module named 'jinja2'          # sonic-yang-models
ModuleNotFoundError: No module named 'fastentrypoints' # sonic-utilities
```

Root cause: newer pip (>= 25.3; the bullseye slave image currently ships **pip 26.0.1**) enforces **PEP 517 build isolation** even for `setup.py`-only projects. The isolated build environment does not contain `pkg_resources` / `jinja2` / `fastentrypoints`, which several SONiC `setup.py` files import at module top level, so the build aborts before the wheel is produced.

The wheel recipe in `slave.mk` first runs `pip install .` (to install the package's dependencies into the user home) and only then builds the wheel via `setup.py bdist_wheel`. The `pip install .` step is the one that triggers build isolation and fails.

### How I did it

Build the wheels with `pip install --no-build-isolation` so `setup.py` runs against the build dependencies that are already pre-installed in the slave image (setuptools, wheel, Jinja2, fastentrypoints, ...), restoring the previous non-isolated behavior. Only the non cross-build path uses `pip install .`; the cross-build path builds via `setup.py` directly and is unaffected.

### How to verify it

On the bullseye slave image (system `pip 26.0.1`, Python 3.9):

- `pip install .` (default, isolated) on a `setup.py` that imports `pkg_resources` reproduces `ModuleNotFoundError: No module named 'pkg_resources'`.
- `pip install --no-build-isolation .` builds successfully.
- `pkg_resources`, `jinja2` and `fastentrypoints` are all importable in the image's build `python3`, so the non-isolated build resolves all of the imports above.

Empirically, pip 24.0–25.2 still use the non-isolated legacy path (builds succeed); pip 25.3+ enforce isolation (builds fail). This change is independent of the pip version.
