### PR TITLE
[config] Set SONIC_CONFIG_BUILD_JOBS=2 and enable ZTP by default

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -10,7 +10,7 @@
 # SONIC_CONFIG_BUILD_JOBS - set number of jobs for parallel build.
 # Corresponding -j argument will be passed to make command inside docker
 # container.
-SONIC_CONFIG_BUILD_JOBS = 1
+SONIC_CONFIG_BUILD_JOBS = 2
 
 # SONIC_CONFIG_MAKE_JOBS - set number of parallel make jobs per package.
 # Corresponding -j argument will be passed to make/dpkg commands that build separate packages
@@ -55,7 +55,7 @@ DEFAULT_PASSWORD = YourPaSsWoRd
 # ENABLE_DHCP_GRAPH_SERVICE = y
 
 # ENABLE_ZTP - installs Zero Touch Provisioning support.
-# ENABLE_ZTP = y
+ENABLE_ZTP = y
 
 # INCLUDE_PDE - Enable platform development enviroment
 # INCLUDE_PDE = y


### PR DESCRIPTION
### Why I did it

Two build configuration defaults for `202311.X_4630_10g_prod`:

1. **`SONIC_CONFIG_BUILD_JOBS = 1` -> `2`** — allow two package targets to be
   built in parallel inside the slave container. `SONIC_CONFIG_MAKE_JOBS` is
   already `$(shell nproc)` and is unchanged, so this only affects how many
   targets run concurrently, not the parallelism within a single package.

2. **`ENABLE_ZTP` enabled by default** — Zero Touch Provisioning was commented
   out, so the shipped image had no ZTP support (`"ENABLE_ZTP" : ""` in the
   build banner). Enable it by default.

### How I did it

```diff
-SONIC_CONFIG_BUILD_JOBS = 1
+SONIC_CONFIG_BUILD_JOBS = 2

 # ENABLE_ZTP - installs Zero Touch Provisioning support.
-# ENABLE_ZTP = y
+ENABLE_ZTP = y
```

No new package is built by enabling ZTP. `rules/sonic-ztp.mk` already adds
`sonic-ztp_1.0.0_all.deb` to `SONIC_DPKG_DEBS` unconditionally, and the
`src/sonic-ztp` submodule is present. `ENABLE_ZTP` only controls:

- `slave.mk:1349` — whether `sonic-ztp` is installed into the image
- `slave.mk:1386` — `export enable_ztp=` passed to `sonic_debian_extension`
- `Makefile.work:518` — propagation of the flag into the build container

### How to verify it

Build banner should now show:

```
"SONIC_CONFIG_BUILD_JOBS"         : "2"
"ENABLE_ZTP"                      : "y"
```

On the resulting image:

```
admin@sonic:~$ dpkg -l sonic-ztp
admin@sonic:~$ show ztp status
```

### Notes

`SONIC_CONFIG_BUILD_JOBS = 2` raises peak memory and disk usage during the
build since two package targets can be in flight at once. Worth watching the
first few Jenkins runs; the AWS build instance currently has plenty of headroom.
