### PR TITLE
[submodule] Advance sonic-ztp to pick up the port config re-assert fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -139,7 +139,7 @@
 [submodule "src/sonic-ztp"]
 	path = src/sonic-ztp
 	url = https://github.com/edge-core/sonic-ztp.git
-	branch = 202311.X
+	branch = 202311.X_4630_10g_prod
 [submodule "src/sonic-stp"]
 	path = src/sonic-stp
 	url = https://github.com/edge-core/sonic-stp.git


### PR DESCRIPTION
### Why I did it

`sonic-ztp` 89fd507 adds a re-assertion of the front panel port configuration at the end of `ztp-profile.sh remove`. This bumps the submodule so the fix is included in the build.

Without it, the `interfaces-config` restart performed while tearing down the ZTP profile runs `ifdown -a` followed by `ifup -a` against a freshly regenerated `/etc/network/interfaces` that no longer contains any Ethernet stanza, because the ZTP in-band block of `interfaces.j2` is gated on `ZTP['mode']` and that table has just been deleted.

Every front panel port that ifupdown2 had adopted for ZTP in-band DHCP is therefore taken down and not brought back. The netdev is left administratively down with its MTU reset to the kernel default, while CONFIG_DB, APPL_DB and the ASIC all still report the port as up, so `show interfaces status` looks healthy. `portmgrd` is event driven only and does not correct the drift, so the port stays down until something writes CONFIG_DB.

### What changed

```
src/sonic-ztp   c488842 -> 89fd507
.gitmodules     submodule.src/sonic-ztp.branch  202311.X -> 202311.X_4630_10g_prod
```

The `.gitmodules` branch field is a separate small correction: the pointer has been tracking `202311.X_4630_10g_prod` in practice, but the field still said `202311.X`, so `git submodule update --remote` would have pulled from the wrong branch.

### How to verify it

After building and installing, run inband ZTP to completion, then once ZTP has removed its profile:

```
grep -cE '^auto Ethernet|^iface Ethernet' /etc/network/interfaces   # 0, the ZTP stanzas are gone
ip -o link show | grep Ethernet | grep -c 'state UP'                # front panel ports with carrier stay up
show interfaces status                                              # agrees with ip link
```

Before the fix the second command drops to 0 while `show interfaces status` still reports every port as up.

Verified on a 54 port platform: the re-assertion issues 108 `portmgrd` re-applications, mtu and admin_status for each port, and completes in 1.8 seconds.

### Possible concerns

- The submodule branch change affects only `git submodule update --remote`; the checked out commit is pinned by SHA either way, so existing builds are unaffected.
- The re-assertion is a remediation rather than a root fix: the port is still torn down briefly before being restored. Preventing the teardown itself would mean keeping front panel ports out of ifupdown2's scope, which is a much larger change.
