### PR TITLE
[AS9817-64D/O][AS9817-32D/O] Rename platform i2c-ocores driver

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as9817-32d/modules/Makefile
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-32d/modules/Makefile
@@ -1,3 +1,3 @@
-obj-m:=i2c-ocores.o accton_as9817_32_fpga.o accton_as9817_32_fan.o \
+obj-m:=accton_as9817_32_i2c-ocores.o accton_as9817_32_fpga.o accton_as9817_32_fan.o \
 	accton_as9817_32_psu.o accton_as9817_32_thermal.o accton_as9817_32_sys.o \
 	accton_as9817_32_leds.o accton_as9817_32_mux.o accton_ipmi_intf.o

--- a/platform/broadcom/sonic-platform-modules-accton/as9817-32d/modules/accton_as9817_32_i2c-ocores.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-32d/modules/accton_as9817_32_i2c-ocores.c
@@ -1,0 +1,1 @@
+../../as9817-32o/modules/accton_as9817_32_i2c-ocores.c

--- a/platform/broadcom/sonic-platform-modules-accton/as9817-32d/modules/i2c-ocores.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-32d/modules/i2c-ocores.c
@@ -1,1 +1,0 @@
-../../as9817-32o/modules/i2c-ocores.c

--- a/platform/broadcom/sonic-platform-modules-accton/as9817-32d/utils/accton_as9817_32d_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-32d/utils/accton_as9817_32d_util.py
@@ -221,7 +221,7 @@ kos = [
     'modprobe i2c_ismt',
     'modprobe optoe',
     'modprobe at24',
-    'modprobe i2c-ocores',
+    'modprobe accton_as9817_32_i2c-ocores',
     'modprobe accton_as9817_32_fpga',
     'modprobe accton_as9817_32_fan',
     'modprobe accton_as9817_32_psu',

--- a/platform/broadcom/sonic-platform-modules-accton/as9817-32o/modules/Makefile
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-32o/modules/Makefile
@@ -1,3 +1,3 @@
-obj-m:=i2c-ocores.o accton_as9817_32_fpga.o accton_as9817_32_fan.o \
+obj-m:=accton_as9817_32_i2c-ocores.o accton_as9817_32_fpga.o accton_as9817_32_fan.o \
 	accton_as9817_32_psu.o accton_as9817_32_thermal.o accton_as9817_32_sys.o \
 	accton_as9817_32_leds.o accton_as9817_32_mux.o accton_ipmi_intf.o

--- a/platform/broadcom/sonic-platform-modules-accton/as9817-32o/modules/accton_as9817_32_fpga.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-32o/modules/accton_as9817_32_fpga.c
@@ -37,7 +37,7 @@
  *       variable define
  * *********************************************/
 #define DRVNAME                        "as9817_32_fpga"
-#define OCORES_I2C_DRVNAME             "ocores-i2c"
+#define OCORES_I2C_DRVNAME             "as9817_32_ocores-i2c"
 
 #define PORT_NUM                       (32 + 2)  /* 32 OSFPs/QSFPDDs + 2 SFP28s */
 

--- a/platform/broadcom/sonic-platform-modules-accton/as9817-32o/modules/accton_as9817_32_i2c-ocores.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-32o/modules/accton_as9817_32_i2c-ocores.c
@@ -1570,22 +1570,6 @@ static const struct i2c_adapter ocores_adapter = {
 };
 
 static const struct of_device_id ocores_i2c_match[] = {
-    {
-        .compatible = "opencores,i2c-ocores",
-        .data = (void *)TYPE_OCORES,
-    },
-    {
-        .compatible = "aeroflexgaisler,i2cmst",
-        .data = (void *)TYPE_GRLIB,
-    },
-    {
-        .compatible = "sifive,fu540-c000-i2c",
-        .data = (void *)TYPE_SIFIVE_REV0,
-    },
-    {
-        .compatible = "sifive,i2c0",
-        .data = (void *)TYPE_SIFIVE_REV0,
-    },
     {},
 };
 MODULE_DEVICE_TABLE(of, ocores_i2c_match);
@@ -1965,7 +1949,7 @@ static struct platform_driver ocores_i2c_driver = {
     .probe   = ocores_i2c_probe,
     .remove  = ocores_i2c_remove,
     .driver  = {
-        .name = "ocores-i2c",
+        .name = "as9817_32_ocores-i2c",
         .of_match_table = ocores_i2c_match,
         .pm = OCORES_I2C_PM,
     },
@@ -1999,6 +1983,7 @@ module_exit(ocores_i2c_as9817_32_exit);
 #endif
 
 MODULE_AUTHOR("Peter Korsgaard <peter@korsgaard.com>");
-MODULE_DESCRIPTION("OpenCores I2C bus driver");
+MODULE_AUTHOR("Ray Huang <rayx_huang@edge-core.com>");
+MODULE_DESCRIPTION("OpenCores I2C bus driver for AS9817-32D/AS9817-32O");
 MODULE_LICENSE("GPL");
-MODULE_ALIAS("platform:ocores-i2c");
+MODULE_ALIAS("platform:as9817_32_ocores-i2c");

--- a/platform/broadcom/sonic-platform-modules-accton/as9817-32o/utils/accton_as9817_32o_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-32o/utils/accton_as9817_32o_util.py
@@ -222,7 +222,7 @@ kos = [
     'modprobe i2c_ismt',
     'modprobe optoe',
     'modprobe at24',
-    'modprobe i2c-ocores',
+    'modprobe accton_as9817_32_i2c-ocores',
     'modprobe accton_as9817_32_fpga',
     'modprobe accton_as9817_32_fan',
     'modprobe accton_as9817_32_psu',

--- a/platform/broadcom/sonic-platform-modules-accton/as9817-64d/modules/Makefile
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-64d/modules/Makefile
@@ -1,3 +1,3 @@
-obj-m:=i2c-ocores.o accton_as9817_64_fpga.o accton_as9817_64_fan.o \
+obj-m:=accton_as9817_64_i2c-ocores.o accton_as9817_64_fpga.o accton_as9817_64_fan.o \
 	accton_as9817_64_psu.o accton_as9817_64_thermal.o accton_as9817_64_sys.o \
 	accton_as9817_64_leds.o

--- a/platform/broadcom/sonic-platform-modules-accton/as9817-64d/modules/accton_as9817_64_i2c-ocores.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-64d/modules/accton_as9817_64_i2c-ocores.c
@@ -1,0 +1,1 @@
+../../as9817-64o/modules/accton_as9817_64_i2c-ocores.c

--- a/platform/broadcom/sonic-platform-modules-accton/as9817-64d/modules/i2c-ocores.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-64d/modules/i2c-ocores.c
@@ -1,1 +1,0 @@
-../../as9817-64o/modules/i2c-ocores.c

--- a/platform/broadcom/sonic-platform-modules-accton/as9817-64d/utils/accton_as9817_64d_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-64d/utils/accton_as9817_64d_util.py
@@ -206,7 +206,7 @@ kos = [
     'modprobe i2c_ismt',
     'modprobe optoe',
     'modprobe at24',
-    'modprobe i2c-ocores',
+    'modprobe accton_as9817_64_i2c-ocores',
     'modprobe accton_as9817_64_fpga',
     'modprobe accton_as9817_64_fan',
     'modprobe accton_as9817_64_psu',

--- a/platform/broadcom/sonic-platform-modules-accton/as9817-64o/modules/Makefile
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-64o/modules/Makefile
@@ -1,3 +1,3 @@
-obj-m:=i2c-ocores.o accton_as9817_64_fpga.o accton_as9817_64_fan.o \
+obj-m:=accton_as9817_64_i2c-ocores.o accton_as9817_64_fpga.o accton_as9817_64_fan.o \
 	accton_as9817_64_psu.o accton_as9817_64_thermal.o accton_as9817_64_sys.o \
 	accton_as9817_64_leds.o

--- a/platform/broadcom/sonic-platform-modules-accton/as9817-64o/modules/accton_as9817_64_fpga.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-64o/modules/accton_as9817_64_fpga.c
@@ -37,7 +37,7 @@
  *       variable define
  * *********************************************/
 #define DRVNAME                        "as9817_64_fpga"
-#define OCORES_I2C_DRVNAME             "ocores-i2c"
+#define OCORES_I2C_DRVNAME             "as9817_64_ocores-i2c"
 
 #define PORT_NUM                       (64 + 2)  /* 64 OSFPs/QSFPDDs + 2 SFP28s */
 

--- a/platform/broadcom/sonic-platform-modules-accton/as9817-64o/modules/accton_as9817_64_i2c-ocores.c
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-64o/modules/accton_as9817_64_i2c-ocores.c
@@ -1570,22 +1570,6 @@ static const struct i2c_adapter ocores_adapter = {
 };
 
 static const struct of_device_id ocores_i2c_match[] = {
-    {
-        .compatible = "opencores,i2c-ocores",
-        .data = (void *)TYPE_OCORES,
-    },
-    {
-        .compatible = "aeroflexgaisler,i2cmst",
-        .data = (void *)TYPE_GRLIB,
-    },
-    {
-        .compatible = "sifive,fu540-c000-i2c",
-        .data = (void *)TYPE_SIFIVE_REV0,
-    },
-    {
-        .compatible = "sifive,i2c0",
-        .data = (void *)TYPE_SIFIVE_REV0,
-    },
     {},
 };
 MODULE_DEVICE_TABLE(of, ocores_i2c_match);
@@ -1965,7 +1949,7 @@ static struct platform_driver ocores_i2c_driver = {
     .probe   = ocores_i2c_probe,
     .remove  = ocores_i2c_remove,
     .driver  = {
-        .name = "ocores-i2c",
+        .name = "as9817_64_ocores-i2c",
         .of_match_table = ocores_i2c_match,
         .pm = OCORES_I2C_PM,
     },
@@ -1999,6 +1983,7 @@ module_exit(ocores_i2c_as9817_64_exit);
 #endif
 
 MODULE_AUTHOR("Peter Korsgaard <peter@korsgaard.com>");
-MODULE_DESCRIPTION("OpenCores I2C bus driver");
+MODULE_AUTHOR("Ray Huang <rayx_huang@edge-core.com>");
+MODULE_DESCRIPTION("OpenCores I2C bus driver for AS9817-64D/AS9817-64O");
 MODULE_LICENSE("GPL");
-MODULE_ALIAS("platform:ocores-i2c");
+MODULE_ALIAS("platform:as9817_64_ocores-i2c");

--- a/platform/broadcom/sonic-platform-modules-accton/as9817-64o/utils/accton_as9817_64o_util.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9817-64o/utils/accton_as9817_64o_util.py
@@ -207,7 +207,7 @@ kos = [
     'modprobe i2c_ismt',
     'modprobe optoe',
     'modprobe at24',
-    'modprobe i2c-ocores',
+    'modprobe accton_as9817_64_i2c-ocores',
     'modprobe accton_as9817_64_fpga',
     'modprobe accton_as9817_64_fan',
     'modprobe accton_as9817_64_psu',


### PR DESCRIPTION
#### What did I do
- Rename AS9817-64D/AS9817-64O i2c-ocores as accton_as9817_64_i2c-ocores
  to avoid collision with system driver.
- Rename AS9817-32D/AS9817-32O i2c-ocores as accton_as9817_32_i2c-ocores
  to avoid collision with system driver.
- Remove unrelated OF device-tree compatible entries