### PR TITLE
[copp]: Add queue4_group4 CoPP group and ospf/ospfv6 trap in copp_cfg.j2

### DIFF
--- a/files/image_config/copp/copp_cfg.j2
+++ b/files/image_config/copp/copp_cfg.j2
@@ -43,6 +43,16 @@
 {% endif %}
 		    "red_action":"drop"
 	    },
+	    "queue4_group4": {
+		    "trap_action":"trap",
+		    "trap_priority":"6",
+		    "queue": "6",
+		    "meter_type":"packets",
+		    "mode":"sr_tcm",
+		    "cir":"100",
+		    "cbs":"100",
+		    "red_action":"drop"
+	    },
 {% if asic_type in ["broadcom"] %}
         "queue4_group6": {
             "trap_action":"trap",
@@ -145,6 +155,10 @@
 	    "sflow": {
 		    "trap_group": "queue2_group1",
 		    "trap_ids": "sample_packet"
+	    },
+	    "ospf": {
+		    "trap_ids": "ospf,ospfv6",
+		    "trap_group": "queue4_group4"
 	    }
 {% if asic_type in ["broadcom"] %}
         ,


### PR DESCRIPTION
#### Why I did it
OSPFv2 / OSPFv6 control plane packets did not have a dedicated CoPP policer.
This change adds a new CoPP group `queue4_group4` and registers the OSPF and
OSPFv6 traps to it, so these protocol packets are trapped to the CPU and
policed on their own queue with a defined rate.

#### How I did it

Modified `files/image_config/copp/copp_cfg.j2`:

- Added a new CoPP policer group `queue4_group4`
  (queue 6, trap_priority 6, cir/cbs 100, `trap_action: trap`).
- Added an `ospf` entry under `COPP_TRAP` with `trap_ids: "ospf,ospfv6"`
  mapped to `queue4_group4`, so both OSPF and OSPFv6 packets are trapped to
  this group.
