### PR TITLE
[caclmgrd] Allow SSH and SNMP to IP2ME addresses via iptables hook

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -684,6 +684,9 @@ sudo cp $IMAGE_CONFIGS/snmp/snmp.yml $FILESYSTEM_ROOT/etc/sonic/
 # Copy ASN configuration files
 sudo cp $IMAGE_CONFIGS/constants/constants.yml $FILESYSTEM_ROOT/etc/sonic/
 
+# Copy caclmgrd control plane ACL hook rules
+sudo cp $IMAGE_CONFIGS/caclmgrd/iptables.json $FILESYSTEM_ROOT/etc/sonic/
+
 # Copy sudoers configuration file
 sudo cp $IMAGE_CONFIGS/sudoers/sudoers $FILESYSTEM_ROOT/etc/
 sudo cp $IMAGE_CONFIGS/sudoers/sudoers.lecture $FILESYSTEM_ROOT/etc/

--- a/files/image_config/caclmgrd/iptables.json
+++ b/files/image_config/caclmgrd/iptables.json
@@ -3,5 +3,10 @@
         "-A INPUT -p tcp --dport 22 -j ACCEPT",
         "-A INPUT -p tcp --dport 161 -j ACCEPT",
         "-A INPUT -p udp --dport 161 -j ACCEPT"
+    ],
+    "ipv6": [
+        "-A INPUT -p tcp --dport 22 -j ACCEPT",
+        "-A INPUT -p tcp --dport 161 -j ACCEPT",
+        "-A INPUT -p udp --dport 161 -j ACCEPT"
     ]
 }

--- a/files/image_config/caclmgrd/iptables.json
+++ b/files/image_config/caclmgrd/iptables.json
@@ -1,0 +1,7 @@
+{
+    "ipv4": [
+        "-A INPUT -p tcp --dport 22 -j ACCEPT",
+        "-A INPUT -p tcp --dport 161 -j ACCEPT",
+        "-A INPUT -p udp --dport 161 -j ACCEPT"
+    ]
+}


### PR DESCRIPTION
### Why I did it

A customer ZTP/provisioning server cannot reach the device after ZTP completes,
so the device stays `Unknown` in their inventory validation. Their service needs
SNMP (identify device type) and SSH (system info + LLDP topology).

`caclmgrd` unconditionally installs a DROP rule for **every** interface IP
address it finds in `LOOPBACK_INTERFACE`, `VLAN_INTERFACE`,
`PORTCHANNEL_INTERFACE`, `INTERFACE` and `VLAN_SUB_INTERFACE`:

```
iptables -A INPUT -d <vlan-ip>/32 -j DROP
```

(`generate_block_ip2me_traffic_iptables_commands`, called unconditionally from
`get_acl_rules_and_translate_to_iptables_commands`)

Nothing in our image installs an ACCEPT rule for SSH or SNMP ahead of it, so
both are dropped on Vlan/Loopback IPs. Deleting the rule by hand does not help
because caclmgrd regenerates the whole ruleset from scratch on every update.

The blanket ACCEPT rules caclmgrd already emits cover localhost, docker
internal traffic, `ESTABLISHED,RELATED`, ICMP/NDP, DHCP 67-68 / 546-547,
BFD 3784/3785/4784, BGP 179, MCLAG 8888 and TTL<2 — but not SSH or SNMP.

### How I did it

Use the hook that already exists in our `caclmgrd`:

```python
HOOK_RULES = "/etc/sonic/iptables.json"
...
iptables_cmds += self.generate_hook_iptables_commands()
```

Nothing currently ships that file, so the hook is unused. This PR adds it.

```json
{
    "ipv4": [
        "-A INPUT -p tcp --dport 22 -j ACCEPT",
        "-A INPUT -p tcp --dport 161 -j ACCEPT",
        "-A INPUT -p udp --dport 161 -j ACCEPT"
    ],
    "ipv6": [
        "-A INPUT -p tcp --dport 22 -j ACCEPT",
        "-A INPUT -p tcp --dport 161 -j ACCEPT",
        "-A INPUT -p udp --dport 161 -j ACCEPT"
    ]
}
```

Both address families are covered: caclmgrd installs equivalent IP2ME DROP
rules via `ip6tables` for every IPv6 interface address, so SSH and SNMP over
IPv6 would be blocked in exactly the same way.

Two reasons this is preferred over adding a `CTRLPLANE` ACL table to the
default `config_db.json`:

1. **No catch-all DROP.** `get_acl_rules_and_translate_to_iptables_commands`
   appends `-A INPUT -j DROP` whenever `num_ctrl_plane_acl_rules > 0`. Adding a
   CTRLPLANE table would flip the host from "drop traffic to my own IPs" to
   "drop everything not explicitly whitelisted", which would then require
   whitelisting gNMI, telemetry, RESTAPI, NTP, radius, tftp, etc. The hook does
   not touch that counter.
2. **Independent of config_db.** ZTP is enabled by default on this branch and
   rewrites `config_db.json`; `/etc/sonic/iptables.json` is unaffected.

The hook is re-applied every time caclmgrd regenerates the ruleset, so the
rules survive `config reload`, ACL updates and interface changes.

TCP 161 is included in addition to UDP 161 to match caclmgrd's own definition
of the SNMP service (`ACL_SERVICES["SNMP"]["ip_protocols"] = ["tcp", "udp"]`).

### How to verify it

```
admin@sonic:~$ cat /etc/sonic/iptables.json
admin@sonic:~$ sudo iptables  -L INPUT -n --line-numbers
admin@sonic:~$ sudo ip6tables -L INPUT -n --line-numbers
```

In both chains the three ACCEPT rules must appear **above** the IP2ME
`DROP ... -d <device-ip>` rules, and no catch-all `DROP all` may be present at
the end of the chain.

Then from the provisioning network:

```
$ ssh admin@<device-vlan-ip>
$ snmpwalk -v2c -c <community> <device-vlan-ip> sysDescr
```

### Notes / limitations

- No source restriction, per the customer requirement — SSH and SNMP are
  accepted from any source on all device IPs. If the provisioning subnet is
  known, adding `-s <subnet>` to each rule would be tighter.
- `generate_hook_iptables_commands` builds plain `iptables`/`ip6tables`
  commands without the `iptables_cmd_ns_prefix`, so the hook applies to the
  host namespace only. Fine for single-ASIC platforms such as AS4630-54PE.
- The hook parser is `except Exception: custom_cmds = []` with no logging, so a
  malformed file silently disables **all** hook rules. The JSON in this PR is
  validated and expands to exactly the three commands above.
