### PR TITLE
[config] Raise SONIC_CONFIG_BUILD_JOBS from 2 to 4

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -10,7 +10,7 @@
 # SONIC_CONFIG_BUILD_JOBS - set number of jobs for parallel build.
 # Corresponding -j argument will be passed to make command inside docker
 # container.
-SONIC_CONFIG_BUILD_JOBS = 2
+SONIC_CONFIG_BUILD_JOBS = 4
 
 # SONIC_CONFIG_MAKE_JOBS - set number of parallel make jobs per package.
 # Corresponding -j argument will be passed to make/dpkg commands that build separate packages


### PR DESCRIPTION
### Why I did it

A full image build currently takes around 8 hours. `SONIC_CONFIG_BUILD_JOBS` was
raised from 1 to 2 recently; raise it to 4 to cut wall-clock time further. The
AWS build instance has 48 cores and ~1 TB of RAM, so there is ample headroom.

### How I did it

```diff
-SONIC_CONFIG_BUILD_JOBS = 2
+SONIC_CONFIG_BUILD_JOBS = 4
```

`SONIC_CONFIG_MAKE_JOBS` is left at `$(shell nproc)`. This change only affects
how many package *targets* run concurrently, not the `-j` used within a single
package build.

### How to verify it

Build banner should show:

```
"SONIC_CONFIG_BUILD_JOBS"         : "4"
```

### Notes

Four concurrent targets raise peak memory, disk I/O and `/var/cache/sonic`
contention. Two things to watch on the first run:

- Packages that install conflicting build dependencies now have a higher chance
  of overlapping. `slave.mk` serialises the actual `dpkg -i` with `dpkg_lock`
  and waits on `_CONFLICT_DEBS`, so this should be handled, but the SAI dev
  package versus `libsaivs-dev` pair is the one to keep an eye on.
- Interleaved build logs make failures harder to read. Per-target logs under
  `target/debs/<dist>/*.log` remain separate, so use those rather than the
  Jenkins console output when triaging.
